### PR TITLE
Automatically request review for baseline and ensemble PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 /src/* @sbidari @dylanhmorris @O957
 /.github/* @sbidari @dylanhmorris @O957
 /hub-config/* @sbidari @dylanhmorris @O957
+/auxiliary_data/weekly-model-submissions/ @sbidari @dylanhmorris @O957
 /model-output/CovidHub-baseline/ @sbidari @dylanhmorris @O957
 /model-output/CovidHub-ensemble/ @sbidari @dylanhmorris @O957
 README.md @sbidari @dylanhmorris @O957


### PR DESCRIPTION
This PR:

* [x] Updates the `CODEOWNERS` file such that reviews from code owners are requested when changes are made in the directories: ` /model-output/CovidHub-ensemble/` and ` /auxiliary_data/weekly-model-submissions/`