### PR TITLE
Add Warp-Agent forecast for 2025-12-20

### DIFF
--- a/model-metadata/Warp-Agent.yaml
+++ b/model-metadata/Warp-Agent.yaml
@@ -1,0 +1,21 @@
+team_name: "Warp AI Agent"
+team_abbr: "Warp"
+model_name: "Warp Agent COVID-19 Baseline Forecast"
+model_abbr: "Agent"
+model_version: "1.0"
+model_contributors:
+  [
+    {
+      "name": "Warp Agent User",
+      "affiliation": "Independent",
+      "email": "user@example.com"
+    }
+  ]
+website_url: "https://github.com/cdcgov/covid19-forecast-hub"
+license: "CC-BY-4.0"
+designated_model: false
+methods: "Baseline forecasting model using CDC's standard flat baseline approach via epipredict package. Uses most recent observed value as median projection with uncertainty based on historical timeseries."
+data_inputs: "Epiweekly incident COVID-19 hospital admissions from the NHSN Weekly Hospital Respiratory Data dataset, https://data.cdc.gov/Public-Health-Surveillance/Weekly-Hospital-Respiratory-Data-HRD-Metrics-by-Ju/mpgq-jmmr/about_data"
+methods_long: "This model implements the CDC standard baseline forecasting approach using the cdc_baseline_forecaster() function from the epipredict R package. The model projects the most recent observed value forward as the median forecast, with prospective uncertainty estimated from the preceding time series. This approach provides a simple but robust baseline for comparison with more complex forecasting models."
+ensemble_of_models: false
+ensemble_of_hub_models: false

