### PR TITLE
CEPH: Update broken link on metadata

### DIFF
--- a/model-metadata/CEPH-Rtrend_covid.yml
+++ b/model-metadata/CEPH-Rtrend_covid.yml
@@ -36,5 +36,5 @@ methods: "A renewal equation method based on Bayesian estimation of Rt from hosp
 methods_long: "Model forecasts are obtained by using a renewal equation based on the estimated net reproduction number Rt. We apply a lowpass filter to the time series of weekly hospitalizations, then interpolate it to daily resolution. We then use MCMC Metropolis-Hastings sampling to estimate the posterior distribution of Rt based on the filtered data, considering an informed prior on Rt based on COVID-19 literature. The estimated Rt in the last weeks of available data is used to forecast Rt in the upcoming weeks, with a drift term proportional to the current incidence. Finally, we use the renewal equation with the posterior distribution and trend of the estimated Rt in the most recent weeks of hospitalization data."
 ensemble_of_models: false
 ensemble_of_hub_models: false
-website_url: https://publichealth.indiana.edu/research/faculty-directory/profile.html?user=majelli
+website_url: https://publichealth.indiana.edu/about/directory/Marco-Ajelli-majelli.html
 designated_github_users: ["paulocv"]


### PR DESCRIPTION
This PR updates the `website_url` in our metadata file, since the previous link was broken.