### PR TITLE
Use up-to-date rclone version

### DIFF
--- a/.github/workflows/hubverse-aws-upload.yaml
+++ b/.github/workflows/hubverse-aws-upload.yaml
@@ -46,8 +46,9 @@ jobs:
     - name: Install rclone
       if: env.CLOUD_ENABLED == 'true'
       run: |
-        sudo apt-get update
-        sudo apt-get install -y rclone
+        # debian version of rclone is outdated and will result in config name errors
+        # https://github.com/rclone/rclone/issues/6060
+        curl https://rclone.org/install.sh | sudo bash
         rclone version
 
     - name: Sync files to cloud storage


### PR DESCRIPTION
It turns out that the debian version of rclone is _still_ badly outdated as we were getting the error message of `config name contains invalid characters`

This reverts part of #615 