### PR TITLE
Update round creation script

### DIFF
--- a/src/make_round_config.R
+++ b/src/make_round_config.R
@@ -22,13 +22,14 @@ get_target_dates <- function(ref_dates, horizon_range) {
 }
 
 create_new_round <- function(
-    hub_path,
-    horizon_range,
-    location,
-    start_date,
-    end_date,
-    weekday = "Saturday",
-    schema_version = hubUtils::get_version_hub(hub_path)) {
+  hub_path,
+  horizon_range,
+  location,
+  start_date,
+  end_date,
+  weekday = "Saturday",
+  schema_version = hubUtils::get_version_hub(hub_path)
+) {
   options(hubAdmin.schema_version = schema_version)
 
   ref_dates <- get_reference_dates(start_date, end_date, weekday)
@@ -232,7 +233,8 @@ parser <- argparser::add_argument(
     } else {
       lubridate::year(Sys.Date()) - 1L
     },
-    "11", "01",
+    "11",
+    "01",
     sep = "-"
   ),
   help = "Season start date in YYYY-MM-DD format. Defaults to 1st November of current season." # nolint
@@ -248,7 +250,8 @@ parser <- argparser::add_argument(
     } else {
       lubridate::year(Sys.Date())
     },
-    "09", "30",
+    "09",
+    "30",
     sep = "-"
   ),
   help = "Season end date in YYYY-MM-DD format. Defaults to 30th September of current season." # nolint


### PR DESCRIPTION
This PR modifies the script used for creating rounds to enable the creation of a round for a full season.

Specifically:
- instead of providing reference dates, the user now provides a range of season dates. A vector of weekly dates in the range are computed as the reference dates.
- The target dates are computed from the reference dates and horizon
- Also added a flag to enable overwriting and existing config instead of only appending.

The changes are completely optional so don't feel you need to merge this PR. It just might make things easier if you do want to extend the season this year (just change the end date and overwrite) or append the next season (provide next years start and end date and append).

See #799 for additional context