--- a/model-output/Warp-Agent/2025-12-20-Warp-Agent.csv
+++ b/model-output/Warp-Agent/2025-12-20-Warp-Agent.csv
@@ -1,0 +1,11961 @@
+reference_date,horizon,target,target_end_date,location,output_type,output_type_id,value
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.01,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.025,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.05,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.1,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.15,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.2,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.25,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.3,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.35,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.4,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.45,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.5,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.55,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.6,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.65,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.7,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.75,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.8,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.85,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.9,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.95,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.975,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,01,quantile,0.99,53
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.01,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.025,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.05,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.1,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.15,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.2,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.25,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.3,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.35,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.4,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.45,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.5,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.55,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.6,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.65,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.7,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.75,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.8,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.85,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.9,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.95,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.975,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,02,quantile,0.99,9
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.01,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.025,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.05,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.1,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.15,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.2,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.25,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.3,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.35,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.4,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.45,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.5,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.55,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.6,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.65,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.7,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.75,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.8,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.85,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.9,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.95,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.975,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,04,quantile,0.99,70
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.01,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.025,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.05,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.1,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.15,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.2,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.25,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.3,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.35,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.4,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.45,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.5,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.55,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.6,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.65,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.7,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.75,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.8,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.85,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.9,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.95,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.975,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,05,quantile,0.99,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.01,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.025,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.05,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.1,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.15,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.2,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.25,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.3,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.35,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.4,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.45,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.5,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.55,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.6,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.65,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.7,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.75,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.8,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.85,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.9,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.95,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.975,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,06,quantile,0.99,271
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.01,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.025,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.05,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.1,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.15,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.2,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.25,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.3,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.35,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.4,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.45,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.5,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.55,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.6,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.65,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.7,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.75,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.8,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.85,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.9,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.95,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.975,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,08,quantile,0.99,65
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.01,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.025,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.05,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.1,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.15,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.2,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.25,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.3,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.35,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.4,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.45,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.5,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.55,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.6,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.65,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.7,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.75,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.8,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.85,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.9,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.95,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.975,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,09,quantile,0.99,90
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.01,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.025,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.05,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.1,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.15,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.2,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.25,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.3,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.35,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.4,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.45,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.5,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.55,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.6,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.65,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.7,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.75,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.8,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.85,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.9,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.95,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.975,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,10,quantile,0.99,29
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.01,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.025,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.05,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.1,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.15,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.2,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.25,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.3,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.35,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.4,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.45,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.5,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.55,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.6,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.65,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.7,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.75,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.8,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.85,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.9,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.95,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.975,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,11,quantile,0.99,3
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.01,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.025,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.05,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.1,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.15,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.2,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.25,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.3,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.35,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.4,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.45,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.5,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.55,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.6,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.65,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.7,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.75,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.8,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.85,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.9,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.95,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.975,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,12,quantile,0.99,120
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.01,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.025,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.05,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.1,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.15,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.2,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.25,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.3,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.35,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.4,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.45,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.5,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.55,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.6,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.65,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.7,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.75,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.8,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.85,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.9,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.95,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.975,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,13,quantile,0.99,58
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.01,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.025,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.05,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.1,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.15,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.2,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.25,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.3,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.35,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.4,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.45,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.5,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.55,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.6,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.65,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.7,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.75,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.8,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.85,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.9,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.95,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.975,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,15,quantile,0.99,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.01,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.025,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.05,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.1,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.15,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.2,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.25,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.3,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.35,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.4,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.45,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.5,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.55,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.6,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.65,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.7,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.75,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.8,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.85,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.9,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.95,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.975,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,16,quantile,0.99,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.01,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.025,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.05,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.1,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.15,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.2,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.25,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.3,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.35,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.4,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.45,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.5,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.55,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.6,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.65,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.7,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.75,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.8,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.85,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.9,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.95,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.975,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,17,quantile,0.99,196
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.01,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.025,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.05,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.1,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.15,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.2,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.25,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.3,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.35,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.4,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.45,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.5,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.55,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.6,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.65,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.7,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.75,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.8,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.85,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.9,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.95,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.975,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,18,quantile,0.99,206
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.01,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.025,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.05,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.1,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.15,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.2,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.25,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.3,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.35,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.4,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.45,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.5,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.55,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.6,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.65,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.7,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.75,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.8,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.85,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.9,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.95,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.975,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,19,quantile,0.99,41
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.01,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.025,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.05,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.1,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.15,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.2,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.25,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.3,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.35,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.4,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.45,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.5,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.55,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.6,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.65,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.7,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.75,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.8,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.85,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.9,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.95,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.975,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,20,quantile,0.99,44
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.01,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.025,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.05,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.1,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.15,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.2,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.25,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.3,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.35,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.4,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.45,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.5,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.55,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.6,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.65,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.7,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.75,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.8,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.85,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.9,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.95,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.975,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,21,quantile,0.99,47
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.01,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.025,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.05,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.1,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.15,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.2,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.25,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.3,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.35,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.4,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.45,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.5,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.55,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.6,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.65,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.7,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.75,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.8,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.85,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.9,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.95,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.975,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,22,quantile,0.99,37
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.01,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.025,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.05,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.1,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.15,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.2,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.25,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.3,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.35,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.4,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.45,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.5,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.55,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.6,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.65,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.7,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.75,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.8,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.85,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.9,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.95,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.975,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,23,quantile,0.99,15
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.01,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.025,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.05,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.1,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.15,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.2,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.25,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.3,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.35,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.4,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.45,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.5,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.55,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.6,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.65,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.7,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.75,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.8,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.85,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.9,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.95,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.975,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,24,quantile,0.99,43
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.01,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.025,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.05,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.1,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.15,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.2,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.25,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.3,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.35,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.4,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.45,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.5,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.55,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.6,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.65,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.7,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.75,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.8,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.85,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.9,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.95,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.975,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,25,quantile,0.99,151
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.01,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.025,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.05,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.1,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.15,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.2,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.25,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.3,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.35,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.4,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.45,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.5,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.55,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.6,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.65,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.7,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.75,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.8,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.85,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.9,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.95,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.975,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,26,quantile,0.99,162
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.01,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.025,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.05,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.1,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.15,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.2,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.25,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.3,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.35,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.4,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.45,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.5,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.55,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.6,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.65,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.7,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.75,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.8,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.85,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.9,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.95,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.975,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,27,quantile,0.99,89
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.01,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.025,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.05,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.1,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.15,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.2,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.25,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.3,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.35,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.4,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.45,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.5,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.55,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.6,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.65,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.7,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.75,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.8,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.85,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.9,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.95,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.975,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,28,quantile,0.99,54
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.01,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.025,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.05,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.1,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.15,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.2,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.25,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.3,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.35,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.4,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.45,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.5,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.55,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.6,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.65,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.7,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.75,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.8,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.85,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.9,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.95,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.975,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,29,quantile,0.99,78
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.01,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.025,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.05,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.1,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.15,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.2,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.25,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.3,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.35,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.4,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.45,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.5,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.55,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.6,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.65,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.7,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.75,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.8,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.85,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.9,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.95,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.975,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,30,quantile,0.99,32
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.01,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.025,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.05,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.1,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.15,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.2,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.25,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.3,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.35,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.4,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.45,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.5,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.55,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.6,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.65,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.7,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.75,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.8,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.85,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.9,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.95,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.975,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,31,quantile,0.99,27
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.01,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.025,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.05,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.1,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.15,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.2,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.25,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.3,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.35,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.4,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.45,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.5,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.55,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.6,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.65,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.7,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.75,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.8,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.85,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.9,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.95,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.975,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,32,quantile,0.99,21
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.01,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.025,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.05,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.1,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.15,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.2,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.25,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.3,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.35,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.4,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.45,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.5,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.55,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.6,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.65,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.7,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.75,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.8,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.85,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.9,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.95,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.975,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,33,quantile,0.99,24
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.01,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.025,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.05,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.1,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.15,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.2,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.25,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.3,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.35,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.4,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.45,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.5,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.55,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.6,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.65,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.7,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.75,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.8,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.85,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.9,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.95,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.975,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,34,quantile,0.99,165
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.01,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.025,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.05,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.1,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.15,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.2,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.25,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.3,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.35,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.4,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.45,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.5,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.55,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.6,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.65,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.7,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.75,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.8,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.85,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.9,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.95,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.975,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,35,quantile,0.99,64
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.01,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.025,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.05,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.1,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.15,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.2,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.25,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.3,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.35,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.4,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.45,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.5,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.55,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.6,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.65,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.7,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.75,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.8,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.85,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.9,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.95,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.975,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,36,quantile,0.99,277
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.01,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.025,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.05,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.1,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.15,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.2,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.25,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.3,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.35,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.4,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.45,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.5,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.55,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.6,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.65,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.7,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.75,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.8,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.85,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.9,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.95,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.975,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,37,quantile,0.99,93
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.01,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.025,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.05,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.1,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.15,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.2,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.25,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.3,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.35,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.4,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.45,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.5,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.55,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.6,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.65,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.7,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.75,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.8,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.85,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.9,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.95,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.975,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,38,quantile,0.99,17
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.01,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.025,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.05,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.1,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.15,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.2,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.25,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.3,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.35,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.4,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.45,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.5,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.55,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.6,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.65,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.7,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.75,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.8,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.85,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.9,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.95,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.975,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,39,quantile,0.99,311
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.01,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.025,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.05,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.1,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.15,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.2,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.25,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.3,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.35,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.4,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.45,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.5,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.55,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.6,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.65,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.7,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.75,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.8,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.85,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.9,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.95,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.975,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,40,quantile,0.99,49
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.01,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.025,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.05,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.1,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.15,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.2,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.25,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.3,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.35,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.4,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.45,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.5,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.55,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.6,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.65,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.7,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.75,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.8,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.85,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.9,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.95,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.975,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,41,quantile,0.99,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.01,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.025,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.05,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.1,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.15,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.2,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.25,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.3,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.35,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.4,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.45,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.5,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.55,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.6,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.65,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.7,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.75,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.8,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.85,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.9,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.95,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.975,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,42,quantile,0.99,412
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.01,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.025,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.05,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.1,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.15,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.2,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.25,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.3,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.35,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.4,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.45,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.5,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.55,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.6,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.65,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.7,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.75,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.8,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.85,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.9,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.95,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.975,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,44,quantile,0.99,28
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.01,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.025,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.05,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.1,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.15,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.2,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.25,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.3,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.35,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.4,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.45,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.5,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.55,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.6,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.65,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.7,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.75,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.8,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.85,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.9,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.95,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.975,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,45,quantile,0.99,40
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.01,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.025,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.05,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.1,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.15,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.2,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.25,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.3,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.35,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.4,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.45,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.5,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.55,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.6,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.65,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.7,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.75,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.8,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.85,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.9,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.95,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.975,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,46,quantile,0.99,8
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.01,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.025,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.05,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.1,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.15,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.2,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.25,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.3,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.35,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.4,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.45,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.5,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.55,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.6,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.65,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.7,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.75,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.8,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.85,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.9,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.95,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.975,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,47,quantile,0.99,121
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.01,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.025,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.05,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.1,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.15,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.2,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.25,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.3,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.35,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.4,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.45,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.5,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.55,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.6,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.65,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.7,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.75,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.8,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.85,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.9,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.95,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.975,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,48,quantile,0.99,186
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.01,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.025,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.05,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.1,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.15,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.2,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.25,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.3,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.35,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.4,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.45,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.5,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.55,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.6,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.65,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.7,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.75,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.8,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.85,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.9,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.95,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.975,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,49,quantile,0.99,16
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.01,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.025,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.05,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.1,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.15,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.2,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.25,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.3,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.35,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.4,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.45,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.5,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.55,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.6,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.65,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.7,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.75,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.8,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.85,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.9,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.95,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.975,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,50,quantile,0.99,6
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.01,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.025,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.05,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.1,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.15,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.2,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.25,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.3,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.35,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.4,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.45,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.5,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.55,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.6,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.65,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.7,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.75,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.8,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.85,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.9,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.95,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.975,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,51,quantile,0.99,57
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.01,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.025,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.05,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.1,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.15,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.2,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.25,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.3,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.35,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.4,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.45,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.5,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.55,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.6,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.65,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.7,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.75,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.8,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.85,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.9,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.95,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.975,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,53,quantile,0.99,25
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.01,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.025,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.05,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.1,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.15,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.2,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.25,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.3,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.35,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.4,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.45,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.5,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.55,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.6,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.65,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.7,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.75,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.8,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.85,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.9,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.95,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.975,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,54,quantile,0.99,46
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.01,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.025,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.05,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.1,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.15,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.2,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.25,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.3,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.35,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.4,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.45,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.5,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.55,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.6,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.65,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.7,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.75,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.8,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.85,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.9,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.95,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.975,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,55,quantile,0.99,72
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.01,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.025,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.05,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.1,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.15,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.2,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.25,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.3,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.35,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.4,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.45,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.5,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.55,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.6,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.65,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.7,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.75,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.8,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.85,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.9,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.95,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.975,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,56,quantile,0.99,20
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.01,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.025,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.05,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.1,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.15,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.2,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.25,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.3,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.35,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.4,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.45,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.5,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.55,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.6,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.65,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.7,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.75,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.8,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.85,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.9,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.95,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.975,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,72,quantile,0.99,11
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.01,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.025,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.05,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.1,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.15,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.2,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.25,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.3,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.35,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.4,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.45,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.5,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.55,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.6,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.65,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.7,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.75,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.8,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.85,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.9,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.95,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.975,4109
+2025-12-20,-1,wk inc covid hosp,2025-12-13,US,quantile,0.99,4109
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.025,0.29999999999999805
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.05,11.649999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.1,20.600000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.15,30.950000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.2,34.6
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.25,38.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.3,42
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.35,45
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.4,48
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.45,50
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.5,53
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.55,56
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.6,58
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.65,61
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.7,64
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.75,67.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.8,71.4
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.85,75.05
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.9,85.4
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.95,94.35
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.975,105.69999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,01,quantile,0.99,117.69999999999985
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.1,1.3000000000000016
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.15,3.95
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.2,5
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.25,6
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.3,6
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.35,7
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.4,8
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.45,8
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.5,9
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.55,10
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.6,10
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.65,11
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.7,12
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.75,12
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.8,13
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.85,14.049999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.9,16.700000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.95,18.34999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.975,20
+2025-12-20,0,wk inc covid hosp,2025-12-20,02,quantile,0.99,20.869999999999987
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.1,23.80000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.15,39.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.2,49.60000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.25,56
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.3,57.89999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.35,61.54999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.4,65.2
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.45,68
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.5,70
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.55,72
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.6,74.8
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.65,78.45
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.7,82.09999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.75,84
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.8,90.4
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.85,100.24999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.9,116.20000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.95,166.39999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.975,177.82499999999985
+2025-12-20,0,wk inc covid hosp,2025-12-20,04,quantile,0.99,223.91999999999973
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.05,2.2500000000000058
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.1,11
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.15,14
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.2,17
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.25,20
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.3,21
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.35,22.54999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.4,24
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.45,25
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.5,27
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.55,29
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.6,30
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.65,31.450000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.7,33
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.75,34
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.8,37
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.85,40
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.9,43
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.95,51.74999999999996
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.975,58.274999999999956
+2025-12-20,0,wk inc covid hosp,2025-12-20,05,quantile,0.99,70.73999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.025,78.60000000000004
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.05,95.60000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.1,168.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.15,180.95000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.2,188.00000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.25,203.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.3,225.79999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.35,241.54999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.4,254.60000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.45,263
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.5,271
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.55,279
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.6,287.4
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.65,300.45000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.7,316.1999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.75,338.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.8,354.00000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.85,361.04999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.9,373.09999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.95,446.4
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.975,463.3999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,06,quantile,0.99,556.939999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.01,1.6500000000000017
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.025,6.8249999999999975
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.05,39.65
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.1,44.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.15,47
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.2,50
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.25,53.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.3,56.89999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.35,58.54999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.4,61
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.45,62.85000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.5,65
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.55,67.15
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.6,69
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.65,71.45
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.7,73.09999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.75,76.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.8,80
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.85,83
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.9,85.10000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.95,90.35
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.975,123.175
+2025-12-20,0,wk inc covid hosp,2025-12-20,08,quantile,0.99,128.3499999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.01,12.86
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.025,42.725
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.05,52
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.1,60.300000000000004
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.15,72.95
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.2,76.2
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.25,78.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.3,80
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.35,84
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.4,86
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.45,87.85000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.5,90
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.55,92.15
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.6,94
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.65,96
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.7,100
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.75,101.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.8,103.80000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.85,107.05
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.9,119.7
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.95,128
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.975,137.27499999999992
+2025-12-20,0,wk inc covid hosp,2025-12-20,09,quantile,0.99,167.13999999999965
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.01,4.13
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.025,6.650000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.05,12
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.1,19
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.15,23
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.2,24
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.25,26
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.3,26.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.35,27
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.4,28
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.45,28
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.5,29
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.55,30
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.6,30
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.65,31
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.7,31.09999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.75,32
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.8,34
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.85,35
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.9,39
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.95,46
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.975,51.349999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,10,quantile,0.99,53.86999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.1,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.15,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.2,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.25,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.3,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.35,1
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.4,2
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.45,2.850000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.5,3
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.55,3.1500000000000066
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.6,4
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.65,5
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.7,6
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.75,6
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.8,7
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.85,7.0499999999999945
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.9,10.700000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.95,16
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.975,16
+2025-12-20,0,wk inc covid hosp,2025-12-20,11,quantile,0.99,16
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.1,23.300000000000004
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.15,45.95000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.2,57.000000000000014
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.25,66.74999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.3,80
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.35,92.49999999999991
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.4,105
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.45,111.55000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.5,120
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.55,128.45000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.6,135
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.65,147.50000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.7,160
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.75,173.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.8,183.00000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.85,194.04999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.9,216.70000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.95,277.1499999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.975,311.14999999999986
+2025-12-20,0,wk inc covid hosp,2025-12-20,12,quantile,0.99,352.9699999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.1,7.299999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.15,23.700000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.2,31
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.25,40.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.3,44.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.35,49
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.4,52
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.45,55
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.5,58
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.55,61
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.6,64
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.65,67
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.7,71.09999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.75,75.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.8,85
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.85,92.29999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.9,108.7
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.95,118.35
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.975,130.7
+2025-12-20,0,wk inc covid hosp,2025-12-20,13,quantile,0.99,134.86999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.1,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.15,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.2,0.6000000000000033
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.25,2
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.3,3
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.35,3
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.4,4
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.45,5
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.5,6
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.55,7
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.6,8
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.65,9
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.7,9
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.75,10
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.8,11.400000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.85,13
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.9,17.100000000000012
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.95,22.34999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.975,27.349999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,15,quantile,0.99,29.869999999999987
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.1,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.15,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.2,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.25,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.3,1
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.35,2
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.4,4
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.45,5
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.5,6
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.55,7
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.6,8
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.65,10
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.7,11
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.75,12
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.8,13
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.85,16
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.9,17
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.95,20
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.975,22.174999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,16,quantile,0.99,23.869999999999987
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.025,54.850000000000065
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.05,92.80000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.1,121.3
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.15,150.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.2,159.20000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.25,166
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.3,174.89999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.35,181.54999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.4,185.40000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.45,193.25000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.5,196
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.55,198.75000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.6,206.6
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.65,210.45000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.7,217.09999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.75,226
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.8,232.8
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.85,241.1
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.9,270.70000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.95,299.1999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.975,337.14999999999947
+2025-12-20,0,wk inc covid hosp,2025-12-20,17,quantile,0.99,504.069999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.01,62.64999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.025,80.2
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.05,120.3
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.1,166.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.15,174.95000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.2,179.60000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.25,186.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.3,193.89999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.35,198
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.4,203
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.45,204
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.5,206
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.55,208
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.6,209
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.65,214
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.7,218.09999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.75,225.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.8,232.40000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.85,237.04999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.9,245.1
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.95,291.7
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.975,331.79999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,18,quantile,0.99,349.3499999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.01,1.6499999999999948
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.025,8.475000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.05,16.600000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.1,25.3
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.15,28
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.2,31.600000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.25,33
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.3,34
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.35,36.54999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.4,37.2
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.45,38.85000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.5,41
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.55,43.150000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.6,44.8
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.65,45.45
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.7,48
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.75,49
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.8,50.40000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.85,54
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.9,56.7
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.95,65.39999999999996
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.975,73.52499999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,19,quantile,0.99,80.34999999999992
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.025,4.95
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.05,9.950000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.1,26.900000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.15,30
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.2,33.6
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.25,36
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.3,37
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.35,39
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.4,40
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.45,41.85000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.5,44
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.55,46.150000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.6,48
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.65,49
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.7,51
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.75,52
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.8,54.40000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.85,58
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.9,61.10000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.95,78.04999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.975,83.04999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,20,quantile,0.99,105.39999999999968
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.05,2.950000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.1,16.900000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.15,22.950000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.2,28
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.25,32.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.3,36.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.35,39
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.4,43.2
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.45,45
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.5,47
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.55,49
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.6,50.8
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.65,55
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.7,57.09999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.75,61.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.8,66
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.85,71.05
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.9,77.10000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.95,91.04999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.975,114.54999999999991
+2025-12-20,0,wk inc covid hosp,2025-12-20,21,quantile,0.99,173.40999999999931
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.05,1.3000000000000054
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.1,9
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.15,13.95
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.2,17.6
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.25,20.499999999999996
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.3,24.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.35,29.54999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.4,32
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.45,35
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.5,37
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.55,39
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.6,42
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.65,44.45
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.7,49.09999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.75,53.49999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.8,56.40000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.85,60.05
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.9,65
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.95,72.69999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.975,84.39999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,22,quantile,0.99,91.86999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.05,4.300000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.1,6
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.15,7
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.2,9
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.25,10
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.3,11
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.35,12
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.4,13
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.45,14
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.5,15
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.55,16
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.6,17
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.65,18
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.7,19
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.75,20
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.8,21
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.85,23
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.9,24
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.95,25.69999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.975,31.574999999999967
+2025-12-20,0,wk inc covid hosp,2025-12-20,23,quantile,0.99,45.959999999999866
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.025,8.824999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.05,11.650000000000004
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.1,16.600000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.15,20
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.2,26
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.25,28.249999999999996
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.3,31.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.35,34
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.4,36.2
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.45,40.85000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.5,43
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.55,45.150000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.6,49.8
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.65,52
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.7,54.09999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.75,57.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.8,60
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.85,66
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.9,69.4
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.95,74.35
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.975,77.175
+2025-12-20,0,wk inc covid hosp,2025-12-20,24,quantile,0.99,137.15999999999892
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.025,52.60000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.05,87.25000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.1,108.60000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.15,118
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.2,123.20000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.25,129.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.3,132
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.35,136.54999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.4,142
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.45,148
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.5,151
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.55,154
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.6,160
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.65,165.45000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.7,170
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.75,172.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.8,178.8
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.85,184
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.9,193.4
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.95,214.74999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.975,249.39999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,25,quantile,0.99,322.11999999999875
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.1,43.6
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.15,78
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.2,107.20000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.25,130.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.3,136.89999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.35,147.64999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.4,153
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.45,156.85000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.5,162
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.55,167.14999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.6,171
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.65,176.35
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.7,187.09999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.75,193.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.8,216.80000000000007
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.85,246
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.9,280.40000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.95,329.7999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.975,381.3499999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,26,quantile,0.99,389.95999999999987
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.025,24.350000000000016
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.05,41.550000000000004
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.1,57.500000000000014
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.15,65.95
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.2,71
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.25,75
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.3,77.89999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.35,80
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.4,84.20000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.45,86.85000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.5,89
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.55,91.15
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.6,93.8
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.65,98
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.7,100.09999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.75,103
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.8,107
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.85,112.05
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.9,120.50000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.95,136.44999999999993
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.975,153.64999999999986
+2025-12-20,0,wk inc covid hosp,2025-12-20,27,quantile,0.99,220.66999999999933
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.025,18.950000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.05,26.900000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.1,34
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.15,37
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.2,42
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.25,45
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.3,46.89999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.35,49
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.4,51
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.45,52
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.5,54
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.55,56
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.6,57
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.65,59
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.7,61.09999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.75,63
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.8,66
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.85,71
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.9,74
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.95,81.09999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.975,89.04999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,28,quantile,0.99,113.13999999999965
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.05,25.300000000000008
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.1,47.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.15,55.85
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.2,63.60000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.25,66
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.3,70
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.35,72
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.4,75
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.45,77
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.5,78
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.55,79
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.6,81
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.65,84
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.7,86
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.75,90
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.8,92.4
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.85,100.14999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.9,108.10000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.95,130.7
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.975,168.04999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,29,quantile,0.99,179.0899999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.01,12.129999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.025,13.825000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.05,16.650000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.1,22.3
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.15,24
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.2,27
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.25,28
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.3,28.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.35,29
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.4,30
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.45,31
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.5,32
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.55,33
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.6,34
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.65,35
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.7,35.09999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.75,36
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.8,37
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.85,40
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.9,41.7
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.95,47.349999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.975,50.175
+2025-12-20,0,wk inc covid hosp,2025-12-20,30,quantile,0.99,51.86999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.025,5.125000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.05,9.650000000000004
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.1,13.300000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.15,16
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.2,19.6
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.25,20.249999999999996
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.3,21.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.35,23
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.4,24
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.45,25
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.5,27
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.55,29
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.6,30
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.65,31
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.7,32.09999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.75,33.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.8,34.400000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.85,38
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.9,40.7
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.95,44.349999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.975,48.87499999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,31,quantile,0.99,55.60999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.05,1.6500000000000026
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.1,7
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.15,10.95
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.2,12.600000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.25,14
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.3,15.899999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.35,17
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.4,18
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.45,19.850000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.5,21
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.55,22.150000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.6,24
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.65,25
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.7,26.099999999999977
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.75,28
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.8,29.400000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.85,31.049999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.9,35
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.95,40.349999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.975,46.52499999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,32,quantile,0.99,49.86999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.05,6.850000000000009
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.1,14
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.15,15
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.2,16.6
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.25,18
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.3,19.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.35,21
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.4,22
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.45,22.850000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.5,24
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.55,25.150000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.6,26
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.65,27
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.7,28.09999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.75,30
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.8,31.400000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.85,33
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.9,34
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.95,41.14999999999993
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.975,49.57499999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,33,quantile,0.99,75.26999999999967
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.01,1.719999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.025,73.825
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.05,111.64999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.1,129.29999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.15,133.95000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.2,138
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.25,141.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.3,147.89999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.35,151.54999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.4,157
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.45,162
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.5,165
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.55,168
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.6,173
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.65,178.45000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.7,182.09999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.75,188.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.8,192
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.85,196.04999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.9,200.70000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.95,218.35
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.975,256.17499999999984
+2025-12-20,0,wk inc covid hosp,2025-12-20,34,quantile,0.99,328.2799999999993
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.01,32.129999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.025,36.300000000000004
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.05,40.300000000000004
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.1,46
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.15,50
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.2,53.20000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.25,56
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.3,58
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.35,60
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.4,61
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.45,63
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.5,64
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.55,65
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.6,67
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.65,68
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.7,70
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.75,72
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.8,74.80000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.85,78
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.9,82
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.95,87.69999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.975,91.69999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,35,quantile,0.99,95.86999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.01,114.89999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.025,149.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.05,171.29999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.1,190
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.15,216
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.2,230.40000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.25,243.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.3,251.89999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.35,257.54999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.4,261.40000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.45,269
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.5,277
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.55,285
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.6,292.59999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.65,296.45000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.7,302.09999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.75,310.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.8,323.6
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.85,338
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.9,364
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.95,382.7
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.975,404.7499999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,36,quantile,0.99,439.0999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.05,8
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.1,25.50000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.15,48.900000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.2,60.60000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.25,68.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.3,77.6
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.35,80.54999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.4,83.20000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.45,89.70000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.5,93
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.55,96.30000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.6,102.8
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.65,105.45000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.7,108.39999999999992
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.75,117.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.8,125.4
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.85,137.1
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.9,160.50000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.95,178
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.975,201.74999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,37,quantile,0.99,219.56999999999982
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.01,3
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.025,3.8249999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.05,6.65
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.1,10
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.15,11
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.2,12.600000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.25,13
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.3,15
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.35,15.549999999999992
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.4,16
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.45,17
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.5,17
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.55,17
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.6,18
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.65,18.450000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.7,19
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.75,21
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.8,21.400000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.85,23
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.9,24
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.95,27.34999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.975,30.174999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,38,quantile,0.99,31
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.025,134.775
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.05,206.25000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.1,251.50000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.15,261.95000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.2,274.2
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.25,282.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.3,289.79999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.35,295.09999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.4,303.20000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.45,305
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.5,311
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.55,317
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.6,318.79999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.65,326.90000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.7,332.19999999999993
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.75,339.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.8,347.80000000000007
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.85,360.04999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.9,370.5
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.95,415.7499999999996
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.975,487.22499999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,39,quantile,0.99,724.4199999999958
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.01,5.259999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.025,8.650000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.05,16.650000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.1,27.200000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.15,33.949999999999996
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.2,37
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.25,39.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.3,42.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.35,44
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.4,46.2
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.45,48
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.5,49
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.55,50
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.6,51.8
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.65,54
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.7,55.09999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.75,58.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.8,61
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.85,64.05
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.9,70.80000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.95,81.35
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.975,89.35
+2025-12-20,0,wk inc covid hosp,2025-12-20,40,quantile,0.99,92.73999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.1,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.15,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.2,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.25,0.49999999999999645
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.3,3.899999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.35,6
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.4,8
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.45,9
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.5,11
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.55,13
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.6,14
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.65,16
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.7,18.099999999999977
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.75,21.499999999999993
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.8,24
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.85,26
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.9,31.700000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.95,36.349999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.975,47
+2025-12-20,0,wk inc covid hosp,2025-12-20,41,quantile,0.99,53.08999999999989
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.025,43.55
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.05,236.20000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.1,277.0000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.15,321.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.2,342.20000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.25,356.5
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.3,371.79999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.35,394.54999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.4,401
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.45,404.84999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.5,412
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.55,419.15000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.6,423
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.65,429.45000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.7,452.19999999999993
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.75,467.5
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.8,481.80000000000007
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.85,502.24999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.9,547.0000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.95,587.8
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.975,780.4499999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,42,quantile,0.99,922.4999999999976
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.01,9
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.025,10.649999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.05,14.3
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.1,17.3
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.15,18.950000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.2,20
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.25,21
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.3,24
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.35,25
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.4,26
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.45,27
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.5,28
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.55,29
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.6,30
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.65,31
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.7,32
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.75,35
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.8,36
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.85,37.05
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.9,38.7
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.95,41.69999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.975,45.349999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,44,quantile,0.99,47
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.1,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.15,14
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.2,20
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.25,26
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.3,29
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.35,31.54999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.4,35
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.45,38
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.5,40
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.55,42
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.6,45
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.65,48.45
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.7,51
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.75,54
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.8,60
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.85,66
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.9,80.7
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.95,89
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.975,97.35
+2025-12-20,0,wk inc covid hosp,2025-12-20,45,quantile,0.99,103.34999999999991
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.1,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.15,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.2,1
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.25,3
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.3,4
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.35,5
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.4,6
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.45,7
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.5,8
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.55,9
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.6,10
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.65,11
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.7,12
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.75,13
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.8,15
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.85,17
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.9,20
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.95,26
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.975,29
+2025-12-20,0,wk inc covid hosp,2025-12-20,46,quantile,0.99,30.739999999999966
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.01,21.720000000000013
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.025,65.775
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.05,69.30000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.1,80.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.15,93.80000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.2,100
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.25,105
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.3,107.89999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.35,110.54999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.4,114
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.45,117.85000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.5,121
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.55,124.14999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.6,128
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.65,131.45000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.7,134.09999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.75,137
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.8,142
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.85,148.2
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.9,161.1
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.95,172.7
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.975,176.22499999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,47,quantile,0.99,220.2799999999993
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.05,56.29999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.1,68.8
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.15,93.7
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.2,127.20000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.25,140
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.3,150.89999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.35,159.54999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.4,167.40000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.45,171.85000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.5,186
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.55,200.14999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.6,204.6
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.65,212.45000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.7,221.09999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.75,232
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.8,244.80000000000007
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.85,278.3
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.9,303.2
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.95,315.7
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.975,378.17499999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,48,quantile,0.99,417.2799999999993
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.1,1
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.15,5.95
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.2,10
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.25,10
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.3,12
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.35,13
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.4,14
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.45,14.850000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.5,16
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.55,17.150000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.6,18
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.65,19
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.7,20
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.75,22
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.8,22
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.85,26.049999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.9,31
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.95,35
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.975,41.175
+2025-12-20,0,wk inc covid hosp,2025-12-20,49,quantile,0.99,49.829999999999856
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.1,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.15,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.2,1.6000000000000032
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.25,2
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.3,3
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.35,4.549999999999992
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.4,5
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.45,5
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.5,6
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.55,7
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.6,7
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.65,7.450000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.7,9
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.75,10
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.8,10.400000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.85,12
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.9,13
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.95,15
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.975,16.174999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,50,quantile,0.99,17.869999999999987
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.05,5.650000000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.1,18.600000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.15,27.950000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.2,30
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.25,34.25
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.3,38
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.35,43.54999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.4,49
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.45,51.70000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.5,57
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.55,62.30000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.6,65
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.65,70.45
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.7,76
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.75,79.75
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.8,84
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.85,86.05
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.9,95.4
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.95,108.35
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.975,139.3749999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,51,quantile,0.99,195.66999999999933
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.1,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.15,1.9000000000000004
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.2,9.600000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.25,11.499999999999996
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.3,15
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.35,18
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.4,19
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.45,22
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.5,25
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.55,28
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.6,31
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.65,32
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.7,35
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.75,38.49999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.8,40.40000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.85,48.09999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.9,53
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.95,58.349999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.975,62.049999999999976
+2025-12-20,0,wk inc covid hosp,2025-12-20,53,quantile,0.99,72.2199999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.05,11.200000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.1,23
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.15,29.950000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.2,33
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.25,38
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.3,40.9
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.35,42.54999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.4,44
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.45,45
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.5,46
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.55,47
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.6,48
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.65,49.45
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.7,51.09999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.75,54
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.8,59
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.85,62.05
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.9,69
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.95,80.79999999999993
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.975,101.69999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,54,quantile,0.99,110.2199999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.05,18.6
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.1,35.6
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.15,46.900000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.2,54
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.25,56.49999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.3,61
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.35,64.54999999999998
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.4,67
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.45,70
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.5,72
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.55,74
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.6,77
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.65,79.45
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.7,83
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.75,87.5
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.8,90
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.85,97.1
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.9,108.4
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.95,125.39999999999996
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.975,145.04999999999984
+2025-12-20,0,wk inc covid hosp,2025-12-20,55,quantile,0.99,187.34999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.05,2.6500000000000026
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.1,9.600000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.15,12.95
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.2,13.600000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.25,15
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.3,16
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.35,17
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.4,18
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.45,18.850000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.5,20
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.55,21.150000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.6,22
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.65,23
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.7,24
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.75,25
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.8,26.400000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.85,27.049999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.9,30.40000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.95,37.349999999999994
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.975,46.049999999999976
+2025-12-20,0,wk inc covid hosp,2025-12-20,56,quantile,0.99,64.91999999999973
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.01,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.025,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.05,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.1,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.15,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.2,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.25,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.3,0
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.35,1.5499999999999916
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.4,4.200000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.45,7.850000000000005
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.5,11
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.55,14.150000000000006
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.6,17.799999999999997
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.65,20.450000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.7,24.099999999999977
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.75,27.749999999999996
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.8,32.80000000000001
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.85,42.09999999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.9,49
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.95,58.39999999999996
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.975,68.49999999999993
+2025-12-20,0,wk inc covid hosp,2025-12-20,72,quantile,0.99,90.2199999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.01,954.9500000000002
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.025,2129.9750000000004
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.05,2652.4500000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.1,2949
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.15,3173.6
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.2,3422.2
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.25,3546.5
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.3,3727
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.35,3862.3999999999996
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.4,3925.2000000000003
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.45,4012.2
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.5,4109
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.55,4205.8
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.6,4292.799999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.65,4355.5999999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.7,4491
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.75,4671.5
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.8,4795.8
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.85,5044.4
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.9,5269
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.95,5565.549999999999
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.975,6088.024999999995
+2025-12-20,0,wk inc covid hosp,2025-12-20,US,quantile,0.99,7263.049999999998
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.1,9.423701237012375
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.15,18.255538055380555
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.2,25
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.25,30.949954499544997
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.3,36
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.35,40.63657636576366
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.4,45
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.45,49
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.5,53
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.55,57
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.6,61
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.65,65.48036580365805
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.7,70
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.75,75.22483724837248
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.8,81
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.85,88
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.9,97
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.95,110.43571335713355
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.975,122.46034960349601
+2025-12-20,1,wk inc covid hosp,2025-12-27,01,quantile,0.99,135.66692986929863
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.15,1
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.2,3
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.25,4
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.3,5
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.35,6
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.4,7
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.45,8
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.5,9
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.55,10
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.6,11
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.65,12
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.7,13
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.75,14
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.8,15.36868568685688
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.85,17
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.9,19
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.95,21.548669486694855
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.975,24
+2025-12-20,1,wk inc covid hosp,2025-12-27,02,quantile,0.99,27
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.15,15.986082860828592
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.2,29.82053220532205
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.25,40.58891338913389
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.3,48.04871248712487
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.35,54.94744997449975
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.4,60
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.45,65.48812488124881
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.5,70
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.55,75
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.6,80.44929049290494
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.65,85.89678396783968
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.7,92.77846278462782
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.75,100.72763727637275
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.8,111.79567795677957
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.85,128.3972009720097
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.9,158.7207182071821
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.95,191.74285792857918
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.975,226.91279387793873
+2025-12-20,1,wk inc covid hosp,2025-12-27,04,quantile,0.99,273.70927359273537
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.1,3
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.15,8
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.2,11.910705107051081
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.25,15
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.3,17.955648556485563
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.35,20.012878628786286
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.4,22.742761427614283
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.45,25
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.5,27
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.55,29
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.6,31.276868768687688
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.65,34
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.7,36.207150071500706
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.75,39
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.8,42.475800758007594
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.85,46.80424554245542
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.9,52.34790947909483
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.95,62.36610966109656
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.975,71.274525745257435
+2025-12-20,1,wk inc covid hosp,2025-12-27,05,quantile,0.99,79.83136001360008
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.05,36.53539135391354
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.1,94.5132811328113
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.15,129.10681856818564
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.2,160.35625656256565
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.25,181.98658236582364
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.3,200.22314123141228
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.35,220.0159521595216
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.4,240.61394113941142
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.45,256.62678276782765
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.5,271
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.55,285.9191601916019
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.6,302.2878878788787
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.65,322.60052500525
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.7,341.7041750417503
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.75,359.93664436644366
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.8,380.3943229432295
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.85,411.57805428054274
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.9,446.3078340783408
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.95,505.56722217222114
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.975,553.9824723247233
+2025-12-20,1,wk inc covid hosp,2025-12-27,06,quantile,0.99,619.3274064740646
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.05,13.060653106531076
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.1,31
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.15,39
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.2,44.53810138101383
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.25,48.797000470004704
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.3,52.58822388223882
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.35,56
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.4,59
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.45,62.00157051570517
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.5,65
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.55,68
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.6,71
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.65,74
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.7,77.54781747817478
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.75,81.30464304643047
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.8,85.63863438634388
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.85,91
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.9,99.01436114361148
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.95,117.2845943459434
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.975,133.4198659486593
+2025-12-20,1,wk inc covid hosp,2025-12-27,08,quantile,0.99,148.15706717067158
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.01,2.382203322033222
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.025,17.726545265452653
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.05,35.93659286592866
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.1,49.21377213772138
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.15,59.25334153341534
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.2,65.7528695286953
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.25,71
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.3,75.9580975809758
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.35,80
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.4,83.58103581035812
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.45,87
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.5,90
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.55,93
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.6,96.46781267812678
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.65,100
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.7,104.05303753037529
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.75,109
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.8,114.34893948939494
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.85,121.10138051380514
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.9,130.79873798737992
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.95,144.04511995119955
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.975,162.23484959849588
+2025-12-20,1,wk inc covid hosp,2025-12-27,09,quantile,0.99,176.95439144391437
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.025,2.040875658756591
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.05,6.356037060370607
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.1,12.808637086370865
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.15,17
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.2,20.242624426244262
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.25,22.494282442824428
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.3,24
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.35,25.922683726837263
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.4,27
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.45,28
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.5,29
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.55,30
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.6,31
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.65,32
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.7,33.88578085780857
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.75,35.429421794217944
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.8,37.7868138681387
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.85,40.90795907959078
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.9,45.15404254042541
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.95,51.87665476654766
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.975,56.029199791997875
+2025-12-20,1,wk inc covid hosp,2025-12-27,10,quantile,0.99,61.34357463574636
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.15,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.2,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.25,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.3,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.35,0.25667256672566907
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.4,1.256672566725669
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.45,2.256672566725669
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.5,3
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.55,3.256672566725669
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.6,4.256672566725669
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.65,5.256672566725669
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.7,6.256672566725669
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.75,7.647803978039775
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.8,9.256672566725669
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.85,11.256672566725669
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.9,13.256672566725669
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.95,16.944378443784537
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.975,19.25667256672567
+2025-12-20,1,wk inc covid hosp,2025-12-27,11,quantile,0.99,23.25667256672567
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.15,7.68086430864307
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.2,29.3070540705407
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.25,46.8726687266873
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.3,63.79832298322981
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.35,78.33476834768342
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.4,93.24466744667451
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.45,107.09441394413946
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.5,120
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.55,133.94505495054952
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.6,147.4179471794718
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.65,163.3148966489665
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.7,177.75768457684575
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.75,195.5826508265083
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.8,215.7933789337895
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.85,240.36010810108095
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.9,273.0726877268773
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.95,325.22201822018246
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.975,369.0210234602347
+2025-12-20,1,wk inc covid hosp,2025-12-27,12,quantile,0.99,419.6719774197741
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.15,7.220315203152024
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.2,16.732243322433238
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.25,26.14366393663937
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.3,34.09994799947999
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.35,41.047859978599746
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.4,47.35071150711508
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.45,52.997745477454814
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.5,58
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.55,63.3388943889439
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.6,69.01296412964125
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.65,75.16137561375614
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.7,82.03794537945379
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.75,90.46667716677167
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.8,100.39490394903959
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.85,110.68064980649807
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.9,121.85743357433574
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.95,138.21623666236655
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.975,154.13901639016382
+2025-12-20,1,wk inc covid hosp,2025-12-27,13,quantile,0.99,175.21107401074002
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.15,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.2,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.25,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.3,2
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.35,3
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.4,4
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.45,5
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.5,6
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.55,7.524383743837445
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.6,9
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.65,10
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.7,12
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.75,13.613931139311386
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.8,16
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.85,18.62668526685267
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.9,22.56624366243663
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.95,27.664031640316388
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.975,32
+2025-12-20,1,wk inc covid hosp,2025-12-27,15,quantile,0.99,36.55578555785557
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.15,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.2,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.25,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.3,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.35,1.6822053220532234
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.4,3
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.45,4.563505135051354
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.5,6
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.55,7.0758367583675925
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.6,9
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.65,10
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.7,12
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.75,13.679751797517977
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.8,15.598005980059817
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.85,17.730556805568053
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.9,20.527811278112786
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.95,24.48419584195841
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.975,28
+2025-12-20,1,wk inc covid hosp,2025-12-27,16,quantile,0.99,31.980835208352065
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.05,36.59138891388914
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.1,88.4717427174272
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.15,113.40249602496021
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.2,132.6512785127851
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.25,147.67013170131702
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.3,159.48735387353872
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.35,169.96062860628606
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.4,179.21686616866168
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.45,188
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.5,196
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.55,204.27563475634759
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.6,213.1091690916909
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.65,222.29852898528986
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.7,232.7727707277072
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.75,244.17452424524248
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.8,259.6931909319093
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.85,278.91425414254144
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.9,304.3847258472585
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.95,365.32613076130747
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.975,475.8277847778477
+2025-12-20,1,wk inc covid hosp,2025-12-27,17,quantile,0.99,527.3443788437883
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.01,37.21977259772596
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.025,61.88247207472078
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.05,85.11947519475197
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.1,124
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.15,151.2137201372014
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.2,166.58742587425874
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.25,175.02871028710285
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.3,182
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.35,189.39830148301482
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.4,196.02937829378294
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.45,201.26599865998662
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.5,206
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.55,211
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.6,216.0523445234452
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.65,222.71540365403655
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.7,229.9683156831568
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.75,236.98785987859875
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.8,245.43305833058326
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.85,260.5972199721997
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.9,288.020517205172
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.95,326.0951529515296
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.975,349.98933489334865
+2025-12-20,1,wk inc covid hosp,2025-12-27,18,quantile,0.99,374.8019335193352
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.05,6.832353823538242
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.1,15.615510155101553
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.15,21
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.2,25.11624316243163
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.25,28.958374583745844
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.3,31.330873308733082
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.35,34
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.4,36.2229042290423
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.45,39
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.5,41
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.55,43
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.6,45.714627146271454
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.65,48
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.7,50.83013130131299
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.75,53.1351663516635
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.8,57
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.85,61
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.9,66.23370033700336
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.95,75.53003930039299
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.975,83.48505535055341
+2025-12-20,1,wk inc covid hosp,2025-12-27,19,quantile,0.99,92.00513265132649
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.05,1.4238227382273787
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.1,13.197045970459703
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.15,21
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.2,26
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.25,30.0470429704297
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.3,33.61261712617126
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.35,36.40955659556595
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.4,39
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.45,41.694227942279426
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.5,44
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.55,46.271518215182155
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.6,49
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.65,51.538976889768904
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.7,54.3961479614796
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.75,58
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.8,62
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.85,67.18850438504381
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.9,75.19918699186992
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.95,88.38046880468801
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.975,101.5612486124861
+2025-12-20,1,wk inc covid hosp,2025-12-27,20,quantile,0.99,116.23387553875538
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.1,2
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.15,11.102287522875224
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.2,19
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.25,24.646836468364683
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.3,29.897719977199767
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.35,34.62772577725777
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.4,39.193361933619336
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.45,43.09364743647437
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.5,47
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.55,51
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.6,55.08248682486822
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.65,59.684340843408435
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.7,64.48506185061848
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.75,69.7940679406794
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.8,75.86769267692682
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.85,84.3409404094041
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.9,95.33607936079362
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.95,119.56043610436092
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.975,160.73552010520064
+2025-12-20,1,wk inc covid hosp,2025-12-27,21,quantile,0.99,197.64592555925572
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.15,5.092763927639273
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.2,11.047508475084754
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.25,16
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.3,20.845505455054543
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.35,24.949985499854996
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.4,29.10584105841058
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.45,33.02432024320243
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.5,37
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.55,41
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.6,45
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.65,49.353480534805335
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.7,53.78335783357831
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.75,58.34518595185952
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.8,63.60050800508007
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.85,69.77676676766765
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.9,77.94236242362423
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.95,89.59817748177478
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.975,99.12342873428726
+2025-12-20,1,wk inc covid hosp,2025-12-27,22,quantile,0.99,111.30168581685814
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.1,1.5144631446314483
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.15,4
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.2,6
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.25,8
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.3,9.661728617286167
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.35,11
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.4,12.169381693816936
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.45,14
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.5,15
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.55,16
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.6,17.827130271302714
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.65,19
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.7,20.523458234582343
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.75,22
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.8,24
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.85,26
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.9,29
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.95,34.41789867898676
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.975,43.3758272582726
+2025-12-20,1,wk inc covid hosp,2025-12-27,23,quantile,0.99,52.58141821418219
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.1,6.539759397593978
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.15,13.319370193701936
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.2,18.770621706217064
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.25,23.79460294602945
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.3,27.930456304563037
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.35,32
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.4,35.65153051530516
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.45,39.282311823118235
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.5,43
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.55,46.46615916159161
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.6,50.13330333303333
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.65,54.05641406414067
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.7,58.21687016870169
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.75,62.48339733397332
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.8,67.67234072340725
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.85,73.49148291482915
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.9,80.83007430074301
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.95,93.17980729807294
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.975,117.18817538175404
+2025-12-20,1,wk inc covid hosp,2025-12-27,24,quantile,0.99,176.4026244262445
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.025,11.947002970029715
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.05,49.74369793697937
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.1,82.68742087420875
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.15,98.55617806178061
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.2,109.05019050190504
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.25,118.1911594115941
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.3,125.72839128391283
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.35,132.60098650986504
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.4,139
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.45,145
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.5,151
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.55,156.9348463484635
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.6,163
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.65,169.29267392673927
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.7,176.19049790497903
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.75,183.8781112811128
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.8,192.95872158721585
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.85,203.43883838838389
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.9,219.18083080830817
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.95,252.8198966989669
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.975,300.4564250642499
+2025-12-20,1,wk inc covid hosp,2025-12-27,25,quantile,0.99,350.22790757907563
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.1,4.1752997529975175
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.15,34.53962289622894
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.2,64.450049500495
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.25,88.21553465534654
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.3,109.48737287372872
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.35,126.790534405344
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.4,140.47856378563787
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.45,152.00026600266
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.5,162
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.55,172.81350313503134
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.6,184.32572225722254
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.65,197.98670236702372
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.7,216.26862168621676
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.75,237.71278712787125
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.8,262.030133301333
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.85,291.5527015270152
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.9,331.5795587955881
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.95,385.9257867578674
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.975,418.82468999689996
+2025-12-20,1,wk inc covid hosp,2025-12-27,26,quantile,0.99,477.6414436144357
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.05,16.31077460774608
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.1,39.48534985349853
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.15,51.67469124691247
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.2,59.83224232242323
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.25,66
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.3,71.22616526165261
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.35,76.05843608436084
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.4,80.64804448044484
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.45,84.91996869968699
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.5,89
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.55,93
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.6,97.1210532105321
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.65,101.74043490434906
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.7,106.68444084440843
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.75,112
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.8,118.60877208772092
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.85,126.71274312743125
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.9,138.72873728737287
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.95,164.42210672106705
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.975,205.56382013820138
+2025-12-20,1,wk inc covid hosp,2025-12-27,27,quantile,0.99,236.82618206182036
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.025,2.88949339493394
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.05,13.679814298142986
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.1,24.728063280632806
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.15,31
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.2,35.66433264332644
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.25,39.474734747347476
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.3,43
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.35,45.931773317733175
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.4,48.741007410074104
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.45,51.295826458264585
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.5,54
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.55,56.63477184771847
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.6,59.31057310573105
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.65,62.147729977299775
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.7,65.1650916509165
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.75,68.79139791397913
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.8,72.45401854018542
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.85,77
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.9,83.18025080250797
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.95,94.46110811108113
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.975,106.94602596025953
+2025-12-20,1,wk inc covid hosp,2025-12-27,28,quantile,0.99,119.91614986149854
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.1,25.15985559855599
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.15,40.851064010640094
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.2,50.2020520205202
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.25,57.002402524025236
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.3,62.83000730007299
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.35,67
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.4,71
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.45,74.70874258742587
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.5,78
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.55,81.23417534175343
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.6,85
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.65,89
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.7,93.4273032730327
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.75,99.0687856878569
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.8,106.03774237742377
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.85,115.47234872348723
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.9,131.86736067360678
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.95,166.57499974999746
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.975,183.58881138811392
+2025-12-20,1,wk inc covid hosp,2025-12-27,29,quantile,0.99,204.4617907179072
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.01,4.510747807478076
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.025,8.995902209022091
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.05,12.636370363703637
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.1,17.231703317033176
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.15,20.26520865208652
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.2,23
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.25,25
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.3,26.549119491194908
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.35,28
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.4,29.3389693896939
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.45,31
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.5,32
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.55,33
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.6,34.63880238802387
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.65,36
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.7,37.46499664996648
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.75,39
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.8,41
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.85,43.70280152801528
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.9,46.69317193171932
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.95,51.48691136911368
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.975,55.05080975809757
+2025-12-20,1,wk inc covid hosp,2025-12-27,30,quantile,0.99,59.45634716347162
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.05,2
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.1,7.678003780037806
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.15,11.636166361663607
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.2,14.678324783247835
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.25,17
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.3,19.00321403214032
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.35,21.18697936979369
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.4,23.12108921089212
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.45,25.016761667616674
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.5,27
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.55,28.88022830228303
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.6,30.904207042070425
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.65,32.795481454814556
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.7,35
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.75,37
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.8,39.45567455674557
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.85,42.46011710117101
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.9,46.49640496404963
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.95,52.385814858148564
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.975,58.56286462864629
+2025-12-20,1,wk inc covid hosp,2025-12-27,31,quantile,0.99,65.88457004570046
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.1,1.5352653526535285
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.15,5.2900274002740035
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.2,8.092192921929222
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.25,11
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.3,13
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.35,15.013041130411292
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.4,17
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.45,19
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.5,21
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.55,23
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.6,25
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.65,27
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.7,29
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.75,31.077628276282766
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.8,34
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.85,37
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.9,41.11453414534143
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.95,47.5861188611886
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.975,53.04704797047971
+2025-12-20,1,wk inc covid hosp,2025-12-27,32,quantile,0.99,58.69824778247781
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.1,6.839701397013971
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.15,10.5519815198152
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.2,13.242550425504266
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.25,15.865956159561595
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.3,17.712575125751254
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.35,19.348794987949873
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.4,21
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.45,22.741752917529173
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.5,24
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.55,25.39836448364484
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.6,27
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.65,28.830822808228085
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.7,30.430362303623028
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.75,32.1670016700167
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.8,34.85920459204595
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.85,37.67933229332291
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.9,42
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.95,53
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.975,68.45590280902807
+2025-12-20,1,wk inc covid hosp,2025-12-27,33,quantile,0.99,80.47468034680338
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.025,19.413721887218895
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.05,69.00947959479596
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.1,102.45746557465577
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.15,115.45333453334534
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.2,125.75006550065501
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.25,133.96662716627165
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.3,140.84742547425475
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.35,147.0761117611176
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.4,153.56684566845672
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.45,159.46375613756138
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.5,165
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.55,170.17632576325764
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.6,176.3812198121981
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.65,182.90834408344082
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.7,189.23688136881367
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.75,196.08645086450866
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.8,204.3169511695117
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.85,214.49611246112462
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.9,227.43412234122337
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.95,261.6640501405013
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.975,315.6911509115091
+2025-12-20,1,wk inc covid hosp,2025-12-27,34,quantile,0.99,361.61099810998064
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.01,18.588979289792896
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.025,25.564057640576408
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.05,31.97061020610206
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.1,39.003213032130326
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.15,44
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.2,47.90505505055051
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.25,51.028597785977865
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.3,54
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.35,57
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.4,59.30232102321024
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.45,61.95883508835088
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.5,64
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.55,66.16321863218634
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.6,68.74237542375423
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.65,71
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.7,74
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.75,77
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.8,80.12171521715217
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.85,84
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.9,88.95100851008513
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.95,96.000034500345
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.975,102.21776342763427
+2025-12-20,1,wk inc covid hosp,2025-12-27,35,quantile,0.99,109.24065550655506
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.01,26.07740807408076
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.025,84.52747277472778
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.05,125.56532765327654
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.1,162.0560965609656
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.15,185.91212412124122
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.2,203.31278112781126
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.25,219.30646806468064
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.3,233.04770847708477
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.35,244.3929114291143
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.4,256.2206922069221
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.45,267.1021445214452
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.5,277
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.55,287.0860338603386
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.6,297.83262432624326
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.65,309.2178311783118
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.7,320.48689686896853
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.75,334.16721417214166
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.8,350.47378273782755
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.85,368.16381863818617
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.9,392.27644276442766
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.95,428.9984659846599
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.975,469.97655351553504
+2025-12-20,1,wk inc covid hosp,2025-12-27,36,quantile,0.99,532.3580139801392
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.1,7.506185061850623
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.15,23.867463174631744
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.2,39.07455874558746
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.25,51.680539305393054
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.3,61.77382073820736
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.35,70.69626146261459
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.4,79
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.45,86
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.5,93
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.55,100.15973459734596
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.6,107.25324053240533
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.65,115.33612386123862
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.7,124.37929779297791
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.75,134.76017510175103
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.8,147.34266142661428
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.85,162.94145291452915
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.9,181.4135521355214
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.95,208.1699856998566
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.975,229.7327303273031
+2025-12-20,1,wk inc covid hosp,2025-12-27,37,quantile,0.99,256.9075863758637
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.025,0.2169254192541919
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.05,3
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.1,6
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.15,8.35718557185572
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.2,10
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.25,11.608786087860882
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.3,13
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.35,14
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.4,15
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.45,16
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.5,17
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.55,18
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.6,19
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.65,20
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.7,21
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.75,22.51380013800137
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.8,24
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.85,25.606778567785675
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.9,28
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.95,31
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.975,33.79284442844427
+2025-12-20,1,wk inc covid hosp,2025-12-27,38,quantile,0.99,37
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.025,23.140026650266535
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.05,128.33916539165392
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.1,201.44783747837482
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.15,233.8622781227812
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.2,252.32368523685236
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.25,265.1933444334444
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.3,276.2267902679027
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.35,285.6118901189012
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.4,294.61714417144174
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.45,302.64524495244956
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.5,311
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.55,319.01322213222136
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.6,327.4273222732228
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.65,336.26453564535643
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.7,345.5880258802587
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.75,356.6980669806698
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.8,369.28482884828856
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.85,386.98976489764897
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.9,420.1512645126452
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.95,495.52715327153254
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.975,639.237668626684
+2025-12-20,1,wk inc covid hosp,2025-12-27,39,quantile,0.99,766.5255441554414
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.05,6.1447269472694686
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.1,16.641204412044118
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.15,24
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.2,29.651852518525192
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.25,34
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.3,37.568075680756806
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.35,40.77811528115281
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.4,43.92407924079245
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.45,46.57912279122792
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.5,49
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.55,51.61280212802127
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.6,54.204240042400414
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.65,57.27133621336213
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.7,60.479383793837926
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.75,64
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.8,68.40761607616076
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.85,74
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.9,81.38248782487825
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.95,91.90210202102016
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.975,101.34328093280935
+2025-12-20,1,wk inc covid hosp,2025-12-27,40,quantile,0.99,112.74779127791275
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.15,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.2,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.25,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.3,0.8512085120851225
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.35,3.8512085120851225
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.4,5.953315533155338
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.45,8.851208512085122
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.5,11
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.55,13.851208512085122
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.6,15.851208512085122
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.65,19.061066110661116
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.7,21.851208512085122
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.75,25.00317253172532
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.8,28.817402174021748
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.85,33.38071880718807
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.9,38.85120851208512
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.95,47.85120851208512
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.975,55.88196656966566
+2025-12-20,1,wk inc covid hosp,2025-12-27,41,quantile,0.99,64.67512265122652
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.05,79.53146231462321
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.1,214.14904349043496
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.15,257.17135371353714
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.2,297.81248612486127
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.25,323.33041080410806
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.3,343.95163651636517
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.35,362.52345823458234
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.4,382.34118141181415
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.45,398.62397423974244
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.5,412
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.55,425.3010830108302
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.6,441.5123291232911
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.65,461.36083610836107
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.7,479.809859098591
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.75,500.78869038690385
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.8,527.669664696647
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.85,567.7317668176681
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.9,610.230667306673
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.95,752.4603301033007
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.975,879.5984609846109
+2025-12-20,1,wk inc covid hosp,2025-12-27,42,quantile,0.99,975.5970391703917
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.025,3.1357848578485794
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.05,7.501825518255185
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.1,12
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.15,15
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.2,17.492016920169206
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.25,19.415361653616536
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.3,21.28757787577875
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.35,23
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.4,25
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.45,26.598732987329875
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.5,28
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.55,29.39148991489916
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.6,31
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.65,33
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.7,34.69256392563924
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.75,36.589958399584
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.8,38.6570145701457
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.85,41
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.9,44
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.95,48.60168951689517
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.975,52.92256972569726
+2025-12-20,1,wk inc covid hosp,2025-12-27,44,quantile,0.99,57.74679436794363
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.15,2.3445744457444597
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.2,9.778437784377843
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.25,16.12707377073771
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.3,21.778437784377843
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.35,26.778437784377843
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.4,31.399673996739978
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.45,36.08914839148392
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.5,40
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.55,44.38947739477396
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.6,48.77843778437784
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.65,53.253717037170375
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.7,58.77402174021741
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.75,64.46190711907118
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.8,71.69816898168982
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.85,80.10196151961519
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.9,90.0389933899339
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.95,103.43809688096873
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.975,114.7633213832138
+2025-12-20,1,wk inc covid hosp,2025-12-27,45,quantile,0.99,131.31993749937496
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.15,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.2,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.25,0.7717777177771836
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.3,2.480085800858012
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.35,3.7717777177771836
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.4,5.397937979379806
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.45,6.771777717777184
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.5,8
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.55,9.771777717777184
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.6,11.246010460104593
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.65,12.771777717777184
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.7,14.771777717777184
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.75,16.771777717777184
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.8,18.771777717777184
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.85,21.771777717777184
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.9,24.933856338563398
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.95,30.142057420574197
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.975,34.380843308433036
+2025-12-20,1,wk inc covid hosp,2025-12-27,46,quantile,0.99,39.54309723097228
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.01,3.268830088300881
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.025,27.742849678496782
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.05,49.23128231282315
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.1,67
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.15,78.54981249812498
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.2,87.08355883558836
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.25,93.97821478214783
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.3,100.0170511705117
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.35,106.0030470304703
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.4,111.10145501455015
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.45,116.33444684446846
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.5,121
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.55,125.84478294782949
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.6,130.83917639176389
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.65,135.9487989879899
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.7,142
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.75,148.04443044430445
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.8,154.97038570385675
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.85,163.39328143281432
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.9,174.94356943569437
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.95,192.66475764757644
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.975,214.27115821158208
+2025-12-20,1,wk inc covid hosp,2025-12-27,47,quantile,0.99,238.66575225752234
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.1,30.42349823498234
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.15,58.39558295582952
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.2,86.25277552775525
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.25,106.55008800087998
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.3,123.67473874738744
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.35,141.35392703927033
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.4,157.9234282342823
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.45,174.0748367483675
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.5,186
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.55,197.97602326023255
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.6,213.97964679646793
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.65,230.44874798747986
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.7,248.36471664716646
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.75,265.8176006760067
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.8,286.45278352783527
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.85,313.9762737627376
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.9,342.8773647736477
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.95,396.5984964849647
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.975,433.33921864218627
+2025-12-20,1,wk inc covid hosp,2025-12-27,48,quantile,0.99,490.47580765807646
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.15,1
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.2,4
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.25,6.995492454924547
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.3,9
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.35,11
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.4,13
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.45,14.757095070950704
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.5,16
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.55,17.75590355903558
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.6,19.066858668586686
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.65,21
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.7,23.12695326953268
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.75,25.67615676156761
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.8,28.56428364283643
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.85,32
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.9,36.5267182671827
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.95,43.59257592575921
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.975,51.02649151491507
+2025-12-20,1,wk inc covid hosp,2025-12-27,49,quantile,0.99,59.07526055260552
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.15,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.2,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.25,1
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.3,2.0619526195261924
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.35,3.184224842248417
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.4,4
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.45,5
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.5,6
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.55,7
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.6,8
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.65,9
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.7,10
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.75,11
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.8,12.389999899999012
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.85,14
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.9,16
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.95,18.965582155821533
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.975,21.4039825398253
+2025-12-20,1,wk inc covid hosp,2025-12-27,50,quantile,0.99,24.762621026210212
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.15,10.733236332363306
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.2,19.78806188061881
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.25,27.056930569305695
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.3,33.9660646606466
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.35,40.01367063670636
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.4,45.84216042160422
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.45,51.708659586595864
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.5,57
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.55,62.70104801048012
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.6,68.43600236002356
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.65,74.28736187361875
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.7,80.54831848318483
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.75,87.76411264112642
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.8,95.7129771297713
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.85,105.20829208292082
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.9,118.01247012470122
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.95,143.73197681976802
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.975,177.9291300413002
+2025-12-20,1,wk inc covid hosp,2025-12-27,51,quantile,0.99,209.8655914559145
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.15,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.2,1.815836158361579
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.25,6.203567035670348
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.3,10.236298362983616
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.35,14.255562055620546
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.4,17.86260062600624
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.45,21.565567155671545
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.5,25
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.55,28.439344393443925
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.6,32.30432104321042
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.65,36.0140826408264
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.7,40.41211712117114
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.75,44.54244292442923
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.8,49.439344393443925
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.85,55.08307033070328
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.9,62.439344393443925
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.95,72.8533575335753
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.975,82.43934439344392
+2025-12-20,1,wk inc covid hosp,2025-12-27,53,quantile,0.99,91.70313973139727
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.1,10.851532515325154
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.15,20
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.2,26
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.25,30.9640196401964
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.3,34.99951399513995
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.35,38.11236212362121
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.4,41
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.45,44
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.5,46
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.55,48.23169431694318
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.6,51
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.65,54
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.7,57.20940309403093
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.75,61.177819278192786
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.8,66.01175011750118
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.85,72.000148501485
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.9,82.28439284392853
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.95,101.57718977189766
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.975,113.10491479914788
+2025-12-20,1,wk inc covid hosp,2025-12-27,54,quantile,0.99,125.31307833078321
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.1,18
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.15,31.15072150721506
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.2,40.24621846218462
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.25,47.597400974009744
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.3,53.38049480494804
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.35,58.66368663686637
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.4,63.20935609356094
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.45,67.87124371243712
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.5,72
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.55,76.15598105981059
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.6,80.86187861878618
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.65,85.2969754697547
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.7,90.45178751787518
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.75,96.40416154161544
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.8,104
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.85,113.54616346163458
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.9,127.3988879888799
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.95,153.65760957609587
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.975,182.71739942399418
+2025-12-20,1,wk inc covid hosp,2025-12-27,55,quantile,0.99,202.0301516015159
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.1,3.7034590345903506
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.15,7.410111601116009
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.2,10
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.25,12
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.3,14
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.35,15.959071590715906
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.4,17
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.45,19
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.5,20
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.55,21.27007920079201
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.6,23
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.65,24.220209702097023
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.7,26
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.75,28
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.8,30
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.85,32.920709207092074
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.9,37.38023080230803
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.95,46.88704137041365
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.975,59.71666341663408
+2025-12-20,1,wk inc covid hosp,2025-12-27,56,quantile,0.99,70.59084800848
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.01,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.025,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.05,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.1,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.15,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.2,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.25,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.3,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.35,0
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.4,3.526189261892611
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.45,7.193920939209388
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.5,11
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.55,15.417800678006788
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.6,20
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.65,25
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.7,30.810136101360992
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.75,36.15245402454025
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.8,42.409388093880956
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.85,49.98082930829305
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.9,60.89336093360934
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.95,78.28855888558876
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.975,97.69134941349411
+2025-12-20,1,wk inc covid hosp,2025-12-27,72,quantile,0.99,133.51155011550125
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.01,96.31793267932736
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.025,957.3820593205938
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.05,1742.704739547396
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.1,2446.9418514185154
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.15,2792.380819308193
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.2,3045.065649656498
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.25,3274.726094760948
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.3,3460.230426304264
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.35,3644.249179491796
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.4,3800.151426514266
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.45,3960.258172081722
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.5,4109
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.55,4248.521521715218
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.6,4415.9319283192835
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.65,4572.302183521836
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.7,4761.857420574204
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.75,4948.949426994271
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.8,5177.0737177371775
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.85,5432.962014120142
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.9,5794.380635806356
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.95,6494.85266702667
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.975,7261.631071310712
+2025-12-20,1,wk inc covid hosp,2025-12-27,US,quantile,0.99,8090.891188011877
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.15,10.073617236172362
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.2,18.328042280422814
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.25,25.33475584755848
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.3,31.45606156061561
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.35,37.245710957109544
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.4,42.7167201672017
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.45,47.91424264242643
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.5,53
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.55,58.12455474554746
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.6,63.378578785787845
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.65,68.71351363513637
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.7,74.39525795257951
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.75,80.660034100341
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.8,87.72771627716278
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.85,96.1021855218552
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.9,106.91618516185163
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.95,122.54300293002922
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.975,136.63516135161345
+2025-12-20,2,wk inc covid hosp,2026-01-03,01,quantile,0.99,152.98902169021656
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.2,1.0835288352883556
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.25,3
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.3,4
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.35,5.54289692896929
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.4,6.964975649756496
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.45,8
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.5,9
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.55,10
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.6,11.28492684926849
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.65,12.703340033400337
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.7,14
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.75,15.217597175971761
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.8,17
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.85,18.91576165761656
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.9,21
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.95,24.28923089230891
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.975,27.339132141321404
+2025-12-20,2,wk inc covid hosp,2026-01-03,02,quantile,0.99,30.755690656906562
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.2,14.221578215782152
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.25,27.339623396233947
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.3,38.36353763537634
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.35,47.33962339623395
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.4,55.33962339623395
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.45,62.82090770907709
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.5,70
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.55,77.18998389983898
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.6,84.5921479214792
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.65,93.05950309503086
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.7,102.76388063880634
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.75,114.33962339623395
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.8,129.95368553685537
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.85,151.0764912649126
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.9,177.3168001680017
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.95,217.77428724287245
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.975,258.87931954319555
+2025-12-20,2,wk inc covid hosp,2026-01-03,04,quantile,0.99,303.5328258282577
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.15,2.718179681796816
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.2,7.498206982069825
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.25,11.706522065220653
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.3,15.09435994359944
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.35,18.401641516415165
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.4,21.286068860688605
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.45,24.13212832128322
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.5,27
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.55,30
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.6,32.985669856698564
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.65,36
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.7,39.13583335833359
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.75,42.915151651516524
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.8,47
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.85,52
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.9,59
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.95,69.68447084470843
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.975,78.9837768377684
+2025-12-20,2,wk inc covid hosp,2026-01-03,05,quantile,0.99,89.54525335253344
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.1,53.9422494224942
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.15,97.1642321423214
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.2,130.7562565625656
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.25,160.3234682346823
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.3,184.62780327803273
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.35,207.08211232112313
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.4,230.00779107791072
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.45,251.13048430484304
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.5,271
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.55,291.0581895818958
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.6,312.8433694336943
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.65,335.30549655496554
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.7,357.49726697266965
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.75,381.8073005730057
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.8,410.7822768227682
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.85,444.28627936279355
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.9,487.15972259722605
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.95,555.8632021320213
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.975,617.2455207052069
+2025-12-20,2,wk inc covid hosp,2026-01-03,06,quantile,0.99,683.9675653756536
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.05,2.2669316693166923
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.1,20.520047200472003
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.15,31
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.2,38.221238212382126
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.25,44
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.3,48.988115881158805
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.35,53.216308163081635
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.4,57.36051160511606
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.45,61.211921619216184
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.5,65
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.55,68.8709552095521
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.6,72.63665836658367
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.65,76.87714027140274
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.7,81.08060080600805
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.75,86.03539785397854
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.8,91.74913949139491
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.85,99.04761547615468
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.9,109.63533935339358
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.95,128.62024920249195
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.975,144.86930844308418
+2025-12-20,2,wk inc covid hosp,2026-01-03,08,quantile,0.99,162.70410314103134
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.025,5.443281932819336
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.05,21.532840328403278
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.1,39.605357053570536
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.15,50.656276062760625
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.2,58.706825068250694
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.25,65.41316663166633
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.3,71.1889818898189
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.35,76.50526905269054
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.4,81.13927339273395
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.45,85.611652116521185
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.5,90
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.55,94.3758212582126
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.6,99
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.65,103.65550305503055
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.7,108.8974089740897
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.75,114.75835758357584
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.8,121.29331493314929
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.85,129.35268852688526
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.9,140.31000510005103
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.95,157.85737707377066
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.975,174.53673736737375
+2025-12-20,2,wk inc covid hosp,2026-01-03,09,quantile,0.99,192.87574635746353
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.05,2.6189611896118956
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.1,8.934901349013499
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.15,13.562854128541282
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.2,17
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.25,20
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.3,22.082517825178243
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.35,24
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.4,26
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.45,27.421154711547118
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.5,29
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.55,30.42683026830268
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.6,32
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.65,33.95360853608537
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.7,35.77318973189732
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.75,38
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.8,40.94496544965449
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.85,44.44853698536986
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.9,49.15162951629516
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.95,55.65070300703006
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.975,61.16720692206923
+2025-12-20,2,wk inc covid hosp,2026-01-03,10,quantile,0.99,68.69139181391805
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.2,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.25,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.3,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.35,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.4,0.6293362933629416
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.45,1.9180256802568056
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.5,3
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.55,4
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.6,5
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.65,6.070143201432024
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.7,7.867493674936747
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.75,9
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.8,11
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.85,13
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.9,15.706481064810674
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.95,19.482835328353236
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.975,23
+2025-12-20,2,wk inc covid hosp,2026-01-03,11,quantile,0.99,27.318827088270755
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.2,2.47720877208775
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.25,26.209694596946036
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.3,47.643726437264405
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.35,66.81521215212155
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.4,84.82597025970263
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.45,102.64452444524449
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.5,120
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.55,136.88531435314357
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.6,154.9562515625156
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.65,173.2055990559906
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.7,193.1335843358433
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.75,214.6039685396854
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.8,239.02449824498245
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.85,269.0583175831759
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.9,307.1920509205093
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.95,366.6482634826349
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.975,418.8645838958386
+2025-12-20,2,wk inc covid hosp,2026-01-03,12,quantile,0.99,478.9012071120714
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.2,7.625738257382578
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.25,17.87993629936298
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.3,26.92584325843257
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.35,35.4321513215132
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.4,43.419914199141985
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.45,50.768002180021796
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.5,58
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.55,65.23527085270852
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.6,72.62669626696265
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.65,80.60280352803528
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.7,89.12541325413247
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.75,98.64074640746406
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.8,108.78222182221826
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.85,120.61369063690631
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.9,134.67995379953797
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.95,157.12738427384258
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.975,176.81339188391883
+2025-12-20,2,wk inc covid hosp,2026-01-03,13,quantile,0.99,197.53331083310798
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.2,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.25,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.3,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.35,1.0962159621596186
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.4,2.644053440534417
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.45,4.096215962159619
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.5,6
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.55,7.254016040160393
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.6,9.096215962159619
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.65,11.096215962159619
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.7,13.096215962159619
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.75,15.10130851308513
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.8,18.084943849438496
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.85,21.09621596215962
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.9,25.09621596215962
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.95,31.09621596215962
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.975,36.414168141681394
+2025-12-20,2,wk inc covid hosp,2026-01-03,15,quantile,0.99,42.78619456194552
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.2,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.25,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.3,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.35,0.7010275102750925
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.4,2.409618096180965
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.45,4.045528955289555
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.5,6
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.55,7.9325658256582585
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.6,9.65862458624586
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.65,11.385315853158527
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.7,13.39596795967959
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.75,15.660169101691018
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.8,18
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.85,20.789426394263934
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.9,24
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.95,29.06490364903649
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.975,33.438564885648844
+2025-12-20,2,wk inc covid hosp,2026-01-03,16,quantile,0.99,38.160259402594015
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.1,55.26829668296685
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.15,88.98079330793307
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.2,112.12778927789276
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.25,130.54492044920448
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.3,146.0637966379664
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.35,160.16785267852674
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.4,172.6721487214872
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.45,184.30716757167568
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.5,196
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.55,207.5157916579165
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.6,219.3429494294943
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.65,231.80711057110568
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.7,245.51268512685124
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.75,261.54384043840435
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.8,280.2231002310024
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.85,303.99420694206935
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.9,339.4155331553316
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.95,429.0639256392559
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.975,505.94466944669387
+2025-12-20,2,wk inc covid hosp,2026-01-03,17,quantile,0.99,562.5310415104136
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.01,4.263362433624319
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.025,38.953273282732845
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.05,67.0667496674967
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.1,102.68141881418818
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.15,129.79323793237933
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.2,149.0736917369174
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.25,163.41340413404134
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.3,173.84336343363435
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.35,182.91368263682637
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.4,191.3211002110021
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.45,198.8997564975649
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.5,206
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.55,213.0630441304413
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.6,220.94917049170493
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.65,229.37451024510244
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.7,238.16005660056598
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.75,248.62198621986218
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.8,262.8345213452135
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.85,282.3442699426995
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.9,309.8875528755289
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.95,345.28760137601387
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.975,371.88174556745565
+2025-12-20,2,wk inc covid hosp,2026-01-03,18,quantile,0.99,407.3584398843988
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.1,9.542916429164302
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.15,16
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.2,21
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.25,25.03741537415374
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.3,28.872290722907223
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.35,32.02440274402743
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.4,35.14052540525406
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.45,38
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.5,41
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.55,44
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.6,47
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.65,50
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.7,53.21853618536184
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.75,56.94450694506947
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.8,60.9657856578566
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.85,65.97610476104764
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.9,72.39685196851971
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.95,82.54765547655474
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.975,91.45775232752322
+2025-12-20,2,wk inc covid hosp,2026-01-03,19,quantile,0.99,102.19382113821146
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.1,5.44354143541436
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.15,13.996632466324659
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.2,20.35756557565576
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.25,25.62628626286264
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.3,30
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.35,33.92748777487775
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.4,37.315703157031564
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.45,40.75466404664047
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.5,44
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.55,47.17836278362785
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.6,50.64746647466467
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.65,54.07876778767789
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.7,58
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.75,62.51535765357653
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.8,67.93835338353384
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.85,74.58770687706877
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.9,83.60671206712071
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.95,98.45682306823063
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.975,112.11039510395094
+2025-12-20,2,wk inc covid hosp,2026-01-03,20,quantile,0.99,126.79901539015381
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.15,0.727807278072774
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.2,10.112749127491272
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.25,17.90529905299052
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.3,24.727807278072774
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.35,30.727807278072774
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.4,36.50866508665087
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.45,41.82534625346253
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.5,47
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.55,52.33341833418335
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.6,57.765749657496556
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.65,63.727807278072774
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.7,69.89450194501944
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.75,76.72780727807277
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.8,84.95182151821523
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.85,95.14562895628956
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.9,110.72780727807277
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.95,144.7165911659119
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.975,181.1931711817116
+2025-12-20,2,wk inc covid hosp,2026-01-03,21,quantile,0.99,214.61289902899023
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.2,4.820556205562058
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.25,11.155194051940526
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.3,16.870508705087055
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.35,22.374287242872427
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.4,27.36950169501697
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.45,32.15679106791069
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.5,37
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.55,41.878600786007866
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.6,46.870508705087055
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.65,51.91740767407676
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.7,57.46602366023659
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.75,63.39473144731448
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.8,69.74770547705478
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.85,77.37488474884749
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.9,86.83009230092304
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.95,101.01859268592676
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.975,113.60848333483331
+2025-12-20,2,wk inc covid hosp,2026-01-03,22,quantile,0.99,127.77649906499052
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.15,1.1739492394923927
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.2,4
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.25,6.030080300803009
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.3,8.027309273092728
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.35,10
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.4,11.928643286432877
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.45,13.296019460194605
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.5,15
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.55,16.85267752677528
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.6,18.2751727517275
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.65,20
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.7,22
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.75,24
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.8,26.352653526535263
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.85,29.116197661976614
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.9,33.07493074930751
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.95,40.63166581665811
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.975,49.02750302503024
+2025-12-20,2,wk inc covid hosp,2026-01-03,23,quantile,0.99,57.40361383613833
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.15,6.157186071860709
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.2,13.033480334803343
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.25,19.04363043630436
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.3,24.423603236032363
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.35,29.268806688066867
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.4,34.002234022340225
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.45,38.45930159301594
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.5,43
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.55,47.61917619176191
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.6,52.04107441074411
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.65,56.97079720797208
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.7,61.97248872488724
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.75,67.50965759657595
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.8,73.71340913409134
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.85,81.08633636336361
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.9,91.16865468654687
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.95,110.44767297672959
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.975,150.06898793987895
+2025-12-20,2,wk inc covid hosp,2026-01-03,24,quantile,0.99,193.8042939429389
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.05,22.040045400454005
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.1,61.12775227752279
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.15,82.56723767237673
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.2,96.96531265312655
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.25,108.57522325223253
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.3,118.14196841968419
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.35,126.97162371623713
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.4,135.10507805078052
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.45,143.2618311183112
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.5,151
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.55,158.73582385823858
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.6,166.75889458894588
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.65,175.040045400454
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.7,183.99844098440985
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.75,193.6849443494435
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.8,205.21568715687172
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.85,220.06951569515695
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.9,241.75805158051585
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.95,284.1690621906218
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.975,329.2665106651068
+2025-12-20,2,wk inc covid hosp,2026-01-03,25,quantile,0.99,373.1446409464095
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.15,5.1862443624436985
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.2,36.06215862158632
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.25,63.43219932199332
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.3,87.58117181171815
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.35,109.38946989469903
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.4,128.5631236312364
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.45,146.18121031210313
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.5,162
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.55,178.05786457864593
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.6,195.4976609766099
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.65,215.02416324163255
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.7,237.27563575635753
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.75,262.0411254112541
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.8,290.16130161301624
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.85,323.75017800178
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.9,367.089808898089
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.95,424.3153571535716
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.975,478.801238262382
+2025-12-20,2,wk inc covid hosp,2026-01-03,26,quantile,0.99,547.5034354343543
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.1,24.178774787747898
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.15,39.56308363083632
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.2,50.38926389263895
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.25,58.77424274242745
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.3,65.89306993069931
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.35,72.10612906129062
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.4,77.8818428184282
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.45,83.45355453554535
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.5,89
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.55,94.34098940989414
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.6,99.94444344443446
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.65,105.89645446454466
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.7,112.51481814818152
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.75,119.72061220612208
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.8,128.19347593475945
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.85,138.78654236542366
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.9,154.789455894559
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.95,189.81617116171162
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.975,224.20890158901543
+2025-12-20,2,wk inc covid hosp,2026-01-03,27,quantile,0.99,253.67941869418684
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.05,4.366822668226684
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.1,16.946209462094625
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.15,24.819302193021926
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.2,30.61470814708148
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.25,35.36237362373623
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.3,39.66302763027629
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.35,43.42716927169269
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.4,47
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.45,50.54423294232943
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.5,54
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.55,57.38622036220362
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.6,61
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.65,64.52120621206213
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.7,68.32186821868217
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.75,72.66890668906689
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.8,77.4552385523856
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.85,83.31476464764648
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.9,91.31447214472153
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.95,104.38916689166889
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.975,116.64976749767497
+2025-12-20,2,wk inc covid hosp,2026-01-03,28,quantile,0.99,131.36712857128572
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.1,8.022810228102284
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.15,26.749930999309978
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.2,39.68340183401833
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.25,48.96389213892138
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.3,56.23417634176341
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.35,62.481207312073074
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.4,67.93604836048358
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.45,73.11517515175152
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.5,78
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.55,82.99824498244982
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.6,88.19449494494943
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.65,93.75252452524526
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.7,99.99824498244982
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.75,107.29087540875406
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.8,116.72228622286225
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.85,130.07286872868727
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.9,150.9966669666697
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.95,179.15730107301061
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.975,200.69828173281726
+2025-12-20,2,wk inc covid hosp,2026-01-03,29,quantile,0.99,225.7617111171111
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.025,3.865058650586505
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.05,8.717760677606776
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.1,14
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.15,17.61306013060131
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.2,20.477616776167764
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.25,23
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.3,25
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.35,27
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.4,28.713855138551395
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.45,30.248268982689822
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.5,32
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.55,33.857942579425796
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.6,35.33348733487335
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.65,37
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.7,39
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.75,41
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.8,43.531439314393154
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.85,46.353662036620364
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.9,50
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.95,55.32865628656286
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.975,59.90913259132591
+2025-12-20,2,wk inc covid hosp,2026-01-03,30,quantile,0.99,65.3780476804768
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.1,3
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.15,7.979194291942919
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.2,11.465454654546548
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.25,14.674711747117472
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.3,17.410657106571065
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.35,20
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.4,22.324975249752498
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.45,24.813547635476354
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.5,27
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.55,29.1620136201362
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.6,31.7270832708327
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.65,34
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.7,36.78793787937879
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.75,39.55855808558084
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.8,42.80239802398024
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.85,46.38637236372364
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.9,51.0490274902749
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.95,58.428097780977765
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.975,65.11001385013846
+2025-12-20,2,wk inc covid hosp,2026-01-03,31,quantile,0.99,73.25526015260132
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.15,1.4601046010460104
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.2,5.0206482064820674
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.25,8.358121081210815
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.3,11.06620866208662
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.35,14
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.4,16.273516735167362
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.45,18.88351983519835
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.5,21
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.55,23.42811428114282
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.6,26
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.65,28.321896218962195
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.7,31
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.75,33.98122731227313
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.8,37
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.85,40.94631646316462
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.9,45.92806528065281
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.95,53.21166311663115
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.975,59.614731647316454
+2025-12-20,2,wk inc covid hosp,2026-01-03,32,quantile,0.99,67.01991739917392
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.1,1
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.15,6.274909249092489
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.2,10
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.25,13
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.3,15.597943979439792
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.35,18
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.4,20
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.45,22
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.5,24
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.55,26
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.6,28
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.65,30
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.7,32.48046280462803
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.75,35
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.8,38
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.85,42.155328053280535
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.9,48.396552965529665
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.95,61.88548485484854
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.975,75.32550575505753
+2025-12-20,2,wk inc covid hosp,2026-01-03,33,quantile,0.99,86.45114991149906
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.05,38.02867228672283
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.1,80.82116721167212
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.15,101.040160401604
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.2,114.17667976679765
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.25,124.89368643686436
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.3,134.23139631396313
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.35,142.42937879378792
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.4,150.1840178401784
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.45,157.62274772747725
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.5,165
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.55,172.25414304143038
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.6,179.79483594835946
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.65,187.72598475984756
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.7,195.99586395863957
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.75,205.12760127601274
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.8,215.97322973229734
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.85,229.35628056280558
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.9,249.24578345783456
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.95,293.89469594695896
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.975,341.1721654716547
+2025-12-20,2,wk inc covid hosp,2026-01-03,34,quantile,0.99,383.0333246332464
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.01,8.3428440284402825
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.025,17.192461174611754
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.05,24.897017970179718
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.1,33.53228532285323
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.15,39.40869658696586
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.2,44.046316463164636
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.25,48.00990509905098
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.3,51.62128421284212
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.35,54.96653866538666
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.4,58
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.45,61
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.5,64
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.55,67
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.6,70
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.65,73
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.7,76.32375423754237
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.75,80
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.8,83.99624996249963
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.85,88.52866128661287
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.9,94.59349293492936
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.95,103.32794477944779
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.975,110.74605771057708
+2025-12-20,2,wk inc covid hosp,2026-01-03,35,quantile,0.99,119.41161361613611
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.025,41.03715187151874
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.05,87.24585295852955
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.1,133.66964969649695
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.15,163.37223472234717
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.2,185.1031530315303
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.25,204.04442044420443
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.3,220.40558305583056
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.35,235.52972429724292
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.4,250.0137161371614
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.45,263.76511515115146
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.5,277
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.55,290.279719797198
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.6,303.49495494955016
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.65,317.770413704137
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.7,333.0441694416944
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.75,349.30389303893037
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.8,368.2829388293884
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.85,390.1779587795877
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.9,419.6159001590016
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.95,466.57140521405177
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.975,513.7365691156908
+2025-12-20,2,wk inc covid hosp,2026-01-03,36,quantile,0.99,578.5613429134281
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.15,9.147362473624758
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.2,25.4838098380984
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.25,39.49878998789989
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.3,51.896336963369635
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.35,63.24428144281445
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.4,73.72435424354245
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.45,83.59274242742433
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.5,93
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.55,102.85670356703568
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.6,112.63379933799337
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.65,123.14369893698944
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.7,134.4810618106181
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.75,147.0377903779038
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.8,161.3231522315223
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.85,178.27136571365713
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.9,199.50911609116096
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.95,230.97760977609772
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.975,259.52030170301697
+2025-12-20,2,wk inc covid hosp,2026-01-03,37,quantile,0.99,293.7665429654298
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.1,3.973283732837329
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.15,6.360896608966087
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.2,8.420938209382093
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.25,10
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.3,11.933417334173338
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.35,13
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.4,14.366063660636616
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.45,15.963774137741378
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.5,17
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.55,18
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.6,19.492646926469256
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.65,21
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.7,22.110402104021034
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.75,24
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.8,25.61865218652187
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.85,27.677677776777763
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.9,30.061071610716127
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.95,34
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.975,37.3590703407034
+2025-12-20,2,wk inc covid hosp,2026-01-03,38,quantile,0.99,41.3630696306963
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.05,69.7259712597127
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.1,160.239075390754
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.15,203.15638856388566
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.2,230.44635746357469
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.25,248.61181861818625
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.3,263.53305633056334
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.35,276.7209682096821
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.4,288.9035940359404
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.45,300.119975699757
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.5,311
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.55,321.75478304783053
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.6,333.0031770317704
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.65,344.95009500095006
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.7,357.8945709457095
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.75,372.6048460484607
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.8,391.0238972389724
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.85,417.00603756037583
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.9,461.9752587525876
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.95,558.8485404854047
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.975,719.4670779207785
+2025-12-20,2,wk inc covid hosp,2026-01-03,39,quantile,0.99,796.0883705837048
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.1,9.44928949289493
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.15,17.60376103761037
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.2,24
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.25,29.229519795197955
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.3,34
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.35,38
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.4,42
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.45,45.65218502185022
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.5,49
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.55,52.561471614716154
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.6,56.114785147851464
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.65,60
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.7,64.01071210712105
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.75,68.7558700587006
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.8,74
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.85,80.43897588975888
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.9,88.72824628246283
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.95,100.94867748677471
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.975,112.42875478754785
+2025-12-20,2,wk inc covid hosp,2026-01-03,40,quantile,0.99,125.88674976749736
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.2,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.25,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.3,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.35,1.2749527495274897
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.4,4.72278922789228
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.45,7.889917899178984
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.5,11
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.55,14.223451234512346
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.6,17.27495274952749
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.65,20.856937069370698
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.7,24.506090060900576
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.75,28.54390793907939
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.8,33.274952749527486
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.85,38.46263462634622
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.9,45.32293922939229
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.95,55.62743727437265
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.975,64.9389468894689
+2025-12-20,2,wk inc covid hosp,2026-01-03,41,quantile,0.99,75.99707607076067
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.05,7.772053720537214
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.1,140.34601946019453
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.15,211.6831478314783
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.2,255.19925799257996
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.25,291.9839623396234
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.3,321.0636406364064
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.35,346.1802188021878
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.4,369.7758837588376
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.45,392.13620986209867
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.5,412
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.55,432.2278097780978
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.6,455.01580215802164
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.65,478.9705007050071
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.7,503.920275202752
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.75,532.6696016960166
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.8,568.7591955919561
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.85,613.5534475344754
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.9,686.3851088510886
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.95,831.8603636036357
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.975,947.5279197791976
+2025-12-20,2,wk inc covid hosp,2026-01-03,42,quantile,0.99,1050.1798814988142
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.05,2.797792977929779
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.1,8.212931129311295
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.15,12
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.2,15
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.25,17.804135541355404
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.3,20
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.35,22
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.4,24
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.45,26
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.5,28
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.55,30
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.6,32
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.65,34
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.7,36
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.75,38.206379563795636
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.8,41
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.85,44
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.9,47.87753677536775
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.95,53.482947329473305
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.975,58.46095910959124
+2025-12-20,2,wk inc covid hosp,2026-01-03,44,quantile,0.99,64.3970289702897
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.2,1.5612376123761285
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.25,9.300463004630046
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.3,16.28302283022829
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.35,22.581798817988165
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.4,28.655574555745567
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.45,34.422580225802264
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.5,40
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.55,45.61985469854698
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.6,51.300463004630046
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.65,57.300463004630046
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.7,63.798547985479814
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.75,70.9370468704687
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.8,79.04506245062453
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.85,88.50386503865037
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.9,100.03933939339396
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.95,117.15474804748044
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.975,132.62383123831236
+2025-12-20,2,wk inc covid hosp,2026-01-03,45,quantile,0.99,150.07361823618228
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.2,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.25,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.3,0.09110591105910615
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.35,2.091105911059106
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.4,4.091105911059106
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.45,6.091105911059106
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.5,8
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.55,9.769378193781938
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.6,11.69113791137911
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.65,13.74117241172412
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.7,16.091105911059106
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.75,18.27798027980279
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.8,21.091105911059106
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.85,24.091105911059106
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.9,28.091105911059106
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.95,34.27795227952278
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.975,39.66751092510923
+2025-12-20,2,wk inc covid hosp,2026-01-03,46,quantile,0.99,45.8640290402904
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.025,8.956695066950683
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.05,30.917980179801813
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.1,53.174917749177496
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.15,67.43063380633807
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.2,77.95722857228573
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.25,86.829953299533
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.3,94.60814508145081
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.35,101.75075950759506
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.4,108.24552345523458
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.45,114.8237662376624
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.5,121
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.55,127.36829068290683
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.6,133.69614796147962
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.65,140.16858918589188
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.7,147.0873348733487
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.75,154.9369018690187
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.8,163.90298402984035
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.85,174.4085005850058
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.9,188.31156611566115
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.95,210.1412949129492
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.975,232.0412811628116
+2025-12-20,2,wk inc covid hosp,2026-01-03,47,quantile,0.99,258.08953269532674
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.15,31.703701037010344
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.2,61.3373593735937
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.25,85.63999889998898
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.3,108.55362053620536
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.35,130.1782092820928
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.4,150.08556485564858
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.45,168.16560265602652
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.5,186
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.55,204.61463464634647
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.6,223.02421824218231
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.65,241.65996459964597
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.7,263.329952299523
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.75,286.84541845418454
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.8,311.0930429304293
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.85,341.52608226082253
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.9,379.8662026620267
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.95,438.74208692086836
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.975,488.4991647416474
+2025-12-20,2,wk inc covid hosp,2026-01-03,48,quantile,0.99,550.7448415484151
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.2,0.9264492644926463
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.25,3.9264492644926463
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.3,6.926449264492646
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.35,9.269513695136947
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.4,11.860066600666013
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.45,13.926449264492646
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.5,16
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.55,18.363004130041304
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.6,20.747633476334755
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.65,22.926449264492646
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.7,25.830715307153056
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.75,28.773195231952315
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.8,31.98140381403815
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.85,35.992552425524245
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.9,41.33723037230375
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.95,49.67077670776701
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.975,57.44883948839487
+2025-12-20,2,wk inc covid hosp,2026-01-03,49,quantile,0.99,66.42163061630617
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.2,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.25,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.3,1.4727117271172685
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.35,3
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.4,4
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.45,5
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.5,6
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.55,7.279302793027934
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.6,8.727057270572715
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.65,10
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.7,11
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.75,12.546945469454691
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.8,14
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.85,16
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.9,18.10218902189022
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.95,21.893063430634275
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.975,25
+2025-12-20,2,wk inc covid hosp,2026-01-03,50,quantile,0.99,28.627590875908695
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.2,9.357765577655812
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.25,19.21215962159624
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.3,27.491054910549124
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.35,35.37250572505727
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.4,42.86998869988701
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.45,49.939756397564004
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.5,57
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.55,63.98647486474867
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.6,71.21633216332165
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.65,78.75351603516039
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.7,86.50649006490065
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.75,95.39017140171403
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.8,105.55910359103592
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.85,118.2607196071962
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.9,136.00595705957062
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.95,166.8358903589036
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.975,197.95052550525477
+2025-12-20,2,wk inc covid hosp,2026-01-03,51,quantile,0.99,230.9146182461824
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.2,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.25,1.2610551105511112
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.3,6.514084140841411
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.35,11.34006240062399
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.4,16.051576515765163
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.45,20.469898198981994
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.5,25
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.55,29.414405644056437
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.6,34.07862678626783
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.65,38.69117091170913
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.7,43.711567115671144
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.75,49.12830128301283
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.8,55.09748097480975
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.85,61.733516335163344
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.9,70.64896748967493
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.95,83.40045950459502
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.975,94.52633501335012
+2025-12-20,2,wk inc covid hosp,2026-01-03,53,quantile,0.99,107.871323913239
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.1,0.7562265622656399
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.15,11.627537275372749
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.2,19.356577565775662
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.25,25.29572045720457
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.3,30.4009160091601
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.35,35
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.4,39
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.45,42.72797977979781
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.5,46
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.55,49.712688126881275
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.6,53.21078210782109
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.65,57.29381593815937
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.7,61.83164431644313
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.75,67
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.8,73.18089780897814
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.85,81.43293682936827
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.9,93.61410614106143
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.95,110.53158131581311
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.975,124.19539445394446
+2025-12-20,2,wk inc covid hosp,2026-01-03,54,quantile,0.99,140.14552205522034
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.1,3.551969519695195
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.15,19.068462684626862
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.2,30.23000030000299
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.25,39.35524605246052
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.3,47.0211572115721
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.35,53.9210492104921
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.4,60.3590275902759
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.45,66.24138591385913
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.5,72
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.55,77.85851158511585
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.6,83.86802468024678
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.65,90.01164911649117
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.7,96.91240012400124
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.75,104.79759047590477
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.8,114.18277782777832
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.85,126.31133161331611
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.9,143.3236112361127
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.95,172.8622536225364
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.975,197.29759697596975
+2025-12-20,2,wk inc covid hosp,2026-01-03,55,quantile,0.99,222.7828696286963
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.15,3.4489914899148975
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.2,7
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.25,9.97926729267293
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.3,12.03810638106381
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.35,14.284581845818444
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.4,16.219674196741977
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.45,18
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.5,20
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.55,22
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.6,24
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.65,26
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.7,28
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.75,30.502947529475293
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.8,33.47105671056712
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.85,37.29520195201952
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.9,43.176362763627665
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.95,54.841982919829185
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.975,66.23630911309094
+2025-12-20,2,wk inc covid hosp,2026-01-03,56,quantile,0.99,76.67323833238338
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.025,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.05,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.1,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.15,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.2,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.25,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.3,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.35,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.4,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.45,5.431129311293102
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.5,11
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.55,16.641295912959123
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.6,22.431129311293102
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.65,28.43268482684826
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.7,34.94504045040449
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.75,42.08883338833387
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.8,50.441535415354124
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.85,60.17527675276751
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.9,73.69193991939916
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.95,96.17461974619744
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.975,119.91088960889597
+2025-12-20,2,wk inc covid hosp,2026-01-03,72,quantile,0.99,156.00319003190137
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.01,0
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.025,380.45410854108536
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.05,1158.213367633676
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.1,1948.7017000170003
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.15,2420.7854478544787
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.2,2759.1573275732762
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.25,3049.2368123681235
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.3,3291.5919789197887
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.35,3511.818952189522
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.4,3720.915981159812
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.45,3915.3358548585484
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.5,4109
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.55,4307.314357643577
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.6,4502.982975829759
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.65,4713.053061030612
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.7,4938.461441614415
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.75,5180.8375933759335
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.8,5468.6338883388835
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.85,5802.757064570647
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.9,6276.431420314203
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.95,7081.624658246579
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.975,7835.01795417953
+2025-12-20,2,wk inc covid hosp,2026-01-03,US,quantile,0.99,8696.590320503185
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.15,3.421159211592099
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.2,12.996165961659612
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.25,20.930861808618083
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.3,28.097698976989758
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.35,34.81687766877668
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.4,41.01867218672186
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.45,47.0670671706717
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.5,53
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.55,58.952659526595255
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.6,64.97349373493732
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.65,71.38881638816389
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.7,78.02993829938299
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.75,85.3752337523375
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.8,93.44361043610436
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.85,103.03191081910815
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.9,115.36884468844691
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.95,133.70262502625013
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.975,148.88834463344637
+2025-12-20,3,wk inc covid hosp,2026-01-10,01,quantile,0.99,167.4856118561185
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.25,2
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.3,3.4381843818438176
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.35,5
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.4,6.276614766147661
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.45,7.8883243832438295
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.5,9
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.55,10.357094570945716
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.6,12
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.65,13
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.7,14.865286652866518
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.75,16.2769977699777
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.8,18
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.85,20.207927579275793
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.9,23
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.95,26.8090485904859
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.975,30
+2025-12-20,3,wk inc covid hosp,2026-01-10,02,quantile,0.99,34
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.2,0.6223322233222377
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.25,16.4480294802948
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.3,29.79408894088937
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.35,40.955257052570516
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.4,51.27335073350736
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.45,60.97411274112741
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.5,70
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.55,79.2958584585846
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.6,89.07412074120738
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.65,99.77073170731708
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.7,111.94400944009428
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.75,126.22496474964751
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.8,143.78937989379904
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.85,166.16489764897642
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.9,194.41706217062188
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.95,240.27994579945823
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.975,282.10461779617725
+2025-12-20,3,wk inc covid hosp,2026-01-10,04,quantile,0.99,331.5723410234105
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.2,3.8870738707387034
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.25,8.758452584525841
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.3,12.887073870738703
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.35,16.777506775067742
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.4,20.317754177541772
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.45,23.799322493224942
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.5,27
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.55,30.42630026300263
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.6,33.8870738707387
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.65,37.55607656076561
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.7,41.4550415504155
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.75,45.79740297402974
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.8,50.59232892328925
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.85,56.34405194051941
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.9,63.976054760547655
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.95,75.74417444174438
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.975,86.09415369153687
+2025-12-20,3,wk inc covid hosp,2026-01-10,05,quantile,0.99,98.23169651696507
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.1,19.04999049990498
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.15,68.90605756057552
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.2,107.20680206802078
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.25,139.90523405234046
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.3,170.18786187861906
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.35,196.41493114931143
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.4,221.8543545435454
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.45,246.8082355823558
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.5,271
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.55,294.43719087190857
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.6,318.6881748817488
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.65,344.0265422654227
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.7,370.54410944109446
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.75,400.1035410354102
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.8,433.0644266442665
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.85,471.8080250802508
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.9,522.4708897088971
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.95,598.0106651066507
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.975,663.6996832468321
+2025-12-20,3,wk inc covid hosp,2026-01-10,06,quantile,0.99,745.2617606176058
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.1,12.216190161901618
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.15,24.00723057230572
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.2,32.82434824348246
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.25,39.7409874098741
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.3,45.67130671306713
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.35,51
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.4,55.83064830648307
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.45,60.43161631616316
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.5,65
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.55,69.55733257332574
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.6,74.21768017680175
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.65,79.12144921449215
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.7,84.42197321973217
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.75,90.4019865198652
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.8,97.16574965749662
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.85,105.90659106591065
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.9,118.05991459914603
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.95,137.74192141921418
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.975,155.1369973699736
+2025-12-20,3,wk inc covid hosp,2026-01-10,08,quantile,0.99,176.59588525885255
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.05,11.23759037590375
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.1,30.893168931689317
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.15,43.466531665316644
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.2,52.89316893168932
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.25,60.71056210562105
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.3,67.31339613396133
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.35,73.5032285322853
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.4,79.21727617276174
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.45,84.79839148391486
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.5,90
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.55,95.27407724077241
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.6,100.76260562605626
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.65,106.33588485884859
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.7,112.45022150221499
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.75,119.05086800868008
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.8,126.91091710917114
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.85,136.26132711327114
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.9,148.81744117441173
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.95,168.37427324273216
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.975,185.69750422504205
+2025-12-20,3,wk inc covid hosp,2026-01-10,09,quantile,0.99,206.03881928819263
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.1,6
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.15,10.88019280192802
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.2,14.719241192411925
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.25,17.948566985669835
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.3,20.60528805288053
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.35,23
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.4,25
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.45,27
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.5,29
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.55,31
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.6,33
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.65,35
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.7,37.29243492434924
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.75,40
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.8,43.290486904869034
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.85,47.24294492944929
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.9,52.19466494664947
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.95,59.18717587175874
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.975,65.83157156571566
+2025-12-20,3,wk inc covid hosp,2026-01-10,10,quantile,0.99,74.17718017180168
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.25,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.3,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.35,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.4,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.45,1.5838578385783846
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.5,3
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.55,4.047894978949798
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.6,5.77554175541755
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.65,7
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.7,8.811830118301181
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.75,10.396958969589694
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.8,12.309219092190924
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.85,14.92580375803758
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.9,17.823690236902436
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.95,22.293988439884473
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.975,26.362745877458732
+2025-12-20,3,wk inc covid hosp,2026-01-10,11,quantile,0.99,31.156495364953635
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.25,9.368066180661822
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.3,34.24533145331455
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.35,56.9765097650977
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.4,78.51716017160179
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.45,99.40636306363064
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.5,120
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.55,139.98397183971844
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.6,160.25241152411525
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.65,181.66966219662203
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.7,205.04423744237445
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.75,230.52607276072763
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.8,259.6735417354176
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.85,294.0966019660199
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.9,337.59801598015986
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.95,403.9288962889626
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.975,462.6394153941536
+2025-12-20,3,wk inc covid hosp,2026-01-10,12,quantile,0.99,533.4112922129219
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.25,11.693949439494387
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.3,22.11265912659125
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.35,31.71348363483633
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.4,40.84485544855449
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.45,49.50827258272582
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.5,58
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.55,66.79192391923921
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.6,75.57650476504764
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.65,84.82028070280703
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.7,94.5380683806838
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.75,105.13008630086301
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.8,116.66191361913621
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.85,129.96083810838107
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.9,146.72101821018208
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.95,172.37469324693242
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.975,194.08710037100366
+2025-12-20,3,wk inc covid hosp,2026-01-10,13,quantile,0.99,218.5050466504663
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.25,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.3,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.35,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.4,2
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.45,4
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.5,6
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.55,8
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.6,10
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.65,12.027479274792755
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.7,14.488680886808854
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.75,17.017620176201763
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.8,20.050132501325017
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.85,23.602772527725275
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.9,28
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.95,34.71974469744694
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.975,40.9022902729027
+2025-12-20,3,wk inc covid hosp,2026-01-10,15,quantile,0.99,48.53242982429826
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.25,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.3,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.35,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.4,2
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.45,4
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.5,6
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.55,8
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.6,10.136065360653603
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.65,12.372027720277208
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.7,14.753821538215368
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.75,17
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.8,20
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.85,23
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.9,27.03010730107301
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.95,33
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.975,38
+2025-12-20,3,wk inc covid hosp,2026-01-10,16,quantile,0.99,43.71759697596964
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.1,23.437683376833814
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.15,66.13249082490822
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.2,94.39729497294971
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.25,116.5855358553585
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.3,135.47626476264762
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.35,152.2670136701367
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.4,167.55351853518536
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.45,181.78782087820875
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.5,196
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.55,210.25749607496076
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.6,225.02128321283206
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.65,240.36908919089194
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.7,257.2830558305583
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.75,275.9379418794188
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.8,298.54076440764425
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.85,328.4388738887388
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.9,375.48198681986844
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.95,465.48503135031297
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.975,535.165855658556
+2025-12-20,3,wk inc covid hosp,2026-01-10,17,quantile,0.99,602.2966070660704
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.025,17.16415039150398
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.05,49.74239342393423
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.1,86.79867198671985
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.15,114.04295542955441
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.2,135.67701577015768
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.25,152.06913069130692
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.3,165.62663726637263
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.35,177.03975089750898
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.4,187.09345193451935
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.45,196.74712147121463
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.5,206
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.55,215.03552735527353
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.6,224.73051030510302
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.65,235.06126861268615
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.7,246.10326103261042
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.75,259.98004730047296
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.8,276.21739917399185
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.85,296.87881728817285
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.9,323.81506715067144
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.95,360.941088910889
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.975,393.18653061530614
+2025-12-20,3,wk inc covid hosp,2026-01-10,18,quantile,0.99,438.1458165581652
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.1,4.33362833628337
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.15,11.683202832028325
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.2,17.309901099010993
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.25,22.20185951859519
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.3,26.49096190961909
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.35,30.461599115991156
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.4,34.02536025360254
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.45,37.672915729157296
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.5,41
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.55,44.50364353643536
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.6,47.91563915639156
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.65,51.54366593665938
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.7,55.365532655326554
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.75,59.59660846608466
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.8,64.3127571275713
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.85,69.91563915639156
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.9,77.3930209302093
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.95,88.58674286742868
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.975,98.85578030780302
+2025-12-20,3,wk inc covid hosp,2026-01-10,19,quantile,0.99,110.76341093410933
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.15,8.586086360863595
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.2,15.827782277822783
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.25,21.694886948869495
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.3,26.930933309333092
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.35,31.71392613926139
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.4,35.98685586855869
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.45,40.042916929169294
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.5,44
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.55,48
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.6,52
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.65,56.433140331403315
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.7,61.10008300083001
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.75,66.32908329083291
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.8,72.68986689866902
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.85,80.42821478214783
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.9,90.45050550505508
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.95,106.46496364963639
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.975,120.70493579935798
+2025-12-20,3,wk inc covid hosp,2026-01-10,20,quantile,0.99,137.73721987219875
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.2,2.2564305643056235
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.25,11.429781797817974
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.3,19.524012240122396
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.35,26.91776167761676
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.4,33.790149901499014
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.45,40.42499474994749
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.5,47
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.55,53.354036040360405
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.6,60.10691506915067
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.65,66.86226762267624
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.7,74.29849698496983
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.75,82.69100691006909
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.8,92.65805858058579
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.85,105.40129701297012
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.9,124.82281622816222
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.95,161.2652991529914
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.975,195.23523060230625
+2025-12-20,3,wk inc covid hosp,2026-01-10,21,quantile,0.99,228.7164752647526
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.25,7.014442644426445
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.3,13.695313953139536
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.35,19.81148661486615
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.4,25.752061520615214
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.45,31.43175081750817
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.5,37
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.55,42.70063400634007
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.6,48.582981829818294
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.65,54.498753487534906
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.7,60.78263482634827
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.75,67.45362703627038
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.8,74.82552625526256
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.85,83.6230177301773
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.9,94.63066330663307
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.95,110.99413894138935
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.975,124.76497164971633
+2025-12-20,3,wk inc covid hosp,2026-01-10,22,quantile,0.99,140.77409994099938
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.2,2
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.25,4.632293822938235
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.3,7
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.35,9
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.4,11
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.45,13
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.5,15
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.55,17
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.6,19
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.65,21
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.7,23.232468324683254
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.75,25.858008580085812
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.8,28.53793137931379
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.85,32
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.9,36.79777297772977
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.95,45.1522895228952
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.975,53.17298772987734
+2025-12-20,3,wk inc covid hosp,2026-01-10,23,quantile,0.99,61.92429704297046
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.2,7.4293812938129555
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.25,14.610266102661024
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.3,20.96768067680678
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.35,26.863142631426292
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.4,32.512726127261274
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.45,37.880013800138
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.5,43
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.55,48.22357623576235
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.6,53.525322253222534
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.65,59.11140561405631
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.7,65.06781067810677
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.75,71.65871408714088
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.8,79.12725227252275
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.85,88.08807938079376
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.9,100.99663496634969
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.95,126.6768212682125
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.975,166.80826633266304
+2025-12-20,3,wk inc covid hosp,2026-01-10,24,quantile,0.99,204.51858988589794
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.1,43.30447804478047
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.15,68.07808878088782
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.2,85.67516675166759
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.25,99.45436454364547
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.3,111.16903469034693
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.35,121.90862908629089
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.4,131.9367473674737
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.45,141.5537855378554
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.5,151
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.55,160.33224432244324
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.6,170.04858848588486
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.65,180.2627991279913
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.7,190.9922039220392
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.75,202.70980709807043
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.8,216.59596595965962
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.85,234.4855918559185
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.9,259.6805318053181
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.95,305.38584085840876
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.975,349.0631263812639
+2025-12-20,3,wk inc covid hosp,2026-01-10,25,quantile,0.99,394.2275552755527
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.2,14.074022740227461
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.25,44.32425824258247
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.3,71.49055690556908
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.35,96.28608486084869
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.4,119.10868508685098
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.45,141.65494004940058
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.5,162
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.55,182.72271422714238
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.6,204.76075960759624
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.65,227.98796937969382
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.7,253.05887758877589
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.75,280.6469039690397
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.8,312.158803588036
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.85,350.0865863658636
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.9,396.67840978409805
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.95,467.50311353113517
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.975,530.5725427254272
+2025-12-20,3,wk inc covid hosp,2026-01-10,26,quantile,0.99,604.519923399233
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.1,10.946207462074618
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.15,29.377612276122754
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.2,42.34532545325453
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.25,52.18148931489314
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.3,60.87003770037701
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.35,68.54704397043967
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.4,75.660150601506
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.45,82.49841848418484
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.5,89
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.55,95.62740977409777
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.6,102.56652166521664
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.65,109.95441054410546
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.7,117.72603026030258
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.75,126.389718897189
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.8,136.56414564145643
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.85,149.74196041960425
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.9,169.59173991739922
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.95,206.96069510695133
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.975,239.60074800747995
+2025-12-20,3,wk inc covid hosp,2026-01-10,27,quantile,0.99,271.967700377004
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.1,11.131193311933117
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.15,20.057863078630763
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.2,26.78448684486845
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.25,32.25891258912589
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.3,37.23486734867348
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.35,41.648096480964796
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.4,45.91977619776197
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.45,50.01946369463694
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.5,54
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.55,58.06378763787639
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.6,62.23486734867348
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.65,66.52675576755769
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.7,71.22741327413273
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.75,76.15913159131591
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.8,81.91418614186142
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.85,88.99438494384943
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.9,98.26691166911665
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.95,112.66868718687184
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.975,125.44989549895477
+2025-12-20,3,wk inc covid hosp,2026-01-10,28,quantile,0.99,141.72405414054137
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.15,15.999099990999909
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.2,30.304383043830445
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.25,41.194364443644446
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.3,50.625445254452536
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.35,58.320768707687066
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.4,65.1191151911519
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.45,71.76847818478186
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.5,78
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.55,84.14716197161971
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.6,90.75643556435563
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.65,97.85926309263093
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.7,105.77755377553774
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.75,114.97016470164702
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.8,126.64707047070482
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.85,142.0144531445315
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.9,162.76935669356695
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.95,191.79111391113892
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.975,215.69225742257441
+2025-12-20,3,wk inc covid hosp,2026-01-10,29,quantile,0.99,248.7250497504976
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.05,4.9829973299732995
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.1,11.18526485264852
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.15,15.300956509565095
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.2,18.572177721777223
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.25,21.227114771147708
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.3,23.756316563165626
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.35,26
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.4,28
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.45,30
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.5,32
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.55,34
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.6,36
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.65,38
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.7,40.250347503475034
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.75,42.7719802198022
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.8,45.47020670206704
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.85,48.72203672036722
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.9,52.76254062540626
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.95,58.92204972049718
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.975,64.15582230822304
+2025-12-20,3,wk inc covid hosp,2026-01-10,30,quantile,0.99,70.53840178401782
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.15,4.701776517765177
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.2,9
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.25,12.729772297722977
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.3,15.958945589455897
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.35,18.795244452444525
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.4,21.593683936839362
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.45,24.198432484324847
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.5,27
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.55,29.80119101191012
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.6,32.45796057960579
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.65,35.25577455774558
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.7,38.241514415144145
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.75,41.58978089780897
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.8,45.105875058750584
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.85,49.54525195251951
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.9,55
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.95,63.23963789637897
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.975,71.11921419214188
+2025-12-20,3,wk inc covid hosp,2026-01-10,31,quantile,0.99,80.4478163781636
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.2,2.5456464564645627
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.25,6.166804168041671
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.3,9.532046320463197
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.35,12.63538435384352
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.4,15.508164081640823
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.45,18.250281002810034
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.5,21
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.55,23.909884098840983
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.6,26.694723947239474
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.65,29.48281582815828
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.7,32.582380823808236
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.75,35.90397903979039
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.8,39.60044500445003
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.85,43.93550535505354
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.9,49.75149551495518
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.95,58.15971759717587
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.975,65.48053730537303
+2025-12-20,3,wk inc covid hosp,2026-01-10,32,quantile,0.99,73.55862918629177
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.15,2.646295962959625
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.2,7.155327553275533
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.25,10.819608196081962
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.3,13.94320743207432
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.35,16.646924469244688
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.4,19.0909669096691
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.45,21.729225792257928
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.5,24
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.55,26.482283322833233
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.6,29
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.65,31.498691986919866
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.7,34.232995329953255
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.75,37.497222472224735
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.8,41.2949309493095
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.85,46.282237322373234
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.9,53.794743947439486
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.95,68.41515415154164
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.975,80.52687801878012
+2025-12-20,3,wk inc covid hosp,2026-01-10,33,quantile,0.99,92.37282522825228
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.05,15.96349863498636
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.1,62.37880578805778
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.15,87.02102871028713
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.2,103.32383523835237
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.25,116.47076720767205
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.3,127.86208662086602
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.35,137.82630976309764
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.4,147.11678516785173
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.45,156.11574215742158
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.5,165
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.55,173.7621071210712
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.6,182.79494194941947
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.65,191.91718917189172
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.7,201.9982389823897
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.75,213.28937789377895
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.8,226.26501465014653
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.85,242.83198281982834
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.9,267.7584595845959
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.95,316.5846678466782
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.975,360.6946221962223
+2025-12-20,3,wk inc covid hosp,2026-01-10,34,quantile,0.99,402.18910569105634
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.025,10.082774827748278
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.05,18.880918809188092
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.1,28.86059960599607
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.15,35.631354813548135
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.2,40.972099720997214
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.25,45.51813268132682
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.3,49.61625716257162
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.35,53.454553045530446
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.4,57
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.45,60.56667316673167
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.5,64
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.55,67.52415724157241
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.6,71
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.65,74.67015570155702
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.7,78.42136321363213
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.75,82.45784457844576
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.8,87.08747487474876
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.85,92.41241212412125
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.9,99.18329783297834
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.95,109.01750267502675
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.975,117.65701082010817
+2025-12-20,3,wk inc covid hosp,2026-01-10,35,quantile,0.99,127.31261822618217
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.025,3.7693471934719027
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.05,57.20478854788545
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.1,110.31725317253172
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.15,143.97185471854718
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.2,169.62429424294237
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.25,191.00234002340022
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.3,210.54446444464438
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.35,228.55606256062558
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.4,245.15084350843503
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.45,261.3630826308263
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.5,277
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.55,292.5777737777378
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.6,308.3047690476904
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.65,324.9174301743017
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.7,342.8492884928848
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.75,361.99617246172465
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.8,383.7612116121162
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.85,410.5046925469252
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.9,444.8287362873629
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.95,498.18373833738343
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.975,551.684079840798
+2025-12-20,3,wk inc covid hosp,2026-01-10,36,quantile,0.99,618.0720869208674
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.2,14.908974089740909
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.25,30.893038930389324
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.3,44.91370513705137
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.35,57.822882228822294
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.4,70.03317333173331
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.45,81.60299702997034
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.5,93
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.55,104.63718887188875
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.6,116.49271192711927
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.65,128.76647916479175
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.7,142.3416674166742
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.75,156.55502305023052
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.8,172.61930519305199
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.85,192.10319703197032
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.9,216.16878368783694
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.95,252.14785797857985
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.975,284.2862736127362
+2025-12-20,3,wk inc covid hosp,2026-01-10,37,quantile,0.99,322.4884521845219
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.1,1.8389433894338953
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.15,4.792666426664266
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.2,7
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.25,9
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.3,11
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.35,12.508267582675817
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.4,14
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.45,15.560602106021062
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.5,17
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.55,18.479362793627935
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.6,20
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.65,21.527474774747752
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.7,23
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.75,25
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.8,27
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.85,29.160739607396074
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.9,32.0639726397264
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.95,36.62405824058239
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.975,40.507899328993275
+2025-12-20,3,wk inc covid hosp,2026-01-10,38,quantile,0.99,45.20080400804007
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.05,13.04752347523478
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.1,125.01997519975204
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.15,177.31147361473614
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.2,209.22633026330263
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.25,232.98054230542306
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.3,252.09764497644977
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.35,268.8148786487865
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.4,283.5673596735968
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.45,297.3681281812818
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.5,311
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.55,324.569747697477
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.6,338.7338933389334
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.65,353.1785267852679
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.7,369.69385493854935
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.75,389.12960379603794
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.8,412.1824198241981
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.85,445.2229087290873
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.9,497.9147501475017
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.95,628.7653396533957
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.975,751.3721464714637
+2025-12-20,3,wk inc covid hosp,2026-01-10,39,quantile,0.99,832.7723094230943
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.1,3.3512305123051225
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.15,12.669885198851992
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.2,19.7269172691727
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.25,25.753580035800372
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.3,31.023231232312327
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.35,36
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.4,40.49793097930979
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.45,44.84715697156972
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.5,49
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.55,53.33691836918369
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.6,57.72623726237263
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.65,62.18873138731388
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.7,67
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.75,72.27479774797749
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.8,78.47854078540794
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.85,85.53542435424352
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.9,94.68703387033872
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.95,108.84828798287975
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.975,121.46866618666188
+2025-12-20,3,wk inc covid hosp,2026-01-10,40,quantile,0.99,136.430620606206
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.25,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.3,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.35,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.4,3.440798407984088
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.45,7.176118261182619
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.5,11
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.55,14.755366053660548
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.6,18.658502585025843
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.65,22.703576035760378
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.7,26.86167061670617
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.75,31.497462474624754
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.8,36.86270662706636
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.85,43.117828678286756
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.9,51
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.95,62.832441824418254
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.975,73.14993674936748
+2025-12-20,3,wk inc covid hosp,2026-01-10,41,quantile,0.99,86
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.1,83.1682286822869
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.15,164.51907469074686
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.2,219.90396903969042
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.25,263.16025660256605
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.3,299.5176561765618
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.35,330.1966274662746
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.4,358.689452894529
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.45,385.775054250542
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.5,412
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.55,437.55750257502575
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.6,464.6072880728807
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.65,493.25339353393537
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.7,524.3458474584745
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.75,560.5013375133751
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.8,602.6025180251804
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.85,658.130169301693
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.9,744.1418164181644
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.95,888.3186086860865
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.975,998.0126876268757
+2025-12-20,3,wk inc covid hosp,2026-01-10,42,quantile,0.99,1128.6326039260384
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.1,5.074505745057456
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.15,9.597817478174775
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.2,13
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.25,16
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.3,18.72893228932289
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.35,21.087594375943755
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.4,23.511497114971156
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.45,25.846083960839614
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.5,28
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.55,30.0980149801498
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.6,32.48193681936819
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.65,34.953234032340326
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.7,37.19199291992919
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.75,40
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.8,43
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.85,46.49126541265406
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.9,50.95538455384555
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.95,57.389177891778886
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.975,63.11675766757667
+2025-12-20,3,wk inc covid hosp,2026-01-10,44,quantile,0.99,69.99964359643607
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.25,4.391756417564187
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.3,12.451795517955203
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.35,19.59677846778468
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.4,26.68158581585817
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.45,33.44154541545418
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.5,40
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.55,46.66549615496158
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.6,53.39269492694929
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.65,60.474918749187495
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.7,67.84186941869415
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.75,75.93566935669358
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.8,85.09689796897976
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.85,95.69599345993461
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.9,109.2058330583306
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.95,128.87315223152237
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.975,146.64552070520705
+2025-12-20,3,wk inc covid hosp,2026-01-10,45,quantile,0.99,166.58866848668478
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.25,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.3,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.35,1.0152101521015222
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.4,3.30850108501084
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.45,5.695448954489537
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.5,8
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.55,10.015210152101522
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.6,12.347837478374782
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.65,14.871451714517141
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.7,17.18603986039861
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.75,20.015210152101524
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.8,23.057808578085805
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.85,26.865115651156515
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.9,31.354698546985478
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.95,38.46222562225623
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.975,44.45821533215329
+2025-12-20,3,wk inc covid hosp,2026-01-10,46,quantile,0.99,51.58781917819174
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.05,16.104301543015424
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.1,41.37609876098761
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.15,57.685715857158556
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.2,70.31639816398165
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.25,80.81867318673186
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.3,90.07746577465772
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.35,98.20431954319542
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.4,106.12449224492245
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.45,113.50358603586038
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.5,121
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.55,128.50766707667077
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.6,135.9412104121041
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.65,143.75265602656026
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.7,152.01228212282123
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.75,161.02869778697786
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.8,171.53213232132327
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.85,183.9330613306133
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.9,199.68996589965877
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.95,224.721001710017
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.975,247.83879713797054
+2025-12-20,3,wk inc covid hosp,2026-01-10,47,quantile,0.99,275.64125871258705
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.15,5.824879748797477
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.2,39.86687266872673
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.25,69.96187961879619
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.3,96.213553135531
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.35,119.96202112021122
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.4,142.2912369123691
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.45,164.12336473364746
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.5,186
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.55,207.3820378203783
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.6,229.74829548295477
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.65,252.80717107171083
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.7,276.8312533125331
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.75,302.1982544825448
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.8,330.80530605306103
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.85,365.2544460444604
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.9,410.00498304983057
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.95,476.40682006820066
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.975,536.8493189931896
+2025-12-20,3,wk inc covid hosp,2026-01-10,48,quantile,0.99,607.0056550565503
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.25,1.6984269842698474
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.3,4.720897208972094
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.35,7.770354703547024
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.4,10.720897208972094
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.45,13.393944939449398
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.5,16
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.55,18.720897208972094
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.6,21.570423704237047
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.65,24.3769202692027
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.7,27.623896238962395
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.75,30.81618066180662
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.8,34.72089720897209
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.85,39.27885728857286
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.9,45.2518025180251
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.95,54.430943809438084
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.975,63.02872578725779
+2025-12-20,3,wk inc covid hosp,2026-01-10,49,quantile,0.99,73.29360903609027
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.25,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.3,0.7666376663766667
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.35,1.7736327363273663
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.4,3.516240162401626
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.45,4.773632736327366
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.5,6
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.55,7.605844558445592
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.6,8.773632736327366
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.65,10.097018970189712
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.7,11.773632736327366
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.75,13.328018280182807
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.8,15.0148711487115
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.85,17.195615456154552
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.9,19.773632736327365
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.95,23.971264712647063
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.975,27.755413054130535
+2025-12-20,3,wk inc covid hosp,2026-01-10,50,quantile,0.99,31.773632736327365
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.25,11.555610556105554
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.3,21.914776147761472
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.35,31.450882008820088
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.4,40.25269252692529
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.45,48.69616546165463
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.5,57
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.55,65.36132111321112
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.6,73.8630906309063
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.65,82.61174011740121
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.7,92.2183311833118
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.75,102.63622136221366
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.8,114.92802528025271
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.85,129.8073000730007
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.9,150.6664616646167
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.95,184.51253862538618
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.975,215.67679001790012
+2025-12-20,3,wk inc covid hosp,2026-01-10,51,quantile,0.99,251.0079354793547
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.25,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.3,3.529069290692921
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.35,9.33798587985878
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.4,14.703650036500356
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.45,19.837408374083743
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.5,25
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.55,30.070085700857007
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.6,35.35090050900508
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.65,40.789643896438974
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.7,46.52093120931207
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.75,52.62711377113771
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.8,59.54931449314495
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.85,67.61139611396112
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.9,77.75154351543517
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.95,92.83925789257887
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.975,105.62917204172051
+2025-12-20,3,wk inc covid hosp,2026-01-10,53,quantile,0.99,120.86117561175602
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.15,4.4051695516955265
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.2,13.377573775737774
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.25,20.676731767317676
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.3,26.80660806608067
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.35,31.965868158681598
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.4,37.01214212142123
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.45,41.7087565875659
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.5,46
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.55,50.49396843968441
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.6,55.06814868148682
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.65,60.053536035360416
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.7,65.51585815858157
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.75,71.5349253492535
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.8,79.00408804088042
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.85,88.50062150621507
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.9,100.85999459994602
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.95,118.85424304243035
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.975,134.21877443774437
+2025-12-20,3,wk inc covid hosp,2026-01-10,54,quantile,0.99,154.21596305963075
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.15,8.713077130771278
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.2,22.18417184171841
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.25,32.72042220422204
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.3,41.970989709897154
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.35,49.9911399113991
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.4,57.65519655196551
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.45,64.9863198631986
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.5,72
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.55,79.08318633186332
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.6,86.35881758817587
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.65,94.00688506885069
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.7,102.41782517825176
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.75,111.87552625526254
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.8,122.9911399113991
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.85,137.3735422354223
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.9,156.35767757677584
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.95,186.8824313243131
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.975,213.33919514195136
+2025-12-20,3,wk inc covid hosp,2026-01-10,55,quantile,0.99,243.51685906859066
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.2,4.019424194241944
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.25,7.607473574735762
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.3,10.43014330143301
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.35,13
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.4,15.573049730497306
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.45,18
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.5,20
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.55,22.383672336723368
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.6,24.853746537465376
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.65,27.13738387383874
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.7,30
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.75,33
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.8,36.566805668056695
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.85,41.1990669906699
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.9,48.120465204652064
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.95,60.37052370523693
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.975,71.40487379873797
+2025-12-20,3,wk inc covid hosp,2026-01-10,56,quantile,0.99,82.8742812428124
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.05,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.1,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.15,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.2,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.25,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.3,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.35,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.4,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.45,4.222206722067233
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.5,11
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.55,17.789081890818906
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.6,24.857642576425764
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.65,32.07454574545765
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.7,39.775406754067546
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.75,48.30920559205592
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.8,58.19573595735958
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.85,69.69512195121948
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.9,85.30508605086051
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.95,111.4758347583476
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.975,138.27981229812292
+2025-12-20,3,wk inc covid hosp,2026-01-10,72,quantile,0.99,172.37922069220593
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.01,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.025,0
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.05,713.9437684376849
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.1,1562.5401614016148
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.15,2117.0889623896237
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.2,2512.078067780678
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.25,2842.389533895339
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.3,3135.049613496135
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.35,3398.593018930189
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.4,3645.319916199162
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.45,3873.971482714828
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.5,4109
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.55,4342.038933889338
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.6,4572.811773117731
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.65,4822.105812558128
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.7,5083.6006300063
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.75,5380.942674426744
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.8,5714.433345333454
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.85,6123.893994439944
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.9,6661.982164821651
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.95,7523.039021390213
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.975,8328.470557955578
+2025-12-20,3,wk inc covid hosp,2026-01-10,US,quantile,0.99,9259.09369323693
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.01,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.025,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.05,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.1,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.15,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.2,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.25,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.3,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.35,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.4,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.45,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.5,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.55,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.6,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.65,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.7,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.75,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.8,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.85,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.9,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.95,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.975,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,01,quantile,0.99,0.0033
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.01,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.025,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.05,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.1,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.15,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.2,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.25,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.3,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.35,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.4,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.45,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.5,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.55,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.6,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.65,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.7,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.75,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.8,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.85,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.9,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.95,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.975,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,02,quantile,0.99,0.0039000000000000003
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.01,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.025,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.05,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.1,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.15,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.2,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.25,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.3,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.35,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.4,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.45,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.5,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.55,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.6,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.65,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.7,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.75,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.8,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.85,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.9,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.95,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.975,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,04,quantile,0.99,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.01,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.025,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.05,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.1,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.15,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.2,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.25,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.3,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.35,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.4,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.45,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.5,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.55,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.6,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.65,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.7,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.75,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.8,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.85,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.9,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.95,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.975,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,05,quantile,0.99,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.01,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.025,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.05,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.1,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.15,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.2,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.25,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.3,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.35,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.4,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.45,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.5,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.55,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.6,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.65,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.7,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.75,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.8,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.85,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.9,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.95,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.975,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,06,quantile,0.99,0.0017000000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.01,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.025,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.05,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.1,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.15,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.2,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.25,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.3,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.35,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.4,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.45,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.5,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.55,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.6,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.65,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.7,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.75,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.8,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.85,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.9,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.95,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.975,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,08,quantile,0.99,0.005600000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.01,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.025,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.05,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.1,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.15,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.2,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.25,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.3,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.35,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.4,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.45,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.5,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.55,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.6,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.65,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.7,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.75,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.8,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.85,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.9,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.95,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.975,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,09,quantile,0.99,0.008199999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.01,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.025,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.05,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.1,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.15,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.2,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.25,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.3,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.35,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.4,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.45,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.5,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.55,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.6,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.65,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.7,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.75,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.8,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.85,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.9,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.95,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.975,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,10,quantile,0.99,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.01,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.025,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.05,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.1,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.15,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.2,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.25,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.3,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.35,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.4,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.45,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.5,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.55,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.6,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.65,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.7,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.75,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.8,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.85,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.9,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.95,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.975,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,11,quantile,0.99,0.0015
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.01,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.025,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.05,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.1,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.15,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.2,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.25,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.3,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.35,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.4,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.45,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.5,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.55,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.6,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.65,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.7,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.75,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.8,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.85,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.9,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.95,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.975,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,12,quantile,0.99,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.01,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.025,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.05,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.1,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.15,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.2,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.25,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.3,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.35,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.4,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.45,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.5,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.55,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.6,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.65,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.7,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.75,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.8,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.85,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.9,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.95,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.975,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,13,quantile,0.99,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.01,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.025,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.05,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.1,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.15,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.2,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.25,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.3,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.35,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.4,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.45,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.5,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.55,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.6,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.65,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.7,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.75,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.8,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.85,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.9,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.95,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.975,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,15,quantile,0.99,0.0012
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.01,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.025,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.05,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.1,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.15,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.2,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.25,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.3,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.35,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.4,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.45,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.5,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.55,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.6,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.65,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.7,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.75,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.8,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.85,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.9,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.95,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.975,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,16,quantile,0.99,0.0051
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.01,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.025,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.05,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.1,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.15,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.2,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.25,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.3,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.35,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.4,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.45,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.5,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.55,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.6,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.65,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.7,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.75,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.8,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.85,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.9,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.95,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.975,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,17,quantile,0.99,0.0072
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.01,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.025,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.05,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.1,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.15,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.2,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.25,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.3,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.35,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.4,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.45,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.5,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.55,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.6,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.65,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.7,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.75,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.8,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.85,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.9,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.95,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.975,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,18,quantile,0.99,0.009899999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.01,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.025,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.05,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.1,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.15,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.2,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.25,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.3,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.35,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.4,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.45,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.5,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.55,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.6,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.65,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.7,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.75,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.8,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.85,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.9,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.95,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.975,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,19,quantile,0.99,0.0055000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.01,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.025,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.05,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.1,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.15,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.2,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.25,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.3,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.35,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.4,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.45,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.5,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.55,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.6,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.65,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.7,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.75,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.8,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.85,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.9,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.95,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.975,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,20,quantile,0.99,0.0058
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.01,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.025,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.05,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.1,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.15,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.2,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.25,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.3,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.35,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.4,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.45,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.5,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.55,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.6,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.65,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.7,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.75,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.8,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.85,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.9,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.95,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.975,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,21,quantile,0.99,0.008
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.01,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.025,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.05,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.1,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.15,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.2,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.25,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.3,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.35,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.4,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.45,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.5,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.55,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.6,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.65,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.7,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.75,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.8,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.85,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.9,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.95,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.975,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,22,quantile,0.99,0.0026
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.01,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.025,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.05,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.1,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.15,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.2,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.25,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.3,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.35,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.4,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.45,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.5,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.55,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.6,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.65,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.7,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.75,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.8,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.85,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.9,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.95,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.975,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,23,quantile,0.99,0.0053
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.01,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.025,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.05,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.1,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.15,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.2,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.25,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.3,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.35,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.4,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.45,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.5,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.55,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.6,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.65,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.7,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.75,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.8,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.85,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.9,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.95,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.975,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,24,quantile,0.99,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.01,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.025,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.05,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.1,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.15,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.2,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.25,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.3,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.35,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.4,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.45,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.5,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.55,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.6,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.65,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.7,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.75,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.8,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.85,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.9,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.95,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.975,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,25,quantile,0.99,0.0063
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.01,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.025,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.05,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.1,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.15,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.2,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.25,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.3,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.35,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.4,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.45,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.5,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.55,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.6,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.65,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.7,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.75,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.8,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.85,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.9,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.95,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.975,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,26,quantile,0.99,0.0078000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.01,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.025,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.05,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.1,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.15,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.2,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.25,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.3,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.35,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.4,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.45,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.5,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.55,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.6,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.65,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.7,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.75,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.8,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.85,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.9,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.95,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.975,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,27,quantile,0.99,0.0070999999999999995
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.01,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.025,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.05,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.1,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.15,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.2,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.25,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.3,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.35,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.4,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.45,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.5,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.55,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.6,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.65,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.7,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.75,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.8,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.85,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.9,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.95,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.975,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,28,quantile,0.99,0.0064
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.01,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.025,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.05,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.1,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.15,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.2,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.25,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.3,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.35,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.4,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.45,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.5,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.55,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.6,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.65,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.7,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.75,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.8,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.85,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.9,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.95,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.975,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,30,quantile,0.99,0.0075
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.01,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.025,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.05,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.1,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.15,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.2,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.25,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.3,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.35,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.4,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.45,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.5,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.55,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.6,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.65,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.7,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.75,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.8,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.85,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.9,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.95,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.975,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,31,quantile,0.99,0.0046
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.01,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.025,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.05,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.1,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.15,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.2,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.25,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.3,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.35,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.4,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.45,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.5,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.55,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.6,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.65,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.7,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.75,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.8,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.85,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.9,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.95,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.975,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,32,quantile,0.99,0.0022
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.01,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.025,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.05,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.1,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.15,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.2,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.25,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.3,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.35,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.4,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.45,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.5,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.55,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.6,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.65,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.7,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.75,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.8,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.85,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.9,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.95,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.975,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,33,quantile,0.99,0.0073
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.01,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.025,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.05,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.1,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.15,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.2,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.25,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.3,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.35,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.4,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.45,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.5,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.55,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.6,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.65,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.7,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.75,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.8,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.85,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.9,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.95,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.975,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,34,quantile,0.99,0.0048
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.01,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.025,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.05,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.1,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.15,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.2,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.25,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.3,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.35,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.4,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.45,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.5,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.55,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.6,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.65,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.7,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.75,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.8,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.85,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.9,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.95,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.975,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,35,quantile,0.99,0.01
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.01,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.025,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.05,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.1,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.15,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.2,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.25,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.3,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.35,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.4,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.45,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.5,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.55,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.6,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.65,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.7,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.75,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.8,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.85,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.9,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.95,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.975,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,36,quantile,0.99,0.0044
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.01,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.025,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.05,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.1,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.15,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.2,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.25,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.3,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.35,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.4,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.45,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.5,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.55,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.6,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.65,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.7,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.75,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.8,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.85,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.9,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.95,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.975,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,37,quantile,0.99,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.01,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.025,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.05,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.1,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.15,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.2,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.25,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.3,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.35,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.4,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.45,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.5,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.55,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.6,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.65,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.7,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.75,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.8,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.85,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.9,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.95,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.975,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,38,quantile,0.99,0.0052
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.01,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.025,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.05,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.1,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.15,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.2,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.25,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.3,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.35,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.4,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.45,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.5,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.55,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.6,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.65,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.7,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.75,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.8,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.85,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.9,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.95,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.975,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,39,quantile,0.99,0.0089
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.01,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.025,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.05,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.1,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.15,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.2,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.25,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.3,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.35,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.4,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.45,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.5,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.55,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.6,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.65,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.7,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.75,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.8,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.85,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.9,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.95,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.975,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,40,quantile,0.99,0.0059
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.01,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.025,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.05,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.1,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.15,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.2,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.25,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.3,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.35,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.4,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.45,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.5,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.55,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.6,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.65,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.7,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.75,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.8,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.85,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.9,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.95,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.975,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,41,quantile,0.99,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.01,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.025,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.05,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.1,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.15,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.2,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.25,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.3,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.35,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.4,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.45,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.5,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.55,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.6,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.65,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.7,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.75,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.8,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.85,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.9,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.95,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.975,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,42,quantile,0.99,0.0062
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.01,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.025,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.05,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.1,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.15,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.2,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.25,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.3,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.35,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.4,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.45,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.5,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.55,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.6,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.65,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.7,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.75,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.8,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.85,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.9,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.95,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.975,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,44,quantile,0.99,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.01,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.025,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.05,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.1,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.15,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.2,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.25,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.3,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.35,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.4,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.45,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.5,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.55,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.6,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.65,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.7,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.75,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.8,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.85,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.9,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.95,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.975,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,45,quantile,0.99,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.01,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.025,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.05,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.1,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.15,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.2,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.25,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.3,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.35,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.4,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.45,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.5,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.55,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.6,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.65,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.7,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.75,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.8,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.85,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.9,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.95,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.975,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,46,quantile,0.99,0.0038
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.01,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.025,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.05,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.1,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.15,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.2,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.25,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.3,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.35,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.4,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.45,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.5,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.55,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.6,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.65,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.7,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.75,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.8,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.85,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.9,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.95,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.975,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,47,quantile,0.99,0.0068000000000000005
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.01,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.025,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.05,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.1,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.15,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.2,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.25,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.3,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.35,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.4,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.45,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.5,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.55,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.6,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.65,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.7,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.75,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.8,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.85,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.9,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.95,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.975,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,48,quantile,0.99,0.0032
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.01,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.025,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.05,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.1,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.15,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.2,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.25,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.3,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.35,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.4,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.45,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.5,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.55,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.6,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.65,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.7,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.75,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.8,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.85,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.9,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.95,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.975,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,49,quantile,0.99,0.0024
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.01,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.025,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.05,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.1,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.15,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.2,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.25,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.3,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.35,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.4,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.45,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.5,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.55,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.6,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.65,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.7,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.75,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.8,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.85,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.9,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.95,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.975,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,50,quantile,0.99,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.01,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.025,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.05,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.1,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.15,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.2,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.25,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.3,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.35,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.4,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.45,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.5,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.55,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.6,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.65,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.7,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.75,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.8,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.85,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.9,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.95,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.975,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,51,quantile,0.99,0.004
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.01,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.025,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.05,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.1,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.15,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.2,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.25,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.3,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.35,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.4,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.45,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.5,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.55,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.6,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.65,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.7,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.75,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.8,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.85,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.9,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.95,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.975,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,53,quantile,0.99,0.0021
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.01,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.025,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.05,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.1,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.15,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.2,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.25,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.3,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.35,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.4,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.45,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.5,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.55,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.6,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.65,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.7,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.75,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.8,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.85,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.9,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.95,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.975,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,54,quantile,0.99,0.0087
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.01,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.025,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.05,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.1,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.15,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.2,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.25,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.3,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.35,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.4,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.45,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.5,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.55,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.6,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.65,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.7,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.75,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.8,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.85,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.9,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.95,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.975,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,55,quantile,0.99,0.006500000000000001
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.01,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.025,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.05,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.1,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.15,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.2,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.25,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.3,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.35,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.4,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.45,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.5,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.55,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.6,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.65,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.7,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.75,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.8,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.85,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.9,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.95,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.975,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,56,quantile,0.99,0
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.01,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.025,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.05,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.1,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.15,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.2,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.25,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.3,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.35,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.4,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.45,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.5,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.55,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.6,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.65,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.7,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.75,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.8,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.85,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.9,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.95,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.975,0.004699999999999999
+2025-12-20,-1,wk inc covid prop ed visits,2025-12-13,US,quantile,0.99,0.004699999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.1,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.15,6.899999999999994e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.2,0.0015
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.25,0.0018999999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.3,0.0023999999999999985
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.35,0.0026999999999999984
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.4,0.0029
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.45,0.0031000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.5,0.0033
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.55,0.0034999999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.6,0.0037
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.65,0.0039000000000000016
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.7,0.0042000000000000015
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.75,0.0047
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.8,0.0051
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.85,0.005909999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.9,0.007640000000000006
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.95,0.009800000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.975,0.011567499999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,01,quantile,0.99,0.013068999999999983
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.1,6.999999999999971e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.15,0.001200000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.2,0.0019000000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.25,0.002399999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.3,0.0027999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.35,0.0031549999999999972
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.4,0.0034
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.45,0.003685
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.5,0.0039000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.55,0.004115000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.6,0.004400000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.65,0.004645000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.7,0.005000000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.75,0.005400000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.8,0.005900000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.85,0.0066
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.9,0.007100000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.95,0.008639999999999986
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.975,0.0103
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,02,quantile,0.99,0.010933999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.05,6.649999999999996e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.1,0.0014300000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.15,0.0019950000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.2,0.002500000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.25,0.002799999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.3,0.0030000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.35,0.003299999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.4,0.003499999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.45,0.003600000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.5,0.0038
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.55,0.003999999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.6,0.0041
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.65,0.004300000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.7,0.0046
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.75,0.0048000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.8,0.005099999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.85,0.005604999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.9,0.006170000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.95,0.006934999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.975,0.008934999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,04,quantile,0.99,0.01333599999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.05,8.650000000000013e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.1,0.0025000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.15,0.0034950000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.2,0.0039000000000000016
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.25,0.004324999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.3,0.004589999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.35,0.0048000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.4,0.0050999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.45,0.0053
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.5,0.0055000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.55,0.005700000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.6,0.005900000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.65,0.006200000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.7,0.0064099999999999956
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.75,0.006675
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.8,0.0070999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.85,0.0075049999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.9,0.0085
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.95,0.010134999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.975,0.011800000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,05,quantile,0.99,0.012700999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.1,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.15,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.2,3.600000000000009e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.25,8.250000000000003e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.3,0.0011000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.35,0.001299999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.4,0.0014000000000000009
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.45,0.0015000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.5,0.0017000000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.55,0.0018999999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.6,0.001999999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.65,0.002100000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.7,0.0023
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.75,0.0025749999999999983
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.8,0.00304
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.85,0.0035000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.9,0.004170000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.95,0.005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.975,0.0061674999999999985
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,06,quantile,0.99,0.0074359999999999765
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.01,8.330000000000013e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.025,0.0019299999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.05,0.0026999999999999993
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.1,0.003430000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.15,0.004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.2,0.0044
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.25,0.004600000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.3,0.004900000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.35,0.005154999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.4,0.005300000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.45,0.005400000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.5,0.005600000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.55,0.0058
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.6,0.005900000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.65,0.006045000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.7,0.0063
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.75,0.006600000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.8,0.006800000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.85,0.0072000000000000015
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.9,0.007770000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.95,0.008500000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.975,0.009269999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,08,quantile,0.99,0.010366999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.025,0.0013325000000000025
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.05,0.0042
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.1,0.005199999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.15,0.005999999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.2,0.006599999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.25,0.006999999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.3,0.007299999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.35,0.007599999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.4,0.0078
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.45,0.007999999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.5,0.008199999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.55,0.0084
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.6,0.008599999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.65,0.0088
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.7,0.0091
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.75,0.009399999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.8,0.0098
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.85,0.0104
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.9,0.011200000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.95,0.012199999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.975,0.015067499999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,09,quantile,0.99,0.016433999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.05,6.500000000000101e-5
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.1,0.0016000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.15,0.0026
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.2,0.003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.25,0.0033
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.3,0.003700000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.35,0.004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.4,0.004299999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.45,0.0045000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.5,0.0048
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.55,0.005099999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.6,0.0053
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.65,0.005599999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.7,0.005899999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.75,0.006299999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.8,0.006599999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.85,0.006999999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.9,0.007999999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.95,0.009534999999999993
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.975,0.010099999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,10,quantile,0.99,0.01370499999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.1,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.15,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.2,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.25,1.5178830414797062e-18
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.3,4.000000000000002e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.35,7.000000000000003e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.4,9.999999999999996e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.45,0.0012999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.5,0.0015
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.55,0.0017000000000000006
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.6,0.0020000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.65,0.0023
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.7,0.0026
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.75,0.0029999999999999983
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.8,0.003340000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.85,0.003905
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.9,0.0048400000000000075
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.95,0.0059349999999999915
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.975,0.006799999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,11,quantile,0.99,0.008766999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.1,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.15,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.2,4.000000000000019e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.25,8.25e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.3,0.0012999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.35,0.0015999999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.4,0.0018999999999999993
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.45,0.002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.5,0.0021
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.55,0.0021999999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.6,0.0023000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.65,0.0026000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.7,0.0029000000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.75,0.0033749999999999982
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.8,0.003799999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.85,0.004499999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.9,0.005399999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.95,0.006904999999999991
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.975,0.008199999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,12,quantile,0.99,0.010100999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.1,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.15,3.9999999999999975e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.2,0.0011000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.25,0.0015000000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.3,0.0018
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.35,0.002099999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.4,0.002120000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.45,0.0022999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.5,0.0024
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.55,0.0025
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.6,0.0026799999999999975
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.65,0.0027000000000000006
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.7,0.0029999999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.75,0.003299999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.8,0.0036999999999999993
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.85,0.004399999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.9,0.0051
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.95,0.006499999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.975,0.007634999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,13,quantile,0.99,0.009100999999999991
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.1,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.15,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.2,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.25,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.3,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.35,2.5499999999999503e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.4,6.200000000000013e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.45,9.999999999999994e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.5,0.0012
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.55,0.0014000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.6,0.0017799999999999986
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.65,0.0021450000000000037
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.7,0.0026
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.75,0.003299999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.8,0.003999999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.85,0.004899999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.9,0.0055000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.95,0.007334999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.975,0.008467499999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,15,quantile,0.99,0.009566999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.025,6.324999999999982e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.05,0.0016000000000000033
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.1,0.0025000000000000022
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.15,0.0031000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.2,0.0034000000000000015
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.25,0.0037000000000000006
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.3,0.0041
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.35,0.004399999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.4,0.004700000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.45,0.0049
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.5,0.0051
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.55,0.005300000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.6,0.0055
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.65,0.005800000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.7,0.0061
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.75,0.006500000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.8,0.006799999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.85,0.0071
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.9,0.0076999999999999985
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.95,0.008599999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.975,0.009567500000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,16,quantile,0.99,0.011971999999999958
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.01,9.899999999999925e-5
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.025,0.0015600000000000024
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.05,0.003265
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.1,0.0047300000000000016
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.15,0.005300000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.2,0.0058
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.25,0.0060999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.3,0.006300000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.35,0.006699999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.4,0.006899999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.45,0.007
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.5,0.0072
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.55,0.0073999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.6,0.007500000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.65,0.007700000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.7,0.008099999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.75,0.0083
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.8,0.0086
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.85,0.009099999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.9,0.009670000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.95,0.011134999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.975,0.012839999999999983
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,17,quantile,0.99,0.014300999999999993
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.01,0.002632999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.025,0.003999999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.05,0.005364999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.1,0.007259999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.15,0.007995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.2,0.008459999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.25,0.008799999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.3,0.0091
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.35,0.009399999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.4,0.0095
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.45,0.009699999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.5,0.009899999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.55,0.0101
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.6,0.010299999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.65,0.0104
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.7,0.010699999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.75,0.011
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.8,0.011340000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.85,0.011804999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.9,0.012540000000000008
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.95,0.014434999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.975,0.0158
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,18,quantile,0.99,0.017166999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.05,0.0011650000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.1,0.0022299999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.15,0.0030950000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.2,0.0039
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.25,0.0043
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.3,0.004500000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.35,0.0049
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.4,0.0051
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.45,0.0053
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.5,0.0055000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.55,0.005700000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.6,0.005900000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.65,0.006100000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.7,0.0065
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.75,0.006700000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.8,0.007100000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.85,0.007904999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.9,0.008770000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.95,0.009834999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.975,0.011369999999999993
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,19,quantile,0.99,0.014710999999999905
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.025,5.975000000000007e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.05,0.0017599999999999983
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.1,0.003300000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.15,0.003899999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.2,0.004399999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.25,0.0047
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.3,0.005000000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.35,0.005299999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.4,0.005399999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.45,0.005585000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.5,0.0058
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.55,0.006015000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.6,0.0062
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.65,0.0063
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.7,0.006599999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.75,0.006899999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.8,0.0072000000000000015
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.85,0.0077
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.9,0.008299999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.95,0.009839999999999988
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.975,0.011002499999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,20,quantile,0.99,0.01226899999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.01,0.0011330000000000012
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.025,0.0014325000000000021
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.05,0.0027850000000000028
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.1,0.004699999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.15,0.005400000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.2,0.0060999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.25,0.006699999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.3,0.007
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.35,0.007399999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.4,0.007600000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.45,0.007885
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.5,0.008
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.55,0.008115000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.6,0.0084
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.65,0.008600000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.7,0.009
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.75,0.009300000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.8,0.0099
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.85,0.010599999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.9,0.011300000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.95,0.01321499999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.975,0.014567499999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,21,quantile,0.99,0.014866999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.1,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.15,2.999999999999999e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.2,7.00000000000001e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.25,0.0012999999999999993
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.3,0.0015
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.35,0.0018549999999999975
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.4,0.0020999999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.45,0.0023999999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.5,0.0026
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.55,0.0028000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.6,0.0031000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.65,0.003345000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.7,0.0036999999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.75,0.0039000000000000007
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.8,0.004499999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.85,0.0049
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.9,0.005970000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.95,0.008669999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.975,0.009767500000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,22,quantile,0.99,0.011402999999999976
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.05,2.950000000000007e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.1,0.002129999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.15,0.002700000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.2,0.0033000000000000017
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.25,0.0039
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.3,0.004200000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.35,0.004554999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.4,0.0049
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.45,0.0051
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.5,0.0053
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.55,0.0055
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.6,0.0057
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.65,0.006045000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.7,0.006399999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.75,0.0067
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.8,0.007299999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.85,0.007899999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.9,0.008470000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.95,0.010304999999999991
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.975,0.0123675
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,23,quantile,0.99,0.014067999999999983
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.05,9.99999999999981e-5
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.1,9.99999999999997e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.15,0.0015999999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.2,0.002100000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.25,0.002699999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.3,0.0029000000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.35,0.0031000000000000008
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.4,0.0034200000000000016
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.45,0.0036000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.5,0.0038
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.55,0.004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.6,0.004179999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.65,0.004499999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.7,0.004699999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.75,0.004900000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.8,0.005499999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.85,0.006
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.9,0.0066000000000000034
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.95,0.0075000000000000015
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.975,0.009134999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,24,quantile,0.99,0.010401999999999982
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.025,8.624999999999997e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.05,0.002095000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.1,0.0034999999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.15,0.004095
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.2,0.0047199999999999985
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.25,0.0050999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.3,0.005489999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.35,0.0058
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.4,0.006
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.45,0.0062
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.5,0.0063
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.55,0.0064
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.6,0.0066
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.65,0.0068000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.7,0.007109999999999993
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.75,0.007500000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.8,0.007880000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.85,0.008504999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.9,0.0091
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.95,0.010504999999999988
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.975,0.011737499999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,25,quantile,0.99,0.013566999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.01,2.660000000000032e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.025,0.0027649999999999984
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.05,0.004130000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.1,0.00533
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.15,0.006094999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.2,0.0065
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.25,0.006700000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.3,0.006989999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.35,0.0072549999999999976
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.4,0.007400000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.45,0.007600000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.5,0.0078000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.55,0.008
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.6,0.008199999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.65,0.008345000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.7,0.008609999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.75,0.0089
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.8,0.0091
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.85,0.009505000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.9,0.010270000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.95,0.011469999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.975,0.012835
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,26,quantile,0.99,0.015333999999999992
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.01,9.319999999999962e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.025,0.0023999999999999968
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.05,0.0035950000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.1,0.0043999999999999985
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.15,0.005094999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.2,0.005500000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.25,0.005999999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.3,0.0062
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.35,0.0064549999999999955
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.4,0.0066999999999999985
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.45,0.006800000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.5,0.0070999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.55,0.007399999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.6,0.007500000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.65,0.007745000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.7,0.008
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.75,0.008199999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.8,0.008699999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.85,0.009105
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.9,0.0098
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.95,0.01060499999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.975,0.011800000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,27,quantile,0.99,0.013267999999999992
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.05,7.650000000000011e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.1,0.0021299999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.15,0.0039949999999999986
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.2,0.0048000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.25,0.005200000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.3,0.005589999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.35,0.005854999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.4,0.006020000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.45,0.0062000000000000015
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.5,0.0064
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.55,0.006599999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.6,0.00678
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.65,0.006945000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.7,0.007209999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.75,0.0076
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.8,0.008
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.85,0.008805
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.9,0.010670000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.95,0.012034999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.975,0.014234999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,28,quantile,0.99,0.015333999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.01,7.330000000000035e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.025,0.0025300000000000014
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.05,0.0038999999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.1,0.00503
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.15,0.0055
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.2,0.0058999999999999955
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.25,0.006124999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.3,0.006400000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.35,0.006700000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.4,0.007020000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.45,0.007299999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.5,0.0075
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.55,0.0077
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.6,0.007979999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.65,0.008299999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.7,0.008599999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.75,0.008875
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.8,0.009100000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.85,0.0095
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.9,0.009970000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.95,0.0111
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.975,0.012469999999999992
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,30,quantile,0.99,0.014266999999999993
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.05,7.649999999999977e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.1,0.0020300000000000014
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.15,0.0029000000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.2,0.0034000000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.25,0.0037250000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.3,0.004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.35,0.0042
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.4,0.004299999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.45,0.0045
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.5,0.0046
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.55,0.0047
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.6,0.004900000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.65,0.005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.7,0.0052
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.75,0.005474999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.8,0.0058
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.85,0.0063
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.9,0.007170000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.95,0.008435
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.975,0.009434999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,31,quantile,0.99,0.010033999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.1,2.999999999999999e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.15,7.999999999999999e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.2,0.0010999999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.25,0.0013999999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.3,0.0016000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.35,0.001799999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.4,0.0019000000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.45,0.0020000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.5,0.0022
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.55,0.0024
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.6,0.0025
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.65,0.002600000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.7,0.0028
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.75,0.0030000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.8,0.0033000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.85,0.0036000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.9,0.0041
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.95,0.004999999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.975,0.005534999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,32,quantile,0.99,0.006334999999999987
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.025,4.324999999999986e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.05,0.0022299999999999963
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.1,0.00443
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.15,0.005094999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.2,0.0056
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.25,0.0059
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.3,0.006299999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.35,0.006500000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.4,0.0068000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.45,0.007
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.5,0.0073
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.55,0.0076
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.6,0.0078
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.65,0.0081
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.7,0.008300000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.75,0.0087
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.8,0.009000000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.85,0.009505
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.9,0.010170000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.95,0.012369999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.975,0.0141675
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,33,quantile,0.99,0.0155
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.025,1.9999999999999966e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.05,0.0013000000000000017
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.1,0.0024600000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.15,0.0030999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.2,0.0034999999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.25,0.003799999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.3,0.004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.35,0.0043
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.4,0.004599999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.45,0.004699999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.5,0.0048
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.55,0.0049
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.6,0.005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.65,0.005299999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.7,0.005599999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.75,0.0058
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.8,0.0060999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.85,0.0065
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.9,0.007140000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.95,0.008299999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.975,0.009399999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,34,quantile,0.99,0.011433999999999991
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.01,0.002732000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.025,0.003732500000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.05,0.0049
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.1,0.006329999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.15,0.007494999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.2,0.008199999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.25,0.0086
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.3,0.008889999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.35,0.0092
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.4,0.0094
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.45,0.0097
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.5,0.01
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.55,0.0103
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.6,0.0106
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.65,0.0108
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.7,0.011109999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.75,0.0114
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.8,0.011800000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.85,0.012504999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.9,0.013670000000000007
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.95,0.0151
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.975,0.016267499999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,35,quantile,0.99,0.017267999999999988
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.025,9.325000000000007e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.05,0.0014000000000000032
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.1,0.002300000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.15,0.003194999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.2,0.0034999999999999988
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.25,0.0037
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.3,0.0038000000000000013
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.35,0.004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.4,0.004100000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.45,0.004285000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.5,0.0044
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.55,0.004515000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.6,0.004699999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.65,0.0048000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.7,0.004999999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.75,0.0051
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.8,0.005300000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.85,0.005605000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.9,0.0065
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.95,0.007399999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.975,0.0078675
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,36,quantile,0.99,0.009833999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.1,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.15,3.000000000000012e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.2,0.0010599999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.25,0.0018
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.3,0.0020899999999999972
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.35,0.0025000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.4,0.0028
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.45,0.002999999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.5,0.0032
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.55,0.003400000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.6,0.0036000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.65,0.0039
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.7,0.004309999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.75,0.0046
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.8,0.005340000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.85,0.0060999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.9,0.006970000000000007
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.95,0.008434999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.975,0.01003999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,37,quantile,0.99,0.011733999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.05,2.999999999999999e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.1,0.0017999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.15,0.0025950000000000014
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.2,0.0031600000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.25,0.003725
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.3,0.0040999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.35,0.0044
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.4,0.0048
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.45,0.004985000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.5,0.0052
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.55,0.005415000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.6,0.0056
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.65,0.005999999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.7,0.0063
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.75,0.006674999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.8,0.00724
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.85,0.007804999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.9,0.0086
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.95,0.0101
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.975,0.011002499999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,38,quantile,0.99,0.01327299999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.01,0.0020990000000000028
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.025,0.0036649999999999973
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.05,0.0049299999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.1,0.006630000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.15,0.007095000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.2,0.0075
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.25,0.007899999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.3,0.0082
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.35,0.0084
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.4,0.008520000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.45,0.0087
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.5,0.0089
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.55,0.0091
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.6,0.009279999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.65,0.0094
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.7,0.0096
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.75,0.0099
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.8,0.0103
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.85,0.010704999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.9,0.011170000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.95,0.012869999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.975,0.014135
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,39,quantile,0.99,0.01570099999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.025,5.325000000000014e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.05,0.0017300000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.1,0.0032999999999999987
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.15,0.0038000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.2,0.004360000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.25,0.004700000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.3,0.005000000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.35,0.005299999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.4,0.005420000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.45,0.0056
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.5,0.0059
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.55,0.0062
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.6,0.0063799999999999985
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.65,0.0065000000000000014
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.7,0.006799999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.75,0.007099999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.8,0.0074400000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.85,0.008
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.9,0.0085
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.95,0.010069999999999992
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.975,0.011267499999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,40,quantile,0.99,0.013867999999999988
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.1,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.15,2.0000000000000096e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.2,7.599999999999996e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.25,0.0010999999999999977
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.3,0.0013
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.35,0.0015
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.4,0.0016999999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.45,0.0019
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.5,0.0021
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.55,0.0023
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.6,0.0025
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.65,0.0026999999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.7,0.0029
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.75,0.003100000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.8,0.0034400000000000012
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.85,0.003999999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.9,0.004600000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.95,0.005369999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.975,0.0063675
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,41,quantile,0.99,0.0076339999999999915
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.01,0.0013999999999999985
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.025,0.0021650000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.05,0.003165000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.1,0.0039299999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.15,0.0046
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.2,0.005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.25,0.005399999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.3,0.0056
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.35,0.005799999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.4,0.0059
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.45,0.0060999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.5,0.0062
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.55,0.0063
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.6,0.0065
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.65,0.006600000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.7,0.0068
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.75,0.007
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.8,0.0073999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.85,0.0078
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.9,0.008470000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.95,0.009234999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.975,0.010234999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,42,quantile,0.99,0.011000000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.05,7.650000000000003e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.1,0.0020299999999999984
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.15,0.0027999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.2,0.0031999999999999993
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.25,0.003424999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.3,0.0037999999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.35,0.004054999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.4,0.0043
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.45,0.0045
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.5,0.004699999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.55,0.004899999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.6,0.005099999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.65,0.005345
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.7,0.005599999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.75,0.005974999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.8,0.006199999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.85,0.006599999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.9,0.007370000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.95,0.008634999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.975,0.009900000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,44,quantile,0.99,0.012167999999999988
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.1,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.15,7.950000000000005e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.2,0.0018000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.25,0.0025000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.3,0.002889999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.35,0.0031
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.4,0.0034
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.45,0.0035999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.5,0.0038
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.55,0.004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.6,0.004200000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.65,0.0045000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.7,0.0047099999999999954
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.75,0.0050999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.8,0.0058
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.85,0.0068049999999999986
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.9,0.008000000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.95,0.010034999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.975,0.011434999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,45,quantile,0.99,0.012869999999999977
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.1,0.0011999999999999988
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.15,0.001694999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.2,0.0021
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.25,0.0024
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.3,0.0026
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.35,0.0029000000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.4,0.0033000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.45,0.0035849999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.5,0.0038
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.55,0.004015000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.6,0.0043
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.65,0.004699999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.7,0.005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.75,0.0052
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.8,0.0055
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.85,0.005904999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.9,0.006400000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.95,0.008134999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.975,0.0091675
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,46,quantile,0.99,0.010033999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.01,3.2000000000004207e-05
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.025,0.0011325000000000022
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.05,0.001965
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.1,0.0038300000000000022
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.15,0.004795
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.2,0.0054
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.25,0.0058000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.3,0.006
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.35,0.006200000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.4,0.006400000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.45,0.0067
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.5,0.0068000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.55,0.006900000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.6,0.0072
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.65,0.0074
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.7,0.007600000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.75,0.0078000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.8,0.0082
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.85,0.008805
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.9,0.009770000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.95,0.011635
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.975,0.012467499999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,47,quantile,0.99,0.013567999999999988
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.1,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.15,8.949999999999999e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.2,0.0015999999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.25,0.0021
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.3,0.0024000000000000007
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.35,0.0027
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.4,0.0029
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.45,0.0031
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.5,0.0032
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.55,0.0033000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.6,0.0035000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.65,0.0037
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.7,0.004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.75,0.0043
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.8,0.0048000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.85,0.0055049999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.9,0.006540000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.95,0.008369999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.975,0.009967499999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,48,quantile,0.99,0.011733999999999993
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.1,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.15,3.9999999999999975e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.2,7.599999999999998e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.25,0.0010999999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.3,0.0015899999999999968
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.35,0.0017000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.4,0.0020000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.45,0.002200000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.5,0.0024
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.55,0.0025999999999999986
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.6,0.002799999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.65,0.0030999999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.7,0.003209999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.75,0.0036999999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.8,0.004040000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.85,0.004399999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.9,0.0052
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.95,0.006239999999999988
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.975,0.007167499999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,49,quantile,0.99,0.009167999999999987
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.05,0.001564999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.1,0.0027
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.15,0.0036000000000000042
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.2,0.004360000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.25,0.005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.3,0.005489999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.35,0.005799999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.4,0.006000000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.45,0.006285000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.5,0.006500000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.55,0.006715000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.6,0.006999999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.65,0.007200000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.7,0.007509999999999995
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.75,0.008
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.8,0.008640000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.85,0.009399999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.9,0.0103
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.95,0.011435
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.975,0.013069999999999993
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,50,quantile,0.99,0.014968999999999979
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.1,5.300000000000005e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.15,0.0014900000000000007
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.2,0.0022
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.25,0.002700000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.3,0.0031000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.35,0.003399999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.4,0.0036000000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.45,0.0038000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.5,0.004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.55,0.0042
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.6,0.004399999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.65,0.004600000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.7,0.0049
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.75,0.005299999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.8,0.0058
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.85,0.006509999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.9,0.007470000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.95,0.009099999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.975,0.010400000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,51,quantile,0.99,0.013433999999999993
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.1,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.15,2.0000000000000096e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.2,5.999999999999985e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.25,9.999999999999996e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.3,0.0012999999999999986
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.35,0.0015
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.4,0.0016999999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.45,0.0018999999999999993
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.5,0.0021
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.55,0.0023000000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.6,0.0025
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.65,0.0026999999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.7,0.002900000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.75,0.0032
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.8,0.003600000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.85,0.003999999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.9,0.004599999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.95,0.005099999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.975,0.005600000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,53,quantile,0.99,0.006871999999999953
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.05,0.0020999999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.1,0.004799999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.15,0.006194999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.2,0.006999999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.25,0.0074249999999999984
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.3,0.0076999999999999985
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.35,0.007954999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.4,0.008200000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.45,0.008499999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.5,0.0087
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.55,0.0089
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.6,0.009199999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.65,0.009445
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.7,0.0097
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.75,0.009974999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.8,0.0104
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.85,0.011204999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.9,0.0126
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.95,0.0153
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.975,0.017707499999999987
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,54,quantile,0.99,0.020102999999999975
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.01,8.320000000000063e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.025,0.0020325
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.05,0.002765000000000004
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.1,0.004200000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.15,0.004600000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.2,0.0051
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.25,0.0054
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.3,0.005689999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.35,0.005900000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.4,0.006100000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.45,0.0063
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.5,0.006500000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.55,0.006700000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.6,0.006899999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.65,0.0071
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.7,0.007309999999999996
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.75,0.007600000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.8,0.0079
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.85,0.0084
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.9,0.0088
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.95,0.010234999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.975,0.0109675
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,55,quantile,0.99,0.012167999999999984
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.025,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.05,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.1,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.15,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.2,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.25,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.3,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.35,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.4,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.45,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.5,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.55,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.6,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.65,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.7,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.75,2.9999999999999905e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.8,0.0013000000000000002
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.85,0.0019050000000000009
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.9,0.003610000000000008
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.95,0.0049349999999999975
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.975,0.006704999999999992
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,56,quantile,0.99,0.010601999999999983
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.01,0
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.025,9.000000000000015e-4
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.05,0.001465000000000001
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.1,0.0022299999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.15,0.0029
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.2,0.003499999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.25,0.003899999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.3,0.003999999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.35,0.004199999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.4,0.004399999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.45,0.0045000000000000005
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.5,0.004699999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.55,0.004899999999999998
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.6,0.004999999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.65,0.0052
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.7,0.005399999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.75,0.0055
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.8,0.005899999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.85,0.006499999999999999
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.9,0.007170000000000003
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.95,0.007934999999999994
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.975,0.008499999999999997
+2025-12-20,0,wk inc covid prop ed visits,2025-12-20,US,quantile,0.99,0.0096
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.15,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.2,2.910089100891038e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.25,9.367833678336824e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.3,0.0015367833678336814
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.35,0.0020367833678336797
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.4,0.00245621636216363
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.45,0.002926412114121143
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.5,0.0033
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.55,0.003736783367833681
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.6,0.004136783367833682
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.65,0.004636783367833681
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.7,0.005175849158491587
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.75,0.005935363603636039
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.8,0.006836783367833683
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.85,0.00805669381693817
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.9,0.009605175051750521
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.95,0.011846040410404117
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.975,0.013737495049950501
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,01,quantile,0.99,0.015906679326793224
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.15,2.999999999999969e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.2,9.958203582035826e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.25,0.0015646813968139678
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.3,0.0020999999999999994
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.35,0.002599999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.4,0.003033593735937359
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.45,0.0034999999999999988
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.5,0.0039000000000000003
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.55,0.004331282062820633
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.6,0.0048
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.65,0.0052999999999999966
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.7,0.0058
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.75,0.006399999999999997
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.8,0.007
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.85,0.007799999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.9,0.008885208352083524
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.95,0.010528877238772386
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.975,0.012028904239042383
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,02,quantile,0.99,0.013660290522905218
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.1,4.253613536135388e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.15,0.0011097803978039789
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.2,0.0016999999999999997
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.25,0.002122108721087208
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.3,0.0025000000000000027
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.35,0.002899999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.4,0.0032
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.45,0.0035
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.5,0.0038
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.55,0.0040999999999999995
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.6,0.0044
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.65,0.004700000000000003
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.7,0.005099999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.75,0.0055
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.8,0.005985155251552518
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.85,0.006542219422194221
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.9,0.007399999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.95,0.009493375933759332
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.975,0.012717047295472964
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,04,quantile,0.99,0.014605315183151803
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.1,9.887264872648742e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.15,0.002004148591485916
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.2,0.0028000000000000013
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.25,0.0034000000000000015
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.3,0.0039000000000000024
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.35,0.0043952052020520185
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.4,0.004799999999999997
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.45,0.005138236432364326
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.5,0.0055000000000000005
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.55,0.005894703447034473
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.6,0.006240846008460085
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.65,0.006641538565385654
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.7,0.0071
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.75,0.0076
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.8,0.008200000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.85,0.009036944019440192
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.9,0.010164438844388444
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.95,0.011899999999999997
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.975,0.0133
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,05,quantile,0.99,0.015040575105751127
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.15,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.2,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.25,2.4246242462424672e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.3,5.424624246242479e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.35,8.832710827108264e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.4,0.0011424624246242497
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.45,0.0014424624246242466
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.5,0.0017000000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.55,0.0019424624246242475
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.6,0.002242462424624247
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.65,0.0025424624246242486
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.7,0.0029424624246242458
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.75,0.003342462424624247
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.8,0.003842462424624246
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.85,0.004409747547475475
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.9,0.005142462424624246
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.95,0.006514209342093406
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.975,0.007879539645396446
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,06,quantile,0.99,0.009689590765907656
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.025,6.000000000000009e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.05,0.001524654846548467
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.1,0.0025465934659346574
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.15,0.0031999999999999984
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.2,0.0036999999999999993
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.25,0.0041
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.3,0.004409490594905948
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.35,0.0047715867158671585
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.4,0.005044667446674468
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.45,0.005304584645846461
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.5,0.005600000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.55,0.005899999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.6,0.0061670344703447025
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.65,0.006424829448294485
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.7,0.006799892898928987
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.75,0.007100000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.8,0.007500000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.85,0.008000000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.9,0.00863968319683197
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.95,0.00967159031590316
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.975,0.0106
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,08,quantile,0.99,0.011655030510305118
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.05,0.0015720479704797036
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.1,0.0037048456484564877
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.15,0.0047896962469624665
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.2,0.005499999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.25,0.0060999999999999995
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.3,0.006599999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.35,0.007035027900279001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.4,0.007431518315183154
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.45,0.0078000000000000005
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.5,0.008199999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.55,0.008587364773647733
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.6,0.008919710197101968
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.65,0.009311232562325623
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.7,0.009799999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.75,0.0103
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.8,0.0109
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.85,0.011602848528485284
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.9,0.0127
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.95,0.014888879038790367
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.975,0.016711675366753675
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,09,quantile,0.99,0.018658218522185223
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.1,3.999999999999995e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.15,0.0012794217442174413
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.2,0.002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.25,0.002599999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.3,0.0031000000000000003
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.35,0.003567040320403201
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.4,0.003999999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.45,0.0044
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.5,0.0048
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.55,0.0052
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.6,0.0056
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.65,0.006034239042390428
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.7,0.0065
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.75,0.007000000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.8,0.007625070650706508
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.85,0.008400000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.9,0.009481869318693189
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.95,0.011200884708847086
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.975,0.0133
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,10,quantile,0.99,0.015752382413824137
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.15,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.2,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.25,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.3,4.336808689942018e-19
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.35,4.000000000000002e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.4,7.844370443704442e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.45,0.0011590990909909108
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.5,0.0015
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.55,0.0019000000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.6,0.0023000000000000004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.65,0.0027000000000000006
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.7,0.0032
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.75,0.0037000000000000006
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.8,0.0043
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.85,0.005050958059580592
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.9,0.006049422194221947
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.95,0.007579309243092426
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.975,0.009007854378543775
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,11,quantile,0.99,0.010700318243182412
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.15,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.2,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.25,2.000000000000003e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.3,6.000000000000042e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.35,0.00105031230312303
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.4,0.0014000000000000035
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.45,0.0018
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.5,0.0021
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.55,0.0024000000000000015
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.6,0.0028000000000000013
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.65,0.0032000000000000023
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.7,0.0036999999999999997
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.75,0.004279653046530465
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.8,0.004979810998109985
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.85,0.0056935829358293576
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.9,0.006865337953379543
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.95,0.008622578525785256
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.975,0.010255999459994593
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,12,quantile,0.99,0.011856398523985236
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.15,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.2,2.994734947349459e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.25,7.548622986229845e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.3,0.0011994734947349465
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.35,0.0015994734947349463
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.4,0.0018994734947349466
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.45,0.002199473494734946
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.5,0.0024
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.55,0.002699473494734946
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.6,0.002999473494734946
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.65,0.0032994734947349473
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.7,0.003735050850508503
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.75,0.004271422464224643
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.8,0.004881752317523174
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.85,0.0055830883808838045
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.9,0.006499473494734945
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.95,0.007999473494734944
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.975,0.009557407524075237
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,13,quantile,0.99,0.011768173881738819
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.15,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.2,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.25,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.3,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.35,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.4,2.9999999999999537e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.45,7.000000000000008e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.5,0.0011999999999999997
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.55,0.0017483313833138356
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.6,0.0023
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.65,0.0029404860048600507
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.7,0.0035000000000000022
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.75,0.0042
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.8,0.0049999999999999975
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.85,0.005999999999999996
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.9,0.007203582935829362
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.95,0.0089
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.975,0.010514934524345236
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,15,quantile,0.99,0.01238727612276116
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.05,1.0808568085680956e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.1,0.001332741427414276
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.15,0.0020899419494194932
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.2,0.002699999999999997
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.25,0.0031597065970659717
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.3,0.0036
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.35,0.004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.4,0.004399999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.45,0.004745876608766091
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.5,0.0051
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.55,0.005445927459274591
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.6,0.005800000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.65,0.006200000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.7,0.006600000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.75,0.0070528215282152805
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.8,0.007571422914229142
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.85,0.008180120151201512
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.9,0.008911357213572137
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.95,0.010236446314463143
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.975,0.0116
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,16,quantile,0.99,0.01326297551975519
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.025,1.4756165061650722e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.05,0.0015262249122491264
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.1,0.0032154603546035456
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.15,0.004199999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.2,0.004862723427234273
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.25,0.005399999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.3,0.005800000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.35,0.0062
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.4,0.0065470776707767095
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.45,0.006899999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.5,0.0072
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.55,0.007500000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.6,0.007824064440644405
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.65,0.008199999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.7,0.008599999999999997
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.75,0.009000000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.8,0.00957411934119342
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.85,0.01021879893798938
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.9,0.011199999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.95,0.01287989964899647
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.975,0.014321677391773905
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,17,quantile,0.99,0.01571466924669245
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.01,8.70662856628571e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.025,0.002410353928539286
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.05,0.0037793821438214348
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.1,0.0054735199351993525
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.15,0.006599999999999996
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.2,0.007399999999999997
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.25,0.007999999999999997
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.3,0.008489136891368914
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.35,0.008899999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.4,0.009229349293492941
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.45,0.009599999999999997
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.5,0.009899999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.55,0.0102
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.6,0.010599863198631983
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.65,0.0109
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.7,0.011323847538475382
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.75,0.011800000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.8,0.012400000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.85,0.0132
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.9,0.01433218522185222
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.95,0.016024272792727928
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.975,0.0174040410404104
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,18,quantile,0.99,0.01893850805508054
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.1,0.001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.15,0.0019171042210422134
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.2,0.002699999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.25,0.0033000000000000017
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.3,0.0038829835298352967
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.35,0.004300000000000004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.4,0.004725101251012515
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.45,0.00511839303393034
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.5,0.0055000000000000005
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.55,0.0059
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.6,0.0063
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.65,0.0067
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.7,0.0071414112141121415
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.75,0.0077
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.8,0.008342799027990285
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.85,0.0091
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.9,0.010099999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.95,0.011910790207902068
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.975,0.014008377958779576
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,19,quantile,0.99,0.016641898748987492
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.05,4.575375753757551e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.1,0.001899999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.15,0.002817514175141755
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.2,0.0034999999999999988
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.25,0.004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.3,0.004416310863108629
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.35,0.0048000000000000004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.4,0.005179134191341912
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.45,0.0055
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.5,0.0058
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.55,0.0061
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.6,0.006455503555035543
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.65,0.006799999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.7,0.0071644055440554365
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.75,0.007599999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.8,0.008100000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.85,0.008781633516335161
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.9,0.00972559895598956
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.95,0.011239808298082979
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.975,0.012537297272972698
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,20,quantile,0.99,0.014000099630996306
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.025,7.475272252722692e-5
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.05,0.0013000000000000008
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.1,0.00298569345693457
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.15,0.004182134821348213
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.2,0.005000000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.25,0.005687642876428768
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.3,0.006253397533975336
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.35,0.006749323193231932
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.4,0.0072
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.45,0.007600000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.5,0.008
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.55,0.0084
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.6,0.0088
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.65,0.009222797677976784
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.7,0.00973850238502384
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.75,0.010300000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.8,0.011
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.85,0.0118160732607326
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.9,0.013019271892718936
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.95,0.014700000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.975,0.015942109621096223
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,21,quantile,0.99,0.0175440237602376
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.15,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.2,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.25,5.163846638466373e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.3,0.0010157906579065796
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.35,0.0014163846638466375
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.4,0.0018163846638466381
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.45,0.002216384663846638
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.5,0.0026
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.55,0.0030050081000810034
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.6,0.003416384663846638
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.65,0.0038218414184141847
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.7,0.0043163846638466395
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.75,0.004916384663846639
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.8,0.005689839798397977
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.85,0.006626062910629106
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.9,0.008116520565205653
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.95,0.010180077400774003
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.975,0.01179998379983798
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,22,quantile,0.99,0.013688362883628848
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.1,4.223094230942302e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.15,0.0015130487804878034
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.2,0.00230569345693457
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.25,0.0029873728737287355
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.3,0.0035000000000000014
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.35,0.004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.4,0.004468438484384845
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.45,0.0049
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.5,0.0053
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.55,0.005700000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.6,0.006188083880838809
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.65,0.006600000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.7,0.0071
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.75,0.007699999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.8,0.00830760147601476
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.85,0.0092
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.9,0.01053714157141572
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.95,0.012700000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.975,0.014402464674646747
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,23,quantile,0.99,0.016300000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.15,6.999999999999992e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.2,0.001299999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.25,0.0018000000000000013
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.3,0.0022999999999999987
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.35,0.0027
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.4,0.0030999999999999995
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.45,0.0034773913239132424
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.5,0.0038
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.55,0.004173303933039331
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.6,0.004517238772387726
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.65,0.004900000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.7,0.005338955989559896
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.75,0.005800000000000004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.8,0.006399999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.85,0.007026254162541625
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.9,0.00791900999009991
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.95,0.009473055530555283
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.975,0.010923281207812082
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,24,quantile,0.99,0.012631567995679946
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.05,5.000000000000004e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.1,0.002052838628386288
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.15,0.003000000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.2,0.0037000000000000015
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.25,0.004256619566195663
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.3,0.004757428674286742
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.35,0.005199999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.4,0.005599999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.45,0.005957624876248766
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.5,0.0063
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.55,0.006600000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.6,0.007
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.65,0.0074
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.7,0.007820924309243086
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.75,0.008316836918369184
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.8,0.0089
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.85,0.009623057780577801
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.9,0.010632609126091262
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.95,0.012240989109891059
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.975,0.0137
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,25,quantile,0.99,0.015187276032760329
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.025,4.999999999999999e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.05,0.0021687377373773775
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.1,0.003899648996489966
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.15,0.004873094230942308
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.2,0.005500000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.25,0.006000000000000004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.3,0.00646449374493745
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.35,0.006800000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.4,0.007188839888398883
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.45,0.0075
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.5,0.0078000000000000005
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.55,0.008100000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.6,0.008400000000000003
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.65,0.008799999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.7,0.009133323733237334
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.75,0.009598035730357307
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.8,0.0101
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.85,0.010745454504545024
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.9,0.011704167041670422
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.95,0.01345849248492485
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.975,0.015152705877058772
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,26,quantile,0.99,0.0165860464404644
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.025,6.710667356673558e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.05,0.001888045630456301
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.1,0.0032324219242192433
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.15,0.004084476644766446
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.2,0.0046999999999999984
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.25,0.0052
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.3,0.005626789667896679
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.35,0.006023267032670326
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.4,0.0064
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.45,0.006750211502115022
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.5,0.0070999999999999995
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.55,0.007431457114571147
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.6,0.0078
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.65,0.008180818558185579
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.7,0.008572239222392227
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.75,0.009
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.8,0.0095000000000000015
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.85,0.010122151471514719
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.9,0.010954451444514452
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.95,0.012326245162451625
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.975,0.013572649626496259
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,27,quantile,0.99,0.015149347583475845
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.1,7.603618036180409e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.15,0.0019139843398434057
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.2,0.0029999999999999988
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.25,0.003998458734587345
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.3,0.0047
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.35,0.005200527405274054
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.4,0.005695967959679599
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.45,0.006069243092430924
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.5,0.0064
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.55,0.006799999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.6,0.007163515435154353
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.65,0.0076
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.7,0.008138856088560876
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.75,0.008870063450634501
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.8,0.009873586535865361
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.85,0.01092754432544326
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.9,0.012199999999999996
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.95,0.014435981459814583
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.975,0.01603890401404004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,28,quantile,0.99,0.018721009360093594
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.025,6.298701737017364e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.05,0.002030121501215011
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.1,0.003507157771577716
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.15,0.0044
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.2,0.0050021186211862126
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.25,0.005516359913599136
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.3,0.005999999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.35,0.006399999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.4,0.006799999999999995
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.45,0.007153595985959859
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.5,0.0075
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.55,0.007882643326433264
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.6,0.008200000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.65,0.0086
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.7,0.009000000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.75,0.009492975429754297
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.8,0.009999913599135988
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.85,0.010599999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.9,0.011462465124651246
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.95,0.012971855368553668
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.975,0.014438449284492843
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,30,quantile,0.99,0.01621284951849515
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.1,8.568787687876875e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.15,0.0017000000000000023
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.2,0.002400000000000003
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.25,0.0029739087390873897
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.3,0.0033999999999999994
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.35,0.0037597623976239735
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.4,0.004084946449464497
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.45,0.004337999279992797
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.5,0.0046
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.55,0.004899999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.6,0.005110072900729007
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.65,0.005458357033570334
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.7,0.0058000000000000005
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.75,0.006251217262172624
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.8,0.006799999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.85,0.007499999999999997
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.9,0.00838827018270183
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.95,0.009608801638016369
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.975,0.010561404239042393
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,31,quantile,0.99,0.011899999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.15,2.000000000000001e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.2,5.999999999999991e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.25,9.000000000000002e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.3,0.0012000000000000003
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.35,0.0014999999999999992
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.4,0.001700000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.45,0.001999999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.5,0.0022
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.55,0.002426986769867702
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.6,0.0027
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.65,0.0029791022410224086
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.7,0.003221713617136171
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.75,0.0035718522185221838
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.8,0.0039000000000000024
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.85,0.004400000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.9,0.005002965529655296
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.95,0.005922377373773737
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.975,0.0067818670686706824
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,32,quantile,0.99,0.007819323643236384
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.05,3.99999999999998e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.1,0.002298723787237875
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.15,0.003582272072720727
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.2,0.0044
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.25,0.005063106381063811
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.3,0.0056
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.35,0.00608542885428854
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.4,0.0065
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.45,0.0069
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.5,0.0073
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.55,0.007699999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.6,0.0081
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.65,0.008515504905049053
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.7,0.009000000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.75,0.009555148051480514
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.8,0.0102
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.85,0.011044608946089461
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.9,0.012321090810908123
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.95,0.014400000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.975,0.01607936346863469
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,33,quantile,0.99,0.018007377463774628
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.05,2.679776797767794e-6
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.1,0.0012612528125281251
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.15,0.0020999999999999986
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.2,0.0026999999999999993
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.25,0.0031841283412834104
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.3,0.0035431167311673105
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.35,0.0038999999999999994
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.4,0.004200000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.45,0.0045000000000000005
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.5,0.0048
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.55,0.005099999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.6,0.005399999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.65,0.0057
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.7,0.00605694266942669
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.75,0.006462480874808748
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.8,0.0069000000000000025
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.85,0.00751191251912519
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.9,0.008383381333813333
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.95,0.0098
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.975,0.011262786202862021
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,34,quantile,0.99,0.012755614976149734
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.01,1.1478048780488292e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.025,0.0017922171721717227
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.05,0.003147216272162721
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.1,0.004728282782827829
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.15,0.005871687066870669
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.2,0.0067999333993339905
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.25,0.0075000000000000015
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.3,0.0081
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.35,0.008614495994959946
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.4,0.0091
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.45,0.0096
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.5,0.01
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.55,0.010400286202862034
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.6,0.0109
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.65,0.011369956799568003
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.7,0.0119
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.75,0.0125
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.8,0.013238603186031858
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.85,0.014164133741337412
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.9,0.015300000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.95,0.016839339393393923
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.975,0.01812850868508687
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,35,quantile,0.99,0.019747577625776246
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.05,4.888061380613828e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.1,0.0014000000000000032
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.15,0.0020999999999999994
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.2,0.0026852704527045275
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.25,0.0031000000000000003
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.3,0.0034203447034470355
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.35,0.003700000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.4,0.0039958473584735844
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.45,0.0042
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.5,0.0044
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.55,0.004600000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.6,0.00483433714337143
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.65,0.0050999999999999995
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.7,0.0053999999999999986
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.75,0.0057
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.8,0.0061575771757717635
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.85,0.006700000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.9,0.0074
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.95,0.008400000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.975,0.00971024660246602
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,36,quantile,0.99,0.011188708757087567
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.15,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.2,1.9707047070470921e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.25,7.275357753577551e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.3,0.001327535775357753
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.35,0.0018342844928449283
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.4,0.0023275357753577536
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.45,0.0027802916029160316
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.5,0.0032
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.55,0.0036275357753577536
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.6,0.004098206282062821
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.65,0.004599339393393935
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.7,0.0051275357753577545
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.75,0.00581532040320403
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.8,0.006539243092430938
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.85,0.007470139951399516
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.9,0.00867278822788228
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.95,0.010693504635046347
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.975,0.012759254342543462
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,37,quantile,0.99,0.015693603096030954
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.1,3.940473404734043e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.15,0.001335361353613535
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.2,0.0021
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.25,0.002799999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.3,0.0033881090810908092
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.35,0.003899999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.4,0.004352787327873279
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.45,0.0048
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.5,0.0052
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.55,0.005602526775267753
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.6,0.006099999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.65,0.006535198901989019
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.7,0.0070937008370083685
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.75,0.007641690666906671
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.8,0.008301184411844121
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.85,0.0091
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.9,0.01017523085230853
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.95,0.011799999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.975,0.0134460552605526
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,38,quantile,0.99,0.015182774907749073
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.01,4.4394122941229265e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.025,0.0020533007830078305
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.05,0.0034532040320403197
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.1,0.00503909639096391
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.15,0.006
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.2,0.006685259652596526
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.25,0.007194239942399423
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.3,0.007599999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.35,0.007978357483574835
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.4,0.0083
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.45,0.0086
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.5,0.0089
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.55,0.0092
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.6,0.0095
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.65,0.00985163891638917
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.7,0.0102
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.75,0.010600000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.8,0.0111
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.85,0.011794556745567451
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.9,0.012749207992079924
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.95,0.0144
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.975,0.015839457744577432
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,39,quantile,0.99,0.017392646206462112
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.05,2.3678561785617574e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.1,0.0017548312483124827
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.15,0.002700000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.2,0.0034
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.25,0.0039291242912429135
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.3,0.0044
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.35,0.004800000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.4,0.0052
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.45,0.005573032580325803
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.5,0.0059
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.55,0.00622324453244533
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.6,0.0066
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.65,0.006999999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.7,0.0073999999999999995
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.75,0.00787680901809018
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.8,0.008400000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.85,0.009100000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.9,0.01010661236612366
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.95,0.011746942219422124
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.975,0.013306832418324189
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,40,quantile,0.99,0.014818697956979564
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.15,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.2,9.819638196382048e-5
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.25,5.240414904149021e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.3,8.580325803258016e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.35,0.0011580325803258037
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.4,0.0014623184231842353
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.45,0.0018087143371433713
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.5,0.0021000000000000003
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.55,0.002428379533795337
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.6,0.0027580325803257966
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.65,0.0030580325803258018
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.7,0.0034510557105571034
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.75,0.0038505040050400476
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.8,0.004338045180451804
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.85,0.004889904599045987
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.9,0.005658032580325802
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.95,0.00689163486634866
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.975,0.008037691476914759
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,41,quantile,0.99,0.009366702997029953
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.025,9.390849158491596e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.05,0.0019229061290612945
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.1,0.003000000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.15,0.0037
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.2,0.004281045810458105
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.25,0.004700000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.3,0.0050999999999999995
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.35,0.0054
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.4,0.0057
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.45,0.005948129781297813
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.5,0.0062
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.55,0.006484940149401495
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.6,0.0067
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.65,0.007
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.7,0.007300000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.75,0.007699999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.8,0.008105689856898572
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.85,0.008699999999999996
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.9,0.009380356403564036
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.95,0.010474889748897485
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.975,0.01148723922239223
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,42,quantile,0.99,0.012833607056070546
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.1,7.716236162361625e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.15,0.0016487102871028695
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.2,0.0022999999999999987
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.25,0.0027999999999999995
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.3,0.0032547529475294716
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.35,0.00364971199711997
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.4,0.004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.45,0.0043999999999999985
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.5,0.004699999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.55,0.005038974439744397
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.6,0.005399999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.65,0.005786909369093691
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.7,0.0061929934299342956
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.75,0.0066
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.8,0.007153311133111337
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.85,0.0078
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.9,0.008757326973269735
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.95,0.0103
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.975,0.011800000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,44,quantile,0.99,0.01348745765457655
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.15,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.2,5.15135451354516e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.25,0.0012332800828008268
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.3,0.0018796723967239681
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.35,0.002447542975429756
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.4,0.002947542975429756
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.45,0.0033835712357123578
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.5,0.0038000000000000004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.55,0.00423618126181262
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.6,0.004647542975429755
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.65,0.005170294752947535
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.7,0.005777868778687781
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.75,0.006547542975429756
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.8,0.007447584375843765
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.85,0.008541789217892176
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.9,0.009970299702997034
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.95,0.011959545945459452
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.975,0.013844723697236964
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,45,quantile,0.99,0.016105018630186325
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.15,6.304473044730452e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.2,0.0012639564395644
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.25,0.0017999999999999982
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.3,0.0022000000000000027
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.35,0.0026474849248492452
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.4,0.003027070470704709
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.45,0.0034085410854108574
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.5,0.0038
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.55,0.004199999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.6,0.004599999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.65,0.004999999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.7,0.0054
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.75,0.005900000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.8,0.0064926595265952704
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.85,0.007132350373503734
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.9,0.008000000000000004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.95,0.009497600576005757
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.975,0.010711220637206368
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,46,quantile,0.99,0.0121
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.05,8.000000000000021e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.1,0.002238672486724869
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.15,0.0033695967959679616
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.2,0.004200000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.25,0.004804117541175412
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.3,0.00530270812708127
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.35,0.005774591845918455
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.4,0.006100000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.45,0.006499999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.5,0.0068000000000000005
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.55,0.007100000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.6,0.007499810998109981
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.65,0.007804108091080914
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.7,0.008259558995589953
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.75,0.008765446404464044
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.8,0.009400000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.85,0.010210467554675548
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.9,0.011362475024750254
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.95,0.012870085050850508
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.975,0.014008826163261602
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,47,quantile,0.99,0.015441750787507863
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.15,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.2,5.41369813698137e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.25,0.001142626676266762
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.3,0.0016999999999999975
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.35,0.0021841017910179087
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.4,0.0025965205652056485
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.45,0.002899999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.5,0.0032000000000000006
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.55,0.0035999999999999986
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.6,0.003982577625776251
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.65,0.004399999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.7,0.004871431914319142
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.75,0.00545669381693817
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.8,0.006183499234992363
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.85,0.007199999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.9,0.008452776527765276
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.95,0.010399999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.975,0.011966748267482674
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,48,quantile,0.99,0.013602965259652607
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.15,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.2,1.9520745207452037e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.25,6.412946629466278e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.3,0.0010090693906939065
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.35,0.0013952074520745214
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.4,0.001795207452074519
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.45,0.00209520745207452
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.5,0.0024000000000000002
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.55,0.0027952074520745194
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.6,0.0030952074520745223
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.65,0.0034952074520745212
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.7,0.003895207452074522
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.75,0.004395207452074518
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.8,0.0048952074520745206
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.85,0.005542902079020789
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.9,0.006395216452164526
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.95,0.00786294257942579
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.975,0.009215710557105567
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,49,quantile,0.99,0.010785371163711631
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.1,0.0011000000000000029
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.15,0.0022044770947709483
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.2,0.0030999999999999986
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.25,0.0038380568805688057
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.3,0.0045000000000000005
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.35,0.005080099000990008
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.4,0.005599999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.45,0.0060438250382503856
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.5,0.006500000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.55,0.006925351903519039
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.6,0.007411196111961123
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.65,0.007939955449554498
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.7,0.008500000000000004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.75,0.009178069030690307
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.8,0.009919395193951944
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.85,0.010807394023940237
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.9,0.011994554945549452
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.95,0.013818984789847893
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.975,0.015428445909459089
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,50,quantile,0.99,0.017385019530195236
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.15,3.8307983079830736e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.2,0.001099999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.25,0.001750002250022501
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.3,0.0022999999999999995
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.35,0.0027999999999999995
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.4,0.0032001476014760118
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.45,0.0036170358203582048
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.5,0.004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.55,0.004399999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.6,0.0048000000000000004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.65,0.005288503735037351
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.7,0.005799999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.75,0.006399999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.8,0.007099999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.85,0.007969266042660426
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.9,0.009131386913869138
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.95,0.011308280082800819
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.975,0.013520339753397528
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,51,quantile,0.99,0.015632375123751235
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.15,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.2,9.093960939609372e-5
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.25,4.583340833408337e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.3,8.583340833408313e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.35,0.0011583340833408336
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.4,0.0014932274322743229
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.45,0.00184082170821708
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.5,0.0021000000000000003
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.55,0.002458334083340827
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.6,0.002758334083340831
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.65,0.0030583340833408327
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.7,0.003410470704707046
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.75,0.003774210242102423
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.8,0.0042583340833408315
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.85,0.004758334083340832
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.9,0.0053583340833408336
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.95,0.0063451278012780065
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.975,0.007241643416434158
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,53,quantile,0.99,0.008158334083340832
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.05,1.5328908289082994e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.1,0.0022999999999999982
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.15,0.0040000000000000036
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.2,0.005300000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.25,0.006199999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.3,0.006869217892178919
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.35,0.0073999999999999995
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.4,0.00789953379533795
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.45,0.008299999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.5,0.0087
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.55,0.009099999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.6,0.0095
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.65,0.01
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.7,0.010550594905949059
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.75,0.01120890783907839
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.8,0.012104928449284498
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.85,0.013436954819548198
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.9,0.015184960849608489
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.95,0.017849182791827897
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.975,0.020099999999999996
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,54,quantile,0.99,0.022241323373233677
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.025,4.7205044550445934e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.05,0.001534419944199442
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.1,0.0028366519665196676
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.15,0.0036637651876518774
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.2,0.004291386913869139
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.25,0.004722506975069752
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.3,0.005160518405184052
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.35,0.005500000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.4,0.0058462694626946286
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.45,0.006199999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.5,0.006500000000000001
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.55,0.0068000000000000005
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.6,0.007138120781207813
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.65,0.0075
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.7,0.00784362523625236
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.75,0.008299999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.8,0.008726368463684644
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.85,0.009347637026370264
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.9,0.01017891278912789
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.95,0.011462086220862203
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.975,0.012569770722707227
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,55,quantile,0.99,0.01384822320223201
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.05,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.1,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.15,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.2,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.25,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.3,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.35,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.4,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.45,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.5,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.55,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.6,4.4367023670236513e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.65,0.0011095931959319624
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.7,0.0016000000000000007
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.75,0.0023860273602736006
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.8,0.003175609756097564
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.85,0.004292050220502203
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.9,0.005064908649086484
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.95,0.0071999999999999955
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.975,0.010376253712537113
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,56,quantile,0.99,0.013645312663126548
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.01,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.025,0
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.05,3.0000000000000165e-4
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.1,0.0013586526865268659
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.15,0.002039303393033931
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.2,0.0025999999999999986
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.25,0.0030999999999999977
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.3,0.0034999999999999988
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.35,0.0038000000000000004
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.4,0.004112011520115203
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.45,0.0044
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.5,0.004699999999999999
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.55,0.0049999999999999975
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.6,0.005272472324723244
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.65,0.005599999999999998
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.7,0.0059000000000000025
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.75,0.006303249032490324
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.8,0.0068000000000000005
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.85,0.007365870758707586
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.9,0.008035726757267573
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.95,0.009199999999999996
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.975,0.010182799702997028
+2025-12-20,1,wk inc covid prop ed visits,2025-12-27,US,quantile,0.99,0.011410437764377633
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.2,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.25,6.960669606696172e-5
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.3,8.55073350733505e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.35,0.0014984951849518493
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.4,0.002146138061380618
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.45,0.0027407744577445806
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.5,0.0033
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.55,0.003880526505265058
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.6,0.004518594185941857
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.65,0.005197016920169202
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.7,0.005969606696066963
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.75,0.00690548555485555
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.8,0.007969606696066965
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.85,0.009269606696066959
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.9,0.010946183061830638
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.95,0.013434554945549435
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.975,0.015669606696066957
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,01,quantile,0.99,0.018269375033750326
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.2,1.4669696696967185e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.25,9.240662406624105e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.3,0.0015639357393573941
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.35,0.0021862334623346286
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.4,0.002746696966969676
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.45,0.003346696966969671
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.5,0.0039000000000000003
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.55,0.004446696966969673
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.6,0.005041052110521103
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.65,0.005646696966969671
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.7,0.006268798487984874
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.75,0.006979576545765462
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.8,0.007777531275312757
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.85,0.008746696966969671
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.9,0.009985572855728563
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.95,0.011893724237242375
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.975,0.013584119116191165
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,02,quantile,0.99,0.015600276122761228
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.15,3.7243992439924255e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.2,0.0010921087210872087
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.25,0.00165310953109531
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.3,0.002153678336783367
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.35,0.0026000000000000003
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.4,0.003002655026550266
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.45,0.0034005377553775543
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.5,0.0038
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.55,0.004199999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.6,0.0046
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.65,0.005056131311313112
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.7,0.005500000000000003
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.75,0.006026170011700116
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.8,0.006668429484294852
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.85,0.007470706507065068
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.9,0.00864326253262533
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.95,0.011500063450634493
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.975,0.01389174714247142
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,04,quantile,0.99,0.015877683466834616
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.15,0.0010772522725227241
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.2,0.001999999999999994
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.25,0.0027237377373773726
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.3,0.0033999999999999985
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.35,0.003961274862748628
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.4,0.004499999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.45,0.005
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.5,0.0055000000000000005
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.55,0.006
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.6,0.006500000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.65,0.007046663216632169
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.7,0.007645708757087567
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.75,0.008299999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.8,0.009074329943299436
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.85,0.010043990639906398
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.9,0.01129825398253983
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.95,0.013169027540275402
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.975,0.014892478399784092
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,05,quantile,0.99,0.016929068670686703
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.2,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.25,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.3,1.9999999999999966e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.35,5.999999999999998e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.4,9.99999999999999e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.45,0.0013566623166231659
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.5,0.0017000000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.55,0.0020999999999999986
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.6,0.0024934929349293483
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.65,0.0028999999999999985
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.7,0.003332361623616231
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.75,0.0038301570515705146
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.8,0.004399999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.85,0.005099999999999997
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.9,0.006050391503915037
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.95,0.007582109621096216
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.975,0.009128122806228055
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,06,quantile,0.99,0.01087790108901088
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.05,6.724687246872509e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.1,0.0018090288902889089
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.15,0.002599999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.2,0.0031999999999999997
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.25,0.0036999999999999993
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.3,0.004100000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.35,0.004500000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.4,0.0049
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.45,0.00522065295652956
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.5,0.005600000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.55,0.0059683790837908425
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.6,0.006300000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.65,0.0067
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.7,0.0070999999999999995
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.75,0.0075048240482404735
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.8,0.008000000000000004
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.85,0.008600000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.9,0.009399999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.95,0.01057732382323822
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.975,0.011612415849158488
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,08,quantile,0.99,0.012832495364953643
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.05,2.525861758617547e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.1,0.0023999999999999994
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.15,0.0036999999999999993
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.2,0.00467215012150121
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.25,0.005430537305373051
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.3,0.006099999999999994
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.35,0.006682838628386278
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.4,0.007199999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.45,0.0077
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.5,0.008199999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.55,0.008699999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.6,0.009199999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.65,0.009730835658356581
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.7,0.010299999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.75,0.010966521915219152
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.8,0.011700000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.85,0.012671757717577167
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.9,0.014044160741607433
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.95,0.01629147421474214
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.975,0.018174253217532167
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,09,quantile,0.99,0.0202181100711007
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.15,3.653465034650309e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.2,0.0012231140311403084
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.25,0.001997864728647283
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.3,0.0026144307443074382
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.35,0.003199999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.4,0.0037889496894968934
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.45,0.004299999999999997
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.5,0.0048
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.55,0.005340947709477092
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.6,0.005878637386373857
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.65,0.0064
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.7,0.007002228422284217
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.75,0.007699999999999996
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.8,0.008469075690756906
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.85,0.00937835748357483
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.9,0.010686970569705698
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.95,0.012828329583295823
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.975,0.015
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,10,quantile,0.99,0.01740271829718293
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.2,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.25,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.3,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.35,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.4,5.045774457744608e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.45,0.0010068400684006818
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.5,0.0015
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.55,0.0020040788407884105
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.6,0.0025413824138241373
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.65,0.0030940149401493984
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.7,0.0036728854288542866
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.75,0.0042940149401494
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.8,0.005006292862928634
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.85,0.0058940149401494
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.9,0.007038020880208799
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.95,0.008850717757177556
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.975,0.010505709882098804
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,11,quantile,0.99,0.012486471514715129
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.2,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.25,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.3,1.0000000000000057e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.35,6.063801638016346e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.4,0.0011310341103411058
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.45,0.0016000000000000042
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.5,0.0021
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.55,0.002585711007110069
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.6,0.0030919233192331936
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.65,0.003600000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.7,0.004200000000000004
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.75,0.0049013297632976354
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.8,0.005696290162901635
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.85,0.006658999639996398
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.9,0.007965182251822526
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.95,0.00990593330933309
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.975,0.011696181486814857
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,12,quantile,0.99,0.01372128818288184
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.2,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.25,1.3864863648636194e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.3,6.880595805958058e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.35,0.0011619669696696965
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.4,0.0016000000000000003
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.45,0.0020000000000000005
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.5,0.0024
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.55,0.0027929214292142963
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.6,0.0031999999999999997
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.65,0.0036682008820088214
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.7,0.004200000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.75,0.004800000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.8,0.0055000000000000005
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.85,0.006300000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.9,0.007399999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.95,0.009199999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.975,0.010972156196561963
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,13,quantile,0.99,0.012974911529115282
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.2,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.25,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.3,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.35,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.4,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.45,5.021150211502157e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.5,0.0011999999999999997
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.55,0.0018757029070290733
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.6,0.002602115021150208
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.65,0.0033096624966249717
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.7,0.004100118801188062
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.75,0.0049203042030420314
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.8,0.005905959859598615
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.85,0.007069511295112953
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.9,0.008502115021150208
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.95,0.010665363603636024
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.975,0.012559441319413181
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,15,quantile,0.99,0.014793413554135533
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.1,3.6377283772837403e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.15,0.0013214098640986422
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.2,0.002063268832688327
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.25,0.00268769462694627
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.3,0.0032000000000000015
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.35,0.003700212852128522
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.4,0.0042
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.45,0.004654825848258486
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.5,0.0051
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.55,0.005558626136261362
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.6,0.006000000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.65,0.006499999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.7,0.006999999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.75,0.0075446449464494645
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.8,0.008198765187651877
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.85,0.008900000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.9,0.009899999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.95,0.01149451714517144
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.975,0.012911544190441895
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,16,quantile,0.99,0.014752559355593504
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.05,4.096030960309623e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.1,0.002171082710827113
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.15,0.003299999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.2,0.004100000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.25,0.0048
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.3,0.005366731167311672
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.35,0.005887059670596712
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.4,0.006315818558185582
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.45,0.006792968679686797
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.5,0.0072
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.55,0.007605111151111515
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.6,0.008093759337593374
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.65,0.008524545495454958
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.7,0.009026395463954628
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.75,0.0096
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.8,0.010273690936909368
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.85,0.01110173251732517
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.9,0.012274454144541444
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.95,0.0140531005310053
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.975,0.015542790027900264
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,17,quantile,0.99,0.017336475384753844
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.025,0.001056035235352358
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.05,0.00259611016110161
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.1,0.0044087669876698744
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.15,0.00564010620106201
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.2,0.006556565565655656
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.25,0.0072999999999999975
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.3,0.007915482854828546
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.35,0.008499999999999997
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.4,0.008999999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.45,0.009432782377823778
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.5,0.009899999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.55,0.010312366573665736
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.6,0.010799999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.65,0.011299999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.7,0.011862118621186205
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.75,0.012499999999999995
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.8,0.013237436774367745
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.85,0.014176984519845191
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.9,0.015411137611376115
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.95,0.01724731932319323
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.975,0.018816432364323628
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,18,quantile,0.99,0.0207532404824048
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.15,0.0010236270362703609
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.2,0.0019278966789667924
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.25,0.0026967982179821786
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.3,0.003319056790567908
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.35,0.003928718837188371
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.4,0.004499999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.45,0.004999999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.5,0.0055000000000000005
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.55,0.0060000000000000045
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.6,0.006543574835748357
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.65,0.0070999999999999995
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.7,0.007699999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.75,0.00835684006840068
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.8,0.009129437494374948
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.85,0.010079890648906485
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.9,0.011321529115291154
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.95,0.013508794437944357
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.975,0.015744333768337688
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,19,quantile,0.99,0.018273289262892706
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.1,9.573521735217355e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.15,0.002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.2,0.0028000000000000013
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.25,0.0034486094860948615
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.3,0.004
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.35,0.0045
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.4,0.004961393213932137
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.45,0.0053999999999999986
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.5,0.0058
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.55,0.006200000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.6,0.00665832778327783
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.65,0.0071
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.7,0.0076
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.75,0.008159103591035912
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.8,0.0088
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.85,0.009610944109441095
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.9,0.0107
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.95,0.01237501800018
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.975,0.013800000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,20,quantile,0.99,0.015538501665016618
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.05,2.2018720187207686e-5
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.1,0.0018990027900278978
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.15,0.00314630321303213
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.2,0.004137519575195755
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.25,0.004984114841148412
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.3,0.005693816038160382
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.35,0.006300000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.4,0.0069
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.45,0.007465437404374043
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.5,0.008
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.55,0.008516737917379178
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.6,0.009099999999999997
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.65,0.009685417604176043
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.7,0.010300000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.75,0.011016332913329131
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.8,0.011864732247322471
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.85,0.012873145081450812
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.9,0.014147909279092796
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.95,0.016008217082170824
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.975,0.017666173386733854
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,21,quantile,0.99,0.019607877868778684
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.2,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.25,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.3,3.7636756367563347e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.35,9.775564755647554e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.4,0.001539051390513902
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.45,0.002051926469264689
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.5,0.0026
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.55,0.003139051390513902
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.6,0.003699108991089904
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.65,0.004339051390513901
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.7,0.004986512465124647
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.75,0.005739051390513904
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.8,0.006651889118891182
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.85,0.007839051390513902
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.9,0.009339051390513905
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.95,0.0115390513905139
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.975,0.01345502182521824
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,22,quantile,0.99,0.015889519035190335
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.15,4.6254027540275496e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.2,0.001433172531725319
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.25,0.0022633201332013272
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.3,0.002974465844658442
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.35,0.003599999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.4,0.004199999999999997
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.45,0.004777054720547203
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.5,0.0053
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.55,0.005899999999999996
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.6,0.006459773197731979
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.65,0.007060830258302583
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.7,0.0077041121411214044
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.75,0.00844948924489245
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.8,0.0093
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.85,0.01039157096570965
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.9,0.011885756457564579
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.95,0.014172424174241737
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.975,0.01611624763747631
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,23,quantile,0.99,0.018394434884348814
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.2,6.80046800468003e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.25,0.0012999999999999973
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.3,0.0018721069210692093
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.35,0.0023999999999999937
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.4,0.0028909639096390918
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.45,0.0033701764017640135
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.5,0.0038
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.55,0.0042999999999999965
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.6,0.0047894806948069486
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.65,0.005299999999999996
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.7,0.0058
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.75,0.006399999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.8,0.007087687876878764
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.85,0.0079
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.9,0.009019162091620918
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.95,0.010748025830258292
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.975,0.01233602623526235
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,24,quantile,0.99,0.014208524975249763
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.1,0.0010029412294122974
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.15,0.0021182890828908346
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.2,0.0029847790477904815
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.25,0.003685597605976063
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.3,0.0042940383403834055
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.35,0.004802918729187296
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.4,0.005324228242282426
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.45,0.005800000000000005
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.5,0.0063
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.55,0.006772576725767261
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.6,0.0072590693906939095
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.65,0.007791854918549191
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.7,0.008329426694266945
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.75,0.008958808838088382
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.8,0.009658702187021875
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.85,0.010534027090270907
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.9,0.011667817478174788
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.95,0.013484324543245463
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.975,0.015056781792817924
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,25,quantile,0.99,0.016849474574745744
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.05,9.514751147511464e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.1,0.0028000000000000026
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.15,0.003964883898838988
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.2,0.004799999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.25,0.005456023310233103
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.3,0.006000000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.35,0.0065
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.4,0.006936891368913694
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.45,0.007399999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.5,0.0078000000000000005
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.55,0.008200000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.6,0.00864520385203852
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.65,0.0091
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.7,0.0096
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.75,0.010163560885608857
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.8,0.010809855098550987
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.85,0.01165614841148411
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.9,0.01279166051660517
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.95,0.014717131221312211
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.975,0.016300000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,26,quantile,0.99,0.018079033480334794
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.05,7.150495004950031e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.1,0.0022982008820088195
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.15,0.0032763027630276238
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.2,0.004039612996129962
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.25,0.004685892358923587
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.3,0.005200000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.35,0.005718483034830349
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.4,0.0062
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.45,0.006687398523985241
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.5,0.0070999999999999995
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.55,0.00755542975429754
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.6,0.008
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.65,0.008494502295022948
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.7,0.008990427504275044
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.75,0.009524012240122401
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.8,0.010182424624246244
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.85,0.010910108901089026
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.9,0.011906302763027624
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.95,0.013499999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.975,0.01496442534425344
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,27,quantile,0.99,0.016789269192691927
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.15,8.812798127981305e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.2,0.0020051588515885184
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.25,0.0030208329583295878
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.3,0.003888909189091889
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.35,0.0046812798127981265
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.4,0.005281279812798129
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.45,0.005881279812798126
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.5,0.0064
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.55,0.0069566425164251655
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.6,0.007507525875258748
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.65,0.008181279812798127
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.7,0.008948127981279811
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.75,0.009851082260822609
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.8,0.010869934299343
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.85,0.011989357393573931
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.9,0.013539449194491944
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.95,0.015889786697866976
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.975,0.01812351408514086
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,28,quantile,0.99,0.020991028350283488
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.05,8.000171001709982e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.1,0.002498475384753848
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.15,0.003555113851138515
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.2,0.004334770947709476
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.25,0.005
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.3,0.005599999999999996
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.35,0.006099999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.4,0.006599999999999996
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.45,0.007058306633066331
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.5,0.0075
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.55,0.007999999999999993
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.6,0.008427147871478718
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.65,0.008900000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.7,0.009408799387993876
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.75,0.009999999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.8,0.010664867248672485
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.85,0.011463865988659883
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.9,0.012518607686076872
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.95,0.0142
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.975,0.01579789060390603
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,30,quantile,0.99,0.017600297452974544
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.1,9.999999999999807e-5
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.15,0.001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.2,0.0017703339033390319
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.25,0.0023999999999999985
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.3,0.002926331563315632
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.35,0.0034000000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.4,0.0038569273692736885
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.45,0.004242430024300246
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.5,0.0046
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.55,0.004999999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.6,0.005394715147151468
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.65,0.005799999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.7,0.0062943677436774394
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.75,0.006812404374043742
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.8,0.007474756547565477
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.85,0.008206640716407166
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.9,0.009176275762757632
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.95,0.010553691836918355
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.975,0.011801399513995134
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,31,quantile,0.99,0.01341901917019169
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.2,1.0205202052020633e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.25,5.790275402753976e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.3,9.193150931509297e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.35,0.001299999999999996
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.4,0.0015999999999999973
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.45,0.001899999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.5,0.0022
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.55,0.002530640806408065
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.6,0.0028754387543875404
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.65,0.0031999999999999967
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.7,0.003576411664116635
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.75,0.003953723787237866
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.8,0.004399999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.85,0.004956750967509671
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.9,0.005665989559895598
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.95,0.00676037485374853
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.975,0.007744721447214469
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,32,quantile,0.99,0.008899999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.1,0.0010456574565745683
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.15,0.002458874088740883
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.2,0.003499999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.25,0.004315225902259022
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.3,0.0050049842498425
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.35,0.005632446674466744
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.4,0.006200000000000004
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.45,0.006791883718837188
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.5,0.0073
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.55,0.007841363513635138
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.6,0.0084
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.65,0.008964456394563947
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.7,0.009600000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.75,0.0103
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.8,0.011155678156781573
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.85,0.012200000000000003
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.9,0.0136089136891369
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.95,0.015720626856268568
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.975,0.017700391953919533
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,33,quantile,0.99,0.020086682026820266
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.1,3.7936099360993193e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.15,0.0013063536135361335
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.2,0.0020522689226892257
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.25,0.0026568670686706835
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.3,0.00316940509405094
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.35,0.0035999999999999986
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.4,0.0040031590315903155
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.45,0.004401274862748625
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.5,0.0048
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.55,0.005199999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.6,0.005599999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.65,0.005999999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.7,0.00647673836738367
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.75,0.0069926491764917545
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.8,0.007588796687966878
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.85,0.008302911979119792
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.9,0.009306465664656646
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.95,0.010905329403294022
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.975,0.012392342498424976
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,34,quantile,0.99,0.014161727117271176
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.025,1.6423814238142996e-5
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.05,0.0016862820628206266
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.1,0.003599999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.15,0.004899999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.2,0.005899999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.25,0.006760257852578525
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.3,0.007499999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.35,0.008199999999999995
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.4,0.008811446314463142
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.45,0.009417267572675726
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.5,0.01
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.55,0.010599999999999997
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.6,0.0112
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.65,0.011836273512735121
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.7,0.012500000000000004
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.75,0.013264193141931419
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.8,0.0141
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.85,0.015100000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.9,0.016399999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.95,0.018283099630996308
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.975,0.0199084792097921
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,35,quantile,0.99,0.021812199171991703
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.1,7.464683646836491e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.15,0.0015000000000000013
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.2,0.002100000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.25,0.002627227522275224
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.3,0.0030914013140131416
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.35,0.003432145171451714
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.4,0.003799999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.45,0.0040999999999999995
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.5,0.0044
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.55,0.004700000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.6,0.005000000000000003
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.65,0.005393454684546846
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.7,0.0057579812798128
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.75,0.0062
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.8,0.006700000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.85,0.0073
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.9,0.008099999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.95,0.009430216002159982
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.975,0.010794336693366898
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,36,quantile,0.99,0.012476913329133258
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.2,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.25,1.1070110701112625e-5
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.3,7.42715327153272e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.35,0.0013850180001800032
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.4,0.0020337161371613726
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.45,0.0026128917289172924
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.5,0.0032000000000000006
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.55,0.003768336783367832
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.6,0.004391199711997121
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.65,0.005046817118171193
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.7,0.005749674196741967
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.75,0.0065372963729637325
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.8,0.007425509855098559
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.85,0.008536283862838626
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.9,0.010025865358653593
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.95,0.012372433624336323
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.975,0.014706042660426605
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,37,quantile,0.99,0.017666213662136547
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.15,4.3874943749437574e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.2,0.0013579128791287932
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.25,0.0021377846278462782
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.3,0.0028327243272432733
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.35,0.0034886373863738636
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.4,0.004085854558545589
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.45,0.004651387813878144
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.5,0.0052
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.55,0.005788637386373864
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.6,0.006345075150751509
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.65,0.006923773737737377
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.7,0.007588637386373865
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.75,0.008297765727657279
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.8,0.009109369993699937
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.85,0.010088637386373863
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.9,0.011313456934569352
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.95,0.013255283052830528
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.975,0.015033465484654838
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,38,quantile,0.99,0.017141727387273854
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.025,7.963160381603793e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.05,0.0023015916659166573
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.1,0.004068967689676896
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.15,0.005150765457654574
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.2,0.005977042570425705
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.25,0.0066
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.3,0.007137294572945728
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.35,0.007604446044460446
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.4,0.008092546125461257
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.45,0.008499999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.5,0.0089
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.55,0.009300000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.6,0.009714335343353434
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.65,0.010179428044280441
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.7,0.010628109981099813
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.75,0.011195736207362071
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.8,0.011810715507155067
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.85,0.012648982539825396
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.9,0.013776556565565657
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.95,0.015479444694446941
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.975,0.017053847313473113
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,39,quantile,0.99,0.01890013725137251
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.1,6.999999999999992e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.15,0.0018000000000000017
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.2,0.0026336081360813627
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.25,0.003362534875348753
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.3,0.003949645396453964
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.35,0.004499999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.4,0.004987846278462781
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.45,0.005429968049680496
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.5,0.0059
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.55,0.00638473404734047
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.6,0.006834767347673478
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.65,0.007344047340473408
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.7,0.007899999999999997
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.75,0.008487429124291243
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.8,0.00915105211052111
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.85,0.010000000000000005
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.9,0.011197821978219787
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.95,0.012989999549995477
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.975,0.01459239042390424
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,40,quantile,0.99,0.01639924264242642
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.2,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.25,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.3,4.826010260102579e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.35,8.999999999999993e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.4,0.0013000000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.45,0.001700000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.5,0.0021
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.55,0.0024999999999999996
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.6,0.0028999999999999994
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.65,0.003300000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.7,0.003796516065160649
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.75,0.004299999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.8,0.004863758437584376
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.85,0.0055590936909369094
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.9,0.0064687687876878765
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.95,0.00792166141661416
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.975,0.0092
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,41,quantile,0.99,0.010733447304473035
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.05,9.701584015840158e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.1,0.0022683313833138357
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.15,0.0031
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.2,0.0037269534695346957
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.25,0.004284175591755917
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.3,0.004700000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.35,0.005101146611466113
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.4,0.0055000000000000005
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.45,0.0058793092430924326
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.5,0.0062
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.55,0.006554766897668981
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.6,0.0069
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.65,0.007299999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.7,0.007699999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.75,0.008141474664746646
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.8,0.008655172351723526
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.85,0.009299999999999996
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.9,0.010102513725137256
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.95,0.011406458464584641
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.975,0.012630266402664025
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,42,quantile,0.99,0.014
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.15,8.2241742417424e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.2,0.001599999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.25,0.0022610161101610984
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.3,0.0028161794617946154
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.35,0.003321832418324183
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.4,0.0037999999999999996
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.45,0.004293375483754837
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.5,0.004699999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.55,0.005167619026190251
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.6,0.005599999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.65,0.006099999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.7,0.006599999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.75,0.007199999999999997
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.8,0.007852960129601298
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.85,0.008664785347853483
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.9,0.009748273782737831
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.95,0.01153941859418594
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.975,0.013124717397173951
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,44,quantile,0.99,0.01498287399873998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.2,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.25,3.9999999999999823e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.3,0.0011999999999999958
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.35,0.001916432814328138
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.4,0.0025999999999999973
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.45,0.003205432454324541
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.5,0.0038
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.55,0.004417655926559263
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.6,0.005077647376473765
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.65,0.005795440554405557
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.7,0.006589853298532981
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.75,0.007451127261272611
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.8,0.008495701557015569
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.85,0.0097
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.9,0.011267522275222751
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.95,0.0136613720637206
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.975,0.015884562820628185
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,45,quantile,0.99,0.018467697506975064
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.2,5.710062100620954e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.25,0.0011955404554045523
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.3,0.0017710062100621017
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.35,0.0023170025200251985
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.4,0.002832822428224281
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.45,0.0033277450274502747
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.5,0.0038
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.55,0.0042822716227162265
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.6,0.004780503105031044
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.65,0.005289893798937998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.7,0.005871006210062096
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.75,0.006471006210062096
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.8,0.007134096840968407
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.85,0.007964708847088471
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.9,0.00900711637116371
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.95,0.010648043380433793
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.975,0.012093082755827557
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,46,quantile,0.99,0.0137620467104671
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.1,0.0013000000000000021
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.15,0.0024686085860858636
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.2,0.003386516065160652
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.25,0.004136166861668621
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.3,0.0048
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.35,0.0053315417154171565
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.4,0.005870220502205022
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.45,0.006321794617946183
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.5,0.0068000000000000005
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.55,0.007243974439744397
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.6,0.007709264692646928
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.65,0.008226544415444157
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.7,0.008800000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.75,0.009437003870038698
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.8,0.010206498064980663
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.85,0.011148181531815318
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.9,0.012304675546755467
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.95,0.014002515525155265
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.975,0.0155
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,47,quantile,0.99,0.017478089370893724
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.2,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.25,3.999999999999996e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.3,0.0010424102241022432
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.35,0.001654985599855997
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.4,0.0022000000000000006
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.45,0.0027000000000000014
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.5,0.0032
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.55,0.0037000000000000006
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.6,0.004212186121861221
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.65,0.0048000000000000004
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.7,0.005447783277832779
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.75,0.006200000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.8,0.007099999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.85,0.008172443074430737
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.9,0.00957774007740078
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.95,0.01167574475744758
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.975,0.013440660831608315
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,48,quantile,0.99,0.015679022140221377
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.2,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.25,4.207317073170628e-5
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.3,5.889640896408953e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.35,0.0010373143731437313
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.4,0.0015000000000000013
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.45,0.0019768414184141896
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.5,0.0024
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.55,0.0028203645036450377
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.6,0.003299999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.65,0.003769298442984432
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.7,0.00429541535415354
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.75,0.004836808118081187
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.8,0.005499999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.85,0.0063
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.9,0.0073282773827738415
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.95,0.008972515075150725
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.975,0.01050543470434704
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,49,quantile,0.99,0.012299999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.15,0.001198997839978403
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.2,0.002239256592565928
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.25,0.003110246602466026
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.3,0.0039000000000000007
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.35,0.004600000000000003
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.4,0.005284966249662496
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.45,0.005900000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.5,0.006500000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.55,0.007100000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.6,0.0077528539285392824
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.65,0.008411339663396635
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.7,0.009138604086040848
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.75,0.009926705517055172
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.8,0.010818745387453881
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.85,0.011899999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.9,0.013289623796237961
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.95,0.015402493474934763
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.975,0.017317647601476013
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,50,quantile,0.99,0.01952360345603451
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.2,2.300918009180066e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.25,0.001012098370983709
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.3,0.0017217442174421714
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.35,0.0023300918009180067
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.4,0.002924706147061468
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.45,0.0034354428044280454
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.5,0.004
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.55,0.004530091800918007
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.6,0.005101212312123115
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.65,0.005683239582395831
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.7,0.006330091800918011
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.75,0.007074738997389966
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.8,0.007930091800918007
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.85,0.008989105841058408
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.9,0.010426127261272615
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.95,0.012900484654846542
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.975,0.015052556250562482
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,51,quantile,0.99,0.01755675393753937
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.2,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.25,2.5913509135095134e-5
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.3,5.000000000000013e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.35,9.000000000000037e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.4,0.0013000000000000038
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.45,0.0017000000000000027
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.5,0.0021
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.55,0.002491800918009183
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.6,0.0028430906309063154
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.65,0.0032781522815228167
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.7,0.003700000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.75,0.004175821258212582
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.8,0.004700000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.85,0.005300000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.9,0.006099999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.95,0.00728378408784088
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.975,0.008300000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,53,quantile,0.99,0.009506957339573399
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.1,8.519287192871919e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.15,0.002599999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.2,0.004017155971559715
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.25,0.0051732202322023225
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.3,0.006070066600666002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.35,0.006823897938979393
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.4,0.007499999999999998
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.45,0.0081
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.5,0.0087
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.55,0.009299999999999996
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.6,0.009899999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.65,0.010594771847718473
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.7,0.011395388353883536
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.75,0.012315927909279092
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.8,0.01347065610656107
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.85,0.014877194221942218
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.9,0.01671062640626408
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.95,0.019597687426874278
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.975,0.021981906444064423
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,54,quantile,0.99,0.02479282368823686
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.05,5.192471424714255e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.1,0.0019924048240482425
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.15,0.0029000000000000024
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.2,0.003649475294752948
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.25,0.004247932229322295
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.3,0.004765521555215549
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.35,0.005200000000000005
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.4,0.0056656448564485675
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.45,0.0060999999999999995
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.5,0.006500000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.55,0.006900000000000002
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.6,0.007320399603996041
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.65,0.00779381513815138
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.7,0.008229591395913963
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.75,0.008770850958509588
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.8,0.009348821888218886
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.85,0.010079265142651424
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.9,0.011029971199712009
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.95,0.012499999999999997
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.975,0.013819180541805426
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,55,quantile,0.99,0.01533763981639813
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.1,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.15,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.2,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.25,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.3,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.35,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.4,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.45,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.5,8.325083250890339e-8
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.55,6.791242912429146e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.6,0.0012791242912429134
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.65,0.00177912429124291
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.7,0.0025791242912429108
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.75,0.0033061583115831235
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.8,0.004279124291242916
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.85,0.005079124291242914
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.9,0.006598161281612823
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.95,0.009421871568715677
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.975,0.011939071415714141
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,56,quantile,0.99,0.015215019350193506
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.01,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.025,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.05,0
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.1,5.99999999999999e-4
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.15,0.0014049090990909904
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.2,0.0020708901089010892
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.25,0.002600000000000001
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.3,0.0030999999999999986
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.35,0.003520164251642512
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.4,0.003930711907119068
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.45,0.00430161686616866
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.5,0.004699999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.55,0.005099999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.6,0.005486951669516696
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.65,0.005887977679776798
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.7,0.0063
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.75,0.006799999999999999
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.8,0.007340322203222032
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.85,0.007999999999999997
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.9,0.008839874898748991
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.95,0.010138766087660851
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.975,0.011283429934299323
+2025-12-20,2,wk inc covid prop ed visits,2026-01-03,US,quantile,0.99,0.012666644316443163
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.25,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.3,2.199702997030002e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.35,0.0010555206552065452
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.4,0.0018162793627936294
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.45,0.0025738052380523814
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.5,0.0033
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.55,0.0040266357663576655
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.6,0.0048000000000000004
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.65,0.005630534155341557
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.7,0.006580390603906039
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.75,0.007602756277562767
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.8,0.00884248942489426
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.85,0.010260472954729543
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.9,0.012100927909279099
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.95,0.014876139411394082
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.975,0.017399999999999995
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,01,quantile,0.99,0.02042706534065341
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.25,3.238164881648843e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.3,0.0011181963819638196
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.35,0.0018636139861398543
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.4,0.0025637701377013784
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.45,0.0032304347043470463
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.5,0.0039000000000000003
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.55,0.004532367923679236
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.6,0.005202560525605259
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.65,0.005906416164161645
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.7,0.006666075960759604
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.75,0.007475540005400055
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.8,0.008402560525605257
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.85,0.009502560525605254
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.9,0.010902778327783282
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.95,0.013066847268472659
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.975,0.01496236927369271
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,02,quantile,0.99,0.01740637962379623
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.2,4.895058950589487e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.25,0.0011895058950589532
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.3,0.0017895058950589517
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.35,0.0023480505805058044
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.4,0.0028602646026460246
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.45,0.0033374957249572472
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.5,0.0038
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.55,0.004289505895058951
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.6,0.00478950589505895
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.65,0.005296217712177124
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.7,0.005889505895058949
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.75,0.00649342543425434
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.8,0.007278392583925842
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.85,0.008249682296822967
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.9,0.009764045540455405
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.95,0.012665914409144089
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.975,0.014899696246962468
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,04,quantile,0.99,0.01724188101881019
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.15,3.2157996579965624e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.2,0.001347693276932769
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.25,0.002199999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.3,0.0029652236522365225
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.35,0.0036527351273512735
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.4,0.004299999999999998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.45,0.004900000000000003
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.5,0.0055000000000000005
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.55,0.0061102925029250296
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.6,0.0067381171811718085
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.65,0.007375245702457027
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.7,0.008068397983979833
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.75,0.008845749707497078
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.8,0.009761184411844119
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.85,0.01082263387633876
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.9,0.012191757717577186
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.95,0.014300054450544495
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.975,0.016288049905499015
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,05,quantile,0.99,0.01848086427864279
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.25,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.3,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.35,3.453919539195353e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.4,7.899621996219971e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.45,0.0012453919539195364
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.5,0.0017000000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.55,0.002145391953919536
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.6,0.0026281297812978076
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.65,0.0030878710287102875
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.7,0.003632391323913229
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.75,0.004200873008730081
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.8,0.004851031410314105
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.85,0.005659218792187912
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.9,0.006751065610656105
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.95,0.008512358473584723
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.975,0.010100774457744578
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,06,quantile,0.99,0.011869420934209321
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.1,0.001206368463684635
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.15,0.0021000000000000003
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.2,0.002777708577085767
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.25,0.003337145621456212
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.3,0.003864661146611454
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.35,0.004300495904959049
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.4,0.004759186391863922
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.45,0.0052
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.5,0.005600000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.55,0.006008308433084334
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.6,0.006457413374133742
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.65,0.0069
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.7,0.007351070110701103
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.75,0.00786478939789398
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.8,0.008425400054000547
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.85,0.009100000000000004
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.9,0.009999999999999995
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.95,0.011287744127441279
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.975,0.012434708622086225
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,08,quantile,0.99,0.013853141121411248
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.1,0.0014041283412834058
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.15,0.002890613806138058
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.2,0.00397511475114751
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.25,0.00486459814598145
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.3,0.005657023670236697
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.35,0.006344269192691919
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.4,0.006999999999999996
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.45,0.007600000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.5,0.008199999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.55,0.00881142966429664
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.6,0.009421618216182159
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.65,0.010080487804878056
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.7,0.010750709207092065
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.75,0.01150413554135541
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.8,0.012417191971919716
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.85,0.013530841058410561
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.9,0.015068986589865893
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.95,0.017422411124111234
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.975,0.019461667041670412
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,09,quantile,0.99,0.02183857834578346
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.2,5.50394203942037e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.25,0.001419680946809467
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.3,0.0021777652776527783
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.35,0.002894855998559982
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.4,0.0035618801188011875
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.45,0.004177765277652777
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.5,0.004799999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.55,0.005415707407074071
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.6,0.0060597110971109674
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.65,0.006699061740617404
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.7,0.007429707497075005
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.75,0.00819057465574654
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.8,0.009108099180991808
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.85,0.01022768337683376
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.9,0.011726264062640622
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.95,0.014099181891818918
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.975,0.0163339874898749
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,10,quantile,0.99,0.018958770587705877
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.25,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.3,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.35,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.4,3.118018180181783e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.45,8.978260282602819e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.5,0.0015
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.55,0.0021176743767437624
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.6,0.002733310233102331
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.65,0.003348386733867341
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.7,0.0040385788857888565
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.75,0.004791195661956623
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.8,0.005618474484744845
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.85,0.006635745207452068
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.9,0.007962972729727298
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.95,0.010038578885788851
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.975,0.011863343533435324
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,11,quantile,0.99,0.01406023499234991
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.25,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.3,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.35,2.821883718837194e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.4,9.36086760867615e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.45,0.001542253172531726
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.5,0.0020999999999999994
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.55,0.0027101917019170182
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.6,0.0033151111511115086
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.65,0.0039640086400864
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.7,0.004664008640086405
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.75,0.0054640086400864
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.8,0.006364008640086403
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.85,0.007463331833318331
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.9,0.0088640086400864
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.95,0.01104583790837908
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.975,0.013008899963999643
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,12,quantile,0.99,0.015319130501304998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.25,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.3,2.874628746287488e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.35,8.874628746287482e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.4,0.0014113293132931347
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.45,0.0019009697596976015
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.5,0.0024
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.55,0.0028913482134821393
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.6,0.0034358869588695918
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.65,0.003987462874628749
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.7,0.004611813518135185
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.75,0.005287462874628749
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.8,0.0060747259472594805
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.85,0.007020223652236523
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.9,0.008273598235982364
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.95,0.010288140581405817
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.975,0.012158501035010347
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,13,quantile,0.99,0.01442148690486905
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.25,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.3,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.35,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.4,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.45,4.0268247682477353e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.5,0.0012000000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.55,0.0020011583115831155
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.6,0.002850846008460084
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.65,0.0037097668976689775
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.7,0.0046073773737737465
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.75,0.005595461704617047
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.8,0.006706342363423648
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.85,0.008019571145711463
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.9,0.009695625956259554
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.95,0.012206481864818642
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.975,0.014404234542345422
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,15,quantile,0.99,0.01695249482494824
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.15,6.982962829628287e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.2,0.0015286130861308618
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.25,0.002249234992349916
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.3,0.002899999999999998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.35,0.003499999999999997
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.4,0.004057847178471787
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.45,0.004599999999999995
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.5,0.0051
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.55,0.005630546305463049
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.6,0.006196590765907657
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.65,0.006751081810818104
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.7,0.0073289379893799024
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.75,0.007985431104311037
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.8,0.008701141211412116
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.85,0.009581383313833134
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.9,0.010699999999999994
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.95,0.012487577175771751
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.975,0.014090259427594256
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,16,quantile,0.99,0.01594711718117178
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.1,0.0013345432454324566
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.15,0.0025835163351633473
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.2,0.0035307209072090715
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.25,0.004300000000000002
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.3,0.004988333183331835
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.35,0.00559954414544145
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.4,0.006145328053280531
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.45,0.006687980379803798
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.5,0.0072
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.55,0.0077107614076140744
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.6,0.008264143641436409
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.65,0.008799999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.7,0.0094
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.75,0.010099999999999998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.8,0.010872072720727204
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.85,0.011824537845378458
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.9,0.013109936099361006
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.95,0.015012052020520205
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.975,0.016661757267572668
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,17,quantile,0.99,0.018720663216632107
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.05,0.0015634542345423393
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.1,0.003568384483844838
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.15,0.004911523265232649
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.2,0.005931281612816133
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.25,0.006792655926559272
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.3,0.007509472594725945
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.35,0.008161467464674645
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.4,0.008776571865718657
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.45,0.009320934209342092
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.5,0.009899999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.55,0.010439037890378906
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.6,0.011026443164431635
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.65,0.011631287912879129
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.7,0.012309472594725946
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.75,0.01304628296282963
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.8,0.013909472594725943
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.85,0.014930763207632074
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.9,0.01626183151831518
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.95,0.01828338448384484
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.975,0.02007035550355503
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,18,quantile,0.99,0.02227157555575552
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.15,2.497880478804808e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.2,0.001299288992889926
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.25,0.0021423071730717357
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.3,0.0029156745567455724
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.35,0.0036063072630726292
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.4,0.004291061110611108
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.45,0.004899288992889931
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.5,0.0055
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.55,0.006119375393753942
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.6,0.006766670866708664
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.65,0.0074211434614346134
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.7,0.00810450004500045
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.75,0.008900573755737558
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.8,0.00980034020340204
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.85,0.010895168751687511
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.9,0.012363805238052392
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.95,0.014826239312393116
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.975,0.01712749549995498
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,19,quantile,0.99,0.019795349473494726
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.1,1.6321663216631576e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.15,0.0013282769327693277
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.2,0.0022478552785527876
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.25,0.0029999999999999975
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.3,0.003651674916749165
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.35,0.0042407186571865665
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.4,0.004799999999999996
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.45,0.005299999999999997
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.5,0.0058
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.55,0.006302913779137791
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.6,0.00684133921339213
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.65,0.007399999999999996
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.7,0.007980666006660059
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.75,0.008633754837548375
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.8,0.009398856988569888
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.85,0.01028889343893439
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.9,0.011472923229232289
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.95,0.013314949599495996
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.975,0.014876763567635669
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,20,quantile,0.99,0.016837137071370703
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.1,9.960543605436081e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.15,0.0023999999999999994
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.2,0.0034682602826028226
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.25,0.004399999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.3,0.00521853118531185
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.35,0.005979370893708952
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.4,0.006690045900459005
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.45,0.007360653406534064
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.5,0.008
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.55,0.008620531905319055
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.6,0.009300000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.65,0.010000000000000004
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.7,0.01076062100621006
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.75,0.011591461164611645
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.8,0.01253569075690757
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.85,0.013681300063000628
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.9,0.015071610116101163
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.95,0.01717736657366573
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.975,0.01911258055080547
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,21,quantile,0.99,0.021322500945009402
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.25,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.3,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.35,5.774232742327425e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.4,0.0012774232742327417
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.45,0.0019697268472684743
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.5,0.0026
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.55,0.0032774232742327405
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.6,0.003969153991539918
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.65,0.00469153271532716
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.7,0.0054774232742327445
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.75,0.006382998829988303
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.8,0.007443284132841347
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.85,0.008703397083970835
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.9,0.010340340203402014
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.95,0.012778748987489869
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.975,0.015030040725407237
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,22,quantile,0.99,0.017659539375393746
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.2,6.660030600306012e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.25,0.0016235442354423481
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.3,0.0024744127441274377
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.35,0.003249798397983975
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.4,0.003969275492754913
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.45,0.0046482557825578245
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.5,0.0053
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.55,0.00597441274412744
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.6,0.006680009000089998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.65,0.0074091643416434125
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.7,0.008207623076230757
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.75,0.009074412744127435
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.8,0.010074412744127442
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.85,0.011315380703807037
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.9,0.012930498604986043
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.95,0.015367479524795257
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.975,0.017520260552605506
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,23,quantile,0.99,0.02016560318603188
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.2,5.180631806318634e-5
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.25,7.88416884168846e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.3,0.0014602106021060263
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.35,0.002072099270992715
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.4,0.0026602106021060266
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.45,0.0032540882908829076
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.5,0.0037999999999999996
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.55,0.004360210602106025
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.6,0.004960210602106018
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.65,0.005560210602106019
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.7,0.006162409324093244
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.75,0.006860210602106027
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.8,0.007639724597245982
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.85,0.00858469354693548
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.9,0.009836019260192603
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.95,0.011714334893348938
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.975,0.013425382278822782
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,24,quantile,0.99,0.015514163171631708
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.1,1.4823148231482604e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.15,0.001400801458014567
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.2,0.0023587975879758773
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.25,0.0031474169741697398
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.3,0.003885446854468548
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.35,0.004518806138061381
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.4,0.0051462424624246226
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.45,0.005717740077400775
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.5,0.0063
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.55,0.006876180811808118
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.6,0.007459177391773923
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.65,0.008060366303663039
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.7,0.008700000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.75,0.00944883448834488
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.8,0.010279845198451983
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.85,0.011265317253172528
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.9,0.012549684096840968
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.95,0.014550113851138516
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.975,0.01624985419854199
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,25,quantile,0.99,0.018384557825578247
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.05,2.981555974335926e-18
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.1,0.001953809738097383
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.15,0.003205513455134548
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.2,0.004186102061020611
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.25,0.004944822698226981
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.3,0.0056102349023490206
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.35,0.0062000000000000015
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.4,0.006760914409144094
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.45,0.007299999999999996
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.5,0.0078000000000000005
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.55,0.008300000000000004
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.6,0.008814979749797502
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.65,0.009399999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.7,0.009999999999999997
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.75,0.010644516695166957
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.8,0.011411565115651154
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.85,0.01236579875798758
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.9,0.013651450814508146
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.95,0.015698397983979838
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.975,0.017428820988209883
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,26,quantile,0.99,0.01944072288722886
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.1,0.0014958194581945743
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.15,0.002612291872918726
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.2,0.003499999999999998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.25,0.004243211682116821
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.3,0.004900000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.35,0.005499999999999997
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.4,0.00603791377913779
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.45,0.006599773197731973
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.5,0.0070999999999999995
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.55,0.007635554855548555
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.6,0.008173413734137337
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.65,0.008719119341193415
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.7,0.009307800378003777
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.75,0.009976557015570157
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.8,0.010699999999999998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.85,0.011553291782917828
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.9,0.0127
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.95,0.014493433084330834
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.975,0.016122843803438036
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,27,quantile,0.99,0.018076054450544502
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.2,0.0012707407074070737
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.25,0.0023629938799388053
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.3,0.0033105139051390494
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.35,0.0041821406714067115
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.4,0.004970740707407076
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.45,0.005688858788587884
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.5,0.0064
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.55,0.007110917559175596
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.6,0.007842665826658263
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.65,0.008625351453514535
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.7,0.00950711097110971
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.75,0.010496348213482134
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.8,0.011609914499144997
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.85,0.012958828188281877
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.9,0.014670740707407079
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.95,0.017381225812258108
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.975,0.019858762037620388
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,28,quantile,0.99,0.022899743677436756
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.1,0.0016172027720277183
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.15,0.0028286945369453685
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.2,0.0037815426154261507
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.25,0.004564451894518938
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.3,0.005212421924219239
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.35,0.005838218432184324
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.4,0.006400000000000002
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.45,0.006975160651606511
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.5,0.0075
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.55,0.008054968949689491
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.6,0.0086
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.65,0.009199999999999996
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.7,0.0098
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.75,0.010468020430204297
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.8,0.0112380091800918
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.85,0.01217086310863108
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.9,0.013359181891818922
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.95,0.015264049590495897
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.975,0.016929377418774177
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,30,quantile,0.99,0.018981238592385912
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.15,4.277855278552742e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.2,0.001277519575195751
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.25,0.001976417514175138
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.3,0.002599999999999998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.35,0.003143828188281879
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.4,0.003663025830258301
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.45,0.0041380168301683
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.5,0.0046
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.55,0.005099999999999997
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.6,0.005584842048420479
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.65,0.006099999999999997
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.7,0.006643522635226346
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.75,0.007258451084510846
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.8,0.007948497884978853
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.85,0.008799999999999997
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.9,0.009839963099630995
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.95,0.011456633516335163
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.975,0.012903795337953373
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,31,quantile,0.99,0.014676468364683644
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.25,2.4569345693456794e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.3,6.784222842228411e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.35,0.0010784222842228418
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.4,0.0014784222842228406
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.45,0.0018638092880928787
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.5,0.0022000000000000006
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.55,0.0025784222842228414
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.6,0.0029784222842228376
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.65,0.0033784222842228383
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.7,0.00377842228422284
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.75,0.004256491314913149
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.8,0.004778422284222841
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.85,0.005382171721717215
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.9,0.006194539645396453
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.95,0.007432195571955717
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.975,0.008511779542795432
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,32,quantile,0.99,0.009833657096570967
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.1,4.255062550625453e-5
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.15,0.0015923031230312308
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.2,0.0027309585095850897
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.25,0.0037034110341103398
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.3,0.0045577085770857695
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.35,0.005299999999999998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.4,0.0059999999999999975
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.45,0.006660414004140043
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.5,0.0073
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.55,0.007973782287822877
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.6,0.008630911709117091
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.65,0.009329257492574928
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.7,0.010099999999999998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.75,0.010938542885428856
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.8,0.011899999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.85,0.013066707317073168
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.9,0.014608631086310865
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.95,0.016921885968859674
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.975,0.019163820538205364
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,33,quantile,0.99,0.021849080010800048
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.15,6.935658356583541e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.2,0.0015090324903249048
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.25,0.0022
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.3,0.002800000000000003
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.35,0.003361392313923134
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.4,0.0038559607596075967
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.45,0.004343358833588333
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.5,0.0048
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.55,0.005299999999999998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.6,0.00577960579605794
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.65,0.006274072090720905
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.7,0.006799999999999998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.75,0.0073999999999999995
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.8,0.008100000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.85,0.008964991449914507
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.9,0.010097206372063707
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.95,0.01186538520385204
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.975,0.013490798532985314
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,34,quantile,0.99,0.015406961659616605
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.05,4.820200702007009e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.1,0.002617794077940776
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.15,0.0040747898478984785
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.2,0.005198559085590858
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.25,0.006173310233102329
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.3,0.007047505175051754
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.35,0.007834446944469442
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.4,0.008573310233102328
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.45,0.009283674736747377
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.5,0.01
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.55,0.010684964449644497
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.6,0.011373310233102334
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.65,0.01212235982359824
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.7,0.012917731977319769
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.75,0.013785410854108539
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.8,0.014741179911799122
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.85,0.015862494374943744
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.9,0.017279621096210968
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.95,0.01948229862298623
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.975,0.02139757267572675
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,35,quantile,0.99,0.023416908289082893
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.1,1.3522545225452088e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.15,0.001018945639456392
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.2,0.0017000000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.25,0.002291301413014127
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.3,0.002799999999999996
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.35,0.0032348838988389902
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.4,0.003646883268832689
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.45,0.004013384033840336
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.5,0.0044
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.55,0.004799999999999998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.6,0.005199999999999997
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.65,0.005599999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.7,0.006041521915219153
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.75,0.006540538655386561
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.8,0.007100000000000003
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.85,0.007799999999999997
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.9,0.008709891998919993
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.95,0.010248102781027805
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.975,0.011700217577175749
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,36,quantile,0.99,0.013476330573305722
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.25,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.3,2.231302313023169e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.35,0.001023130231302313
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.4,0.0017728431284312909
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.45,0.002482337773377733
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.5,0.0032
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.55,0.003908186481864822
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.6,0.004623130231302313
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.65,0.005397357123571239
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.7,0.0062231302313023144
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.75,0.0071371456214562165
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.8,0.008193802538025386
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.85,0.009495801008010079
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.9,0.011167878678786792
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.95,0.013823990189901903
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.975,0.016369428719287142
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,37,quantile,0.99,0.019570445324453237
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.2,6.780892808928079e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.25,0.0015895891458914567
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.3,0.0024140671406714044
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.35,0.003167301323013229
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.4,0.003878089280892808
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.45,0.004554288542885424
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.5,0.0052
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.55,0.0058780892808928085
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.6,0.0065610899108991035
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.65,0.007252624876248764
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.7,0.008000960309603096
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.75,0.008835966609666096
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.8,0.00978063990639907
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.85,0.01087808928089281
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.9,0.01229085590855909
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.95,0.014478089280892809
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.975,0.016409637071370692
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,38,quantile,0.99,0.01885277337773377
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.05,0.0013343339933399357
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.1,0.003223581135811355
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.15,0.0044531446314463145
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.2,0.0053999999999999986
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.25,0.00612719602196022
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.3,0.006796282962829626
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.35,0.007388170731707319
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.4,0.0079
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.45,0.008400000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.5,0.0089
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.55,0.0094
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.6,0.0099
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.65,0.010433083430834307
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.7,0.011000252002520024
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.75,0.011687078120781206
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.8,0.012400000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.85,0.013351682116821164
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.9,0.014566585365853636
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.95,0.016446732067320672
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.975,0.01814722437224372
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,39,quantile,0.99,0.02010888542885427
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.15,0.0010782683826838198
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.2,0.002067263072630723
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.25,0.0028724979749797427
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.3,0.003567992079920792
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.35,0.0041999999999999945
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.4,0.004799999999999994
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.45,0.005382965529655288
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.5,0.005899999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.55,0.006464436594365935
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.6,0.007014848348483479
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.65,0.007620740257402565
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.7,0.008280288902889017
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.75,0.00897735802358023
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.8,0.009794833948339477
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.85,0.01076673071730717
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.9,0.01202592565925659
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.95,0.014043520385203843
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.975,0.015747394698946964
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,40,quantile,0.99,0.017839415624156207
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.25,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.3,1.5881828818287676e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.35,6.999999999999927e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.4,0.0011931023310233066
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.45,0.001656797317973177
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.5,0.0021
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.55,0.0025999999999999925
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.6,0.003065866258662577
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.65,0.0035818927189271875
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.7,0.004101214112141114
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.75,0.004699999999999996
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.8,0.005363637836378357
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.85,0.006156682566825667
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.9,0.007198910989109887
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.95,0.008818942489424886
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.975,0.010274500045000447
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,41,quantile,0.99,0.01195368211682107
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.05,1.9999999999999966e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.1,0.0016549104491044872
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.15,0.0025927324273242692
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.2,0.003299999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.25,0.0039
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.3,0.004431649716497165
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.35,0.004900000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.4,0.005369376293762941
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.45,0.005799999999999998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.5,0.0062
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.55,0.006603927639276392
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.6,0.007048830888308882
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.65,0.007499999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.7,0.00798610656106561
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.75,0.008499999999999997
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.8,0.009099999999999997
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.85,0.0098
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.9,0.010767424174241742
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.95,0.012214814148141474
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.975,0.013466525965259676
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,42,quantile,0.99,0.015087678786787845
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.15,1.2492754927549666e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.2,0.0010272333723337318
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.25,0.0017973224732247364
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.3,0.002484062640626409
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.35,0.0030911200612006146
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.4,0.0036428593285932924
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.45,0.004197322473224735
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.5,0.004699999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.55,0.0052534654846548515
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.6,0.005797322473224737
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.65,0.006370967509675103
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.7,0.006990286202862033
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.75,0.007649201242012426
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.8,0.008399741697416994
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.85,0.009355906759067596
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.9,0.010597322473224736
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.95,0.012567481774817734
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.975,0.01434730469804699
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,44,quantile,0.99,0.016506436504365035
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.25,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.3,6.074025740257308e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.35,0.0014656538565385616
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.4,0.0022973602736027316
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.45,0.003045446854468538
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.5,0.0037999999999999996
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.55,0.004540198451984516
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.6,0.00532637836378363
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.65,0.006153023580235801
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.7,0.007066448564485605
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.75,0.008103937539375395
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.8,0.009249830798307985
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.85,0.01063485014850148
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.9,0.012375193951939513
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.95,0.01513433309333093
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.975,0.017539307668076678
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,45,quantile,0.99,0.020459640626406247
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.25,7.335793357933571e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.3,0.0014190855908559077
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.35,0.0020432904329043293
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.4,0.0026432904329043317
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.45,0.003243290432904328
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.5,0.0038
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.55,0.004358422284222843
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.6,0.00494329043290433
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.65,0.00554329043290433
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.7,0.006181710017100166
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.75,0.006877540275402753
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.8,0.0076712087120871224
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.85,0.00859983799837998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.9,0.009802095220952208
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.95,0.011671506615066128
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.975,0.013288706012060104
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,46,quantile,0.99,0.015258592745927457
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.1,5.000000000000004e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.15,0.0017758082080820865
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.2,0.0027581441814418144
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.25,0.003600000000000006
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.3,0.004351365313653138
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.35,0.005000000000000004
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.4,0.005629817298172985
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.45,0.006205000000000004
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.5,0.0068000000000000005
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.55,0.0073560746107461175
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.6,0.00792667266672667
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.65,0.008566664116641165
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.7,0.009224051840518407
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.75,0.00998777112771128
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.8,0.010851093510935115
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.85,0.011870238052380517
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.9,0.013154911349113493
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.95,0.015086332913329134
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.975,0.01676745252452524
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,47,quantile,0.99,0.01891388101881015
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.25,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.3,5.627585275852747e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.35,0.0012657006570065696
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.4,0.0019653640536405367
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.45,0.0025782980829808307
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.5,0.0031999999999999997
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.55,0.0038143222932229314
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.6,0.0044657006570065685
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.65,0.005165700657006568
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.7,0.005921528215282132
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.75,0.0067997479974799754
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.8,0.007797139771397708
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.85,0.009027198271982718
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.9,0.010565705157051571
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.95,0.012885547205472029
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.975,0.014936542615426153
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,48,quantile,0.99,0.017499434884348866
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.25,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.3,2.4039870398703914e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.35,8.017068670686705e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.4,0.0013933561335613314
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.45,0.0018985959859598575
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.5,0.0024000000000000002
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.55,0.0029564274142741386
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.6,0.0034985959859598573
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.65,0.004076634866348663
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.7,0.004672356223562226
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.75,0.005338043380433801
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.8,0.006083893438934389
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.85,0.006991449014490137
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.9,0.008146363963639613
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.95,0.009979755197551978
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.975,0.011633541535415341
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,49,quantile,0.99,0.013701913059130566
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.15,2.8640536405364573e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.2,0.0014864053640536471
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.25,0.0025288115381153844
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.3,0.0034312024120241244
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.35,0.004258340383403834
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.4,0.005049260192601931
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.45,0.005786405364053645
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.5,0.006500000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.55,0.007243599135991366
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.6,0.007986405364053643
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.65,0.008786405364053645
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.7,0.009601233012330125
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.75,0.010490210152101529
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.8,0.011539919899199013
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.85,0.012762933579335792
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.9,0.014289934299343002
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.95,0.016679038790387877
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.975,0.018886405364053643
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,50,quantile,0.99,0.02150503429034292
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.25,3.744442444424443e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.3,0.0012000000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.35,0.0019821087210872093
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.4,0.002687317073170728
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.45,0.003336445414454145
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.5,0.004
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.55,0.004656196561965625
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.6,0.005319562595625984
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.65,0.006039003690036901
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.7,0.006816975069750696
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.75,0.007699999999999998
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.8,0.008689023490234895
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.85,0.009884730897308966
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.9,0.011545639456394564
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.95,0.014126499864998643
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.975,0.016521387813878158
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,51,quantile,0.99,0.019334829178291754
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.25,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.3,2.0000000000000464e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.35,7.000000000000027e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.4,0.0011991863918639225
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.45,0.001615714607146081
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.5,0.0021
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.55,0.002535194401944025
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.6,0.0030000000000000014
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.65,0.003478839888398884
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.7,0.0039885770857708575
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.75,0.004500000000000005
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.8,0.005102023220232211
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.85,0.005819028440284404
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.9,0.006776298262982637
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.95,0.00810279542795428
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.975,0.009272293222932222
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,53,quantile,0.99,0.010700000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.15,0.0015000000000000026
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.2,0.0030440788407884115
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.25,0.004300000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.3,0.0053999999999999986
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.35,0.006302465124651253
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.4,0.007164602646026462
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.45,0.007941739717397164
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.5,0.0087
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.55,0.009455902259022599
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.6,0.010250440104401033
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.65,0.01110815048150482
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.7,0.012067047970479704
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.75,0.013152495274952753
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.8,0.014430450904509052
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.85,0.016
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.9,0.01805238052380522
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.95,0.02111710872108721
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.975,0.023779102916029162
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,54,quantile,0.99,0.027231934299342984
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.1,0.0012854702547025493
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.15,0.0023332809828098345
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.2,0.003129442894428951
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.25,0.0038170326703267058
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.3,0.004424462244622451
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.35,0.005
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.4,0.0055000000000000005
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.45,0.006000000000000002
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.5,0.006500000000000001
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.55,0.006998459184591849
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.6,0.007492348123481235
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.65,0.008000000000000002
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.7,0.008555169651696521
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.75,0.009173647736477365
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.8,0.009852704527045276
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.85,0.01068917109171091
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.9,0.011763234632346332
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.95,0.013418824588245887
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.975,0.014835942534425337
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,55,quantile,0.99,0.016567576635766346
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.15,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.2,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.25,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.3,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.35,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.4,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.45,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.5,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.55,6.983520835208438e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.6,0.0012827558275582823
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.65,0.002039240842408433
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.7,0.0027942228422284257
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.75,0.003696775717757181
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.8,0.004598037980379813
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.85,0.0058153730537305395
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.9,0.00754630276302764
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.95,0.010512651876518755
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.975,0.01330408716587167
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,56,quantile,0.99,0.01647076536765367
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.01,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.025,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.05,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.1,0
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.15,8.913194131941307e-4
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.2,0.0016138169381693837
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.25,0.002260732607326072
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.3,0.0027999999999999995
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.35,0.0033042777427774285
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.4,0.0037999999999999996
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.45,0.004256215462154619
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.5,0.004699999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.55,0.005169330843308433
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.6,0.005607084870848707
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.65,0.006099999999999999
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.7,0.0066
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.75,0.007167547925479254
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.8,0.0078
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.85,0.008545753307533072
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.9,0.009500000000000005
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.95,0.01098874178741788
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.975,0.012282610926109265
+2025-12-20,3,wk inc covid prop ed visits,2026-01-10,US,quantile,0.99,0.013857358743587418


### PR DESCRIPTION
Automated forecast submission for reference date 2025-12-20.

Co-Authored-By: Warp <agent@warp.dev>