### PR TITLE
add libcurl dependency 

### DIFF
--- a/.github/workflows/create_ensemble.yaml
+++ b/.github/workflows/create_ensemble.yaml
@@ -16,7 +16,12 @@ jobs:
       with:
         install-r: false
         use-public-rspm: true
-      
+    
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libcurl4-openssl-dev
+
     - name: Install dependencies
       run: |
         install.packages(c("hubEnsembles", "dplyr", "lubridate", "purrr", "yaml", "remotes"))


### PR DESCRIPTION
This fixes GH action for model ensemble failing with the following error:
```
Configuration failed because libcurl was not found. Try installing:
 * deb: libcurl4-openssl-dev (Debian, Ubuntu, etc)
 * rpm: libcurl-devel (Fedora, CentOS, RHEL)
 ```