### PR TITLE
Update metadata for `EpiAutoGP`

### DIFF
--- a/model-metadata/CFA-EpiAutoGP.yaml
+++ b/model-metadata/CFA-EpiAutoGP.yaml
@@ -35,9 +35,9 @@ license: "CC-BY-4.0"
 designated_model: true
 methods: "Ensemble of Gaussian processes."
 data_inputs: "Weekly NHSN COVID-19 hospitalisation visits."
-methods_long: "Ensemble of Gaussian processes, implemented using AutoGP.jl"
-website_url: "https://github.com/cdcgov/pyrenew-hew"
-repo_url: "https://github.com/cdcgov/pyrenew-hew"
+methods_long: "Ensemble of Gaussian processes, with most recent week nowcasting, implemented using NowcastAutoGP.jl. Before reference date, 2025-11-29, model was based directly on AutoGP.jl, and has been updated to NowcastAutoGP.jl."
+website_url: "https://github.com/CDCgov/NowcastAutoGP"
+repo_url: "https://github.com/CDCgov/NowcastAutoGP"
 ensemble_of_models: true
 ensemble_of_hub_models: false
 designated_github_users: ["SamuelBrand1"]


### PR DESCRIPTION
Since the methodology has changed a bit, and now directly uses `NowcastAutoGP.jl`, I would like to update the metadata of the model to reflect this change.