### PR TITLE
Make `output_folder_path` customizable

### DIFF
--- a/.github/workflows/generate-forecast-visualization-data.yaml
+++ b/.github/workflows/generate-forecast-visualization-data.yaml
@@ -22,6 +22,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: 'CDCgov/covidhub-reports'
+          path: report
+
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
@@ -38,10 +44,7 @@ jobs:
       - name: Generate data files
         run: |
           REF_DATE=$(Rscript -e "cat(strftime(lubridate::ceiling_date(lubridate::today(), 'week', week_start = 6, change_on_boundary = FALSE)))")
-          Rscript src/get_covid_hosp_data.R --reference_date "$REF_DATE" --base_hub_path "." --target_data FALSE
-          Rscript src/get_forecast_data.R --reference_date "$REF_DATE" --base_hub_path "." --horizons_to_include 0 1 2
-          Rscript src/get_map_data.R --reference_date "$REF_DATE" --base_hub_path "." --horizons_to_include 0 1 2
-          Rscript src/get_webtext.R --reference_date "$REF_DATE" --base_hub_path "."
+          Rscript src/get_forecast_data.R --reference_date "$REF_DATE" --base_hub_path "." --hub_report_path "report" --horizons_to_include 0 1 2
         env:
           NHSN_API_KEY_ID: ${{ secrets.NHSN_API_KEY_ID }}  
           NHSN_API_KEY_SECRET: ${{ secrets.NHSN_API_KEY_SECRET }}

--- a/.github/workflows/generate-forecast-visualization-data.yaml
+++ b/.github/workflows/generate-forecast-visualization-data.yaml
@@ -22,12 +22,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          repository: 'CDCgov/covidhub-reports'
-          path: report
-
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
@@ -44,7 +38,10 @@ jobs:
       - name: Generate data files
         run: |
           REF_DATE=$(Rscript -e "cat(strftime(lubridate::ceiling_date(lubridate::today(), 'week', week_start = 6, change_on_boundary = FALSE)))")
-          Rscript src/get_forecast_data.R --reference_date "$REF_DATE" --base_hub_path "." --hub_report_path "report" --horizons_to_include 0 1 2
+          Rscript src/get_forecast_data.R --reference_date "$REF_DATE" --base_hub_path "." --hub_reports_path "." --horizons_to_include 0 1 2
+          Rscript src/get_forecast_data.R --reference_date "$REF_DATE" --base_hub_path "." --hub_reports_path "." --horizons_to_include 0 1 2
+          Rscript src/get_map_data.R --reference_date "$REF_DATE" --base_hub_path "." --hub_reports_path "." --horizons_to_include 0 1 2
+          Rscript src/get_webtext.R --reference_date "$REF_DATE" --base_hub_path "." --hub_reports_path "."
         env:
           NHSN_API_KEY_ID: ${{ secrets.NHSN_API_KEY_ID }}  
           NHSN_API_KEY_SECRET: ${{ secrets.NHSN_API_KEY_SECRET }}

--- a/.github/workflows/generate-forecast-visualization-data.yaml
+++ b/.github/workflows/generate-forecast-visualization-data.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Generate data files
         run: |
           REF_DATE=$(Rscript -e "cat(strftime(lubridate::ceiling_date(lubridate::today(), 'week', week_start = 6, change_on_boundary = FALSE)))")
-          Rscript src/get_forecast_data.R --reference_date "$REF_DATE" --base_hub_path "." --hub_reports_path "." --horizons_to_include 0 1 2
+          Rscript src/get_covid_hosp_data.R --reference_date "$REF_DATE" --base_hub_path "." --hub_reports_path "." --target_data FALSE
           Rscript src/get_forecast_data.R --reference_date "$REF_DATE" --base_hub_path "." --hub_reports_path "." --horizons_to_include 0 1 2
           Rscript src/get_map_data.R --reference_date "$REF_DATE" --base_hub_path "." --hub_reports_path "." --horizons_to_include 0 1 2
           Rscript src/get_webtext.R --reference_date "$REF_DATE" --base_hub_path "." --hub_reports_path "."

