### PR TITLE
update affected workflow to use a replacement for changed files

### DIFF
--- a/.github/workflows/merge-validated-pr.yaml
+++ b/.github/workflows/merge-validated-pr.yaml
@@ -1,0 +1,104 @@
+name: Merge valid PRs
+
+on:
+  workflow_dispatch:
+  pull_request_target:
+    branches: main
+    paths:
+      - 'model-output/**'
+      - '!model-output/README.md'
+      - '!model-output/CovidHub-ensemble/**'
+      - '!model-output/CovidHub-baseline/**'
+
+jobs:
+  validate-user-and-approve:
+    runs-on: ubuntu-22.04
+    permissions: 
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Get Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v4
+        with:
+          application_id: ${{ vars.GH_APP_ID }}
+          application_private_key: ${{ secrets.GH_APP_KEY }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Read authorized user
+        id: read_authorized_user
+        uses: jaywcjlove/github-action-read-file@main
+        with:
+          branch: main
+          path: 'auxiliary-data/authorized_users.txt'
+
+      - name: Get model output changes
+        id: get_changed_files_in_model_output
+        uses: step-security/changed-files@v45
+        with:
+          path: model-output
+          dir_names: "true"
+
+      - name: Get all changes
+        id: get_all_changed_files
+        uses: step-security/changed-files@v45
+
+      - name: Check for changes outside model-output folder
+        id: check_changes_outside_model_output
+        run: |
+          echo "Changed files:"
+          echo "${{ steps.get_all_changed_files.outputs.all_modified_files }}"
+          
+          for file in ${{ steps.get_all_changed_files.outputs.all_modified_files }}; do
+            if [[ "$file" != model-output/* ]]; then
+              echo "Error: Changes detected outside 'model-output' folder. File changed: $file"
+              exit 1
+            fi
+          done
+
+      - name: Approve PR if changes made by authorized user
+        run: |
+          readarray -t lines_arr <<< "${{ steps.read_authorized_user.outputs.content }}"
+          is_authorized=false
+          
+          for line in "${lines_arr[@]}"; do
+            read -r dir user_list <<< $line
+            IFS=', ' read -r -a user_array <<< "$user_list"  
+            
+            for file in ${{ steps.get_changed_files_in_model_output.outputs.all_modified_files }}; do
+              if [[ "$file" == "$dir" ]]; then
+                is_authorized=false
+                if [[ "$user_array" == "NA" ]]; then
+                  echo "Changes found within `$dir/`, but no authorized users found for '$dir/'. Will not attempt auto-approval of changes. Consider adding one or more authorized users to allow auto-approval in the future."
+                  exit 0
+                fi                  
+                for user in "${user_array[@]}"; do
+                  if [[ "${{ github.actor }}" == "$user" ]]; then
+                    is_authorized=true
+                    break
+                  fi
+                done
+                if [[ "$is_authorized" != true ]]; then
+                  echo "Error: Only following users are allowed to change files in '$dir/': ${user_array[*]}"
+                  exit 1
+                fi 
+              fi # end if "$file" == "$dir"
+            done # end loop over files
+            
+          done # end loop over models
+          # only approve PR if all changes were authorized.
+          if [[ "$is_authorized" == true ]]; then
+            gh pr review --approve "${{ github.event.pull_request.html_url }}"
+            exit 0
+          fi
+        env:
+          GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
+
+      - name: Enable auto-merge for approved PRs
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}

--- a/.github/workflows/validate-submission.yaml
+++ b/.github/workflows/validate-submission.yaml
@@ -52,7 +52,8 @@ jobs:
           library("hubValidations")
           v <- hubValidations::validate_pr(
               gh_repo = Sys.getenv("GITHUB_REPOSITORY"),
-              pr_number = Sys.getenv("PR_NUMBER")
+              pr_number = Sys.getenv("PR_NUMBER"),
+              skip_submit_window_check = Sys.getenv("model") == "ensemble"
           )
           hubValidations::check_for_errors(v, verbose = TRUE)
         shell: Rscript {0}

--- a/.github/workflows/validate-submission.yaml
+++ b/.github/workflows/validate-submission.yaml
@@ -29,6 +29,21 @@ jobs:
           packages: |
             any::hubValidations
             any::sessioninfo
+          
+      - name: Get model output changes
+        id: get_changed_files_in_model_output
+        uses: step-security/changed-files@v45
+        with:
+          path: model-output
+          dir_names: "true"
+
+      - name: check output dirs modified
+        run: |   
+          if [ "${{ steps.get_changed_files_in_model_output.outputs.all_modified_files }}" == "CovidHub-ensemble" ]; then
+            { echo "model=ensemble" | tee -a $GITHUB_ENV; }
+          else
+            { echo "model=other" | tee -a $GITHUB_ENV; }
+          fi
 
       - name: Run validations
         env:


### PR DESCRIPTION
Changes here just essentially replace the affected GH actions with [step-security/changed-files](https://github.com/step-security/changed-files). I have also refreshed the GH APP key, so we should be ready to proceed as usual tomorrow.