### PR TITLE
Update Air Format Check Workflow Header

### DIFF
--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -1,17 +1,5 @@
-###############################################################################
-# OVERVIEW
-###############################################################################
 # The following is a workflow derived from
 # https://github.com/posit-dev/setup-air/blob/main/examples/format-check.yaml
-#
-# Description:
-#
-# This runs air format . --check on every push to main and on every pull
-# request. This is a very simple action that fails if any files would be
-# reformatted. When this happens, reformat locally using air format . or
-# the Air: Format Workspace Folder command in VS Code or Positron, and commit
-# and push the results.
-###############################################################################
 on:
   push:
     branches: [main, master]


### PR DESCRIPTION
This PR:

* [x] Removes most of the header in the workflow file `format-check.yaml` to match the one used in the internal RSV hub, which only contains the comment on attribution for the file.