--- a/src/get_covid_hosp_data.R
+++ b/src/get_covid_hosp_data.R
@@ -40,6 +40,12 @@ parser <- argparser::add_argument(
 )
 parser <- argparser::add_argument(
   parser,
+  "--hub_reports_path",
+  type = "character",
+  help = "path to COVIDhub reports directory"
+)
+parser <- argparser::add_argument(
+  parser,
   "--target_data",
   type = "logical",
   help = "If FALSE, fetches NHSN historical data. IF TRUE, gets target data."
@@ -56,6 +62,7 @@ parser <- argparser::add_argument(
 args <- argparser::parse_args(parser)
 reference_date <- args$reference_date
 base_hub_path <- args$base_hub_path
+hub_reports_path <- args$hub_reports_path
 target_data <- args$target_data
 first_full_weekending_date <- args$first_full_weekending_date
 
@@ -154,7 +161,7 @@ if (!target_data) {
     )
   # output folder and file paths for Truth Data
   output_folder_path <- fs::path(
-    base_hub_path, "weekly-summaries", reference_date
+    hub_reports_path, "weekly-summaries", reference_date
   )
   output_filename <- paste0(
     reference_date, "_covid_target_hospital_admissions_data.csv"

--- a/src/get_forecast_data.R
+++ b/src/get_forecast_data.R
@@ -23,7 +23,7 @@
 #'
 #' To run:
 #' Rscript src/get_forecast_data.R --reference_date 2024-12-21
-#' --base_hub_path "." --hub_report_path "path/to/covidhub-reports"
+#' --base_hub_path "." --hub_reports_path "path/to/covidhub-reports"
 #' --horizons_to_include 0 1 2
 
 
@@ -45,7 +45,7 @@ parser <- argparser::add_argument(
 )
 parser <- argparser::add_argument(
   parser,
-  "--hub_report_path",
+  "--hub_reports_path",
   type = "character",
   help = "path to COVIDhub reports directory"
 )
@@ -60,7 +60,7 @@ parser <- argparser::add_argument(
 args <- argparser::parse_args(parser)
 ref_date <- args$reference_date
 base_hub_path <- args$base_hub_path
-hub_report_path <- args$hub_report_path
+hub_reports_path <- args$hub_reports_path
 horizons_to_include <- as.integer(args$horizons_to_include)
 
 # check for invalid horizon entries
@@ -181,7 +181,7 @@ all_forecasts_data <- forecasttools::pivot_hubverse_quantiles_wider(
 
 # output folder and file paths for All Forecasts
 output_folder_path <- fs::path(
-  hub_report_path,
+  hub_reports_path,
   "weekly-summaries",
   ref_date
 )

--- a/src/get_forecast_data.R
+++ b/src/get_forecast_data.R
@@ -22,8 +22,9 @@
 #' - `forecast_fullnames`: full model name
 #'
 #' To run:
-#' Rscript get_forecast_data.R --reference_date 2024-12-21
-#' --base_hub_path ../ --horizons_to_include 0 1 2
+#' Rscript src/get_forecast_data.R --reference_date 2024-12-21
+#' --base_hub_path "." --hub_report_path "path/to/covidhub-reports"
+#' --horizons_to_include 0 1 2
 
 
 # set up command line argument parser
@@ -44,6 +45,12 @@ parser <- argparser::add_argument(
 )
 parser <- argparser::add_argument(
   parser,
+  "--hub_report_path",
+  type = "character",
+  help = "path to COVIDhub reports directory"
+)
+parser <- argparser::add_argument(
+  parser,
   "--horizons_to_include",
   nargs = "Inf",
   help = "A list of horizons to include."
@@ -53,6 +60,7 @@ parser <- argparser::add_argument(
 args <- argparser::parse_args(parser)
 ref_date <- args$reference_date
 base_hub_path <- args$base_hub_path
+hub_report_path <- args$hub_report_path
 horizons_to_include <- as.integer(args$horizons_to_include)
 
 # check for invalid horizon entries
@@ -173,7 +181,7 @@ all_forecasts_data <- forecasttools::pivot_hubverse_quantiles_wider(
 
 # output folder and file paths for All Forecasts
 output_folder_path <- fs::path(
-  base_hub_path,
+  hub_report_path,
   "weekly-summaries",
   ref_date
 )

--- a/src/get_map_data.R
+++ b/src/get_map_data.R
@@ -65,6 +65,12 @@ parser <- argparser::add_argument(
 )
 parser <- argparser::add_argument(
   parser,
+  "--hub_reports_path",
+  type = "character",
+  help = "path to COVIDhub reports directory"
+)
+parser <- argparser::add_argument(
+  parser,
   "--horizons_to_include",
   nargs = "Inf",
   help = "A list of horizons to include."
@@ -73,6 +79,7 @@ parser <- argparser::add_argument(
 args <- argparser::parse_args(parser)
 ref_date <- args$reference_date
 base_hub_path <- args$base_hub_path
+hub_reports_path <- args$hub_reports_path
 horizons_to_include <- as.integer(args$horizons_to_include)
 
 
@@ -261,7 +268,7 @@ map_data <- forecasttools::pivot_hubverse_quantiles_wider(
   )
 
 output_folder_path <- fs::path(
-  base_hub_path, "weekly-summaries", ref_date
+  hub_reports_path, "weekly-summaries", ref_date
 )
 output_filename <- paste0(ref_date, "_covid_map_data.csv")
 output_filepath <- fs::path(


### PR DESCRIPTION
Makes `output_folder_path` depend on a customizable argument `hub-reports-path` in preparation for saving visualization data files in a different repo