### PR TITLE
feat: add CMU-TimeSeries team metadata

### DIFF
--- a/model-metadata/CMU-TimeSeries.yml
+++ b/model-metadata/CMU-TimeSeries.yml
@@ -1,0 +1,25 @@
+team_name: "Carnegie Mellon Delphi Group"
+team_abbr: "CMU"
+model_name: "AR ensemble with auxiliary data"
+model_abbr: "TimeSeries"
+model_version: "1.0"
+model_contributors:
+  [
+    { "name": "Logan Brooks", "affiliation": "UC Berkeley", "email": "lcbrooks@berkeley.edu" },
+    { "name": "Dmitry Shemetov", "affiliation": "Carnegie Mellon University", "email": "dshemeto@andrew.cmu.edu" },
+    { "name": "Nat DeFries", "affiliation": "Carnegie Mellon University", "email": "ndefries@andrew.cmu.edu" },
+    { "name": "David Weber", "affiliation": "Carnegie Mellon University", "email": "davidweb@andrew.cmu.edu" },
+    { "name": "Daniel McDonald", "affiliation": "University of British Columbia", "email": "daniel@stat.ubc.ca" },
+    { "name": "Ryan Tibshirani", "affiliation": "UC Berkeley", "email": "ryantibs@berkeley.edu" },
+  ]
+website_url: "https://github.com/cmu-delphi/exploration-tooling/"
+repo_url: "https://github.com/cmu-delphi/exploration-tooling/"
+license: "CC-BY-4.0"
+designated_model: true
+team_funding: "Centers for Disease Control and Prevention Awards: U011P001121, 75D30123C15907, NU38FT000005"
+methods: "An ensemble of AR-based time-series models."
+data_inputs: "Daily and weekly incident covid hospitalizations, queried through Delphi Epidata API."
+methods_long: "A basic quantile autoregression fit using lagged values of influenza-related hospitalization counts (normalized by population). The data are smoothed in time and the latter data source is adjusted to remove systematic day-of-week effects. The model is fit jointly across all 50 US states, the District of Columbia, Puerto Rico, and the Virgin Islands, using the most recently available 21 days of training data. Each of the 23 quantiles is learned using a separate quantile regression with nonnegativity and quantile sorting constraints applied post hoc. All data signals are available as indicators through the Delphi Epidata API (https://cmu-delphi.github.io/delphi-epidata)."
+ensemble_of_models: true
+ensemble_of_hub_models: false
+designated_github_users: ["dshemetov", "dsweber2"]


### PR DESCRIPTION
Note that the new field causes a validation error:

```
r$> hubValidations::validate_model_metadata(hub_path=".", file_path="CMU-TimeSeries.yml")

── model-metadata-schema.json ────

✔ [metadata_schema_exists]: File exists at path hub-config/model-metadata-schema.json.

── CMU-TimeSeries.yml ────

✔ [metadata_file_exists]: File exists at path model-metadata/CMU-TimeSeries.yml.
✔ [metadata_file_ext]: Metadata file extension is "yml" or "yaml".
✔ [metadata_file_location]: Metadata file directory name matches "model-metadata".
ⓧ [metadata_matches_schema]: Metadata file contents must be consistent with schema specifications.  - must NOT have
  additional properties; saw unexpected property 'designated_github_users'.
```