### PR TITLE
Update hubverse-aws-upload.yaml 

### DIFF
--- a/.github/workflows/hubverse-aws-upload.yaml
+++ b/.github/workflows/hubverse-aws-upload.yaml
@@ -16,6 +16,8 @@ permissions:
 
 jobs:
   upload:
+    # Don't run on forked repositories
+    if: github.event.repository.fork != true
     runs-on: ubuntu-22.04
 
     steps:
@@ -44,7 +46,8 @@ jobs:
     - name: Install rclone
       if: env.CLOUD_ENABLED == 'true'
       run: |
-        curl https://rclone.org/install.sh | sudo bash
+        sudo apt-get update
+        sudo apt-get install -y rclone
         rclone version
 
     - name: Sync files to cloud storage


### PR DESCRIPTION
This brings in changes from the hubverse-actions repository which includes:

1. prevent this workflow from running in forks
2. install curl from apt as a secure trusted source (as opposed to random shell script distributed by the developer)