### PR TITLE
Update Code Owners File To Target `.github` Folder Directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 /src/* @sbidari @dylanhmorris @O957
-/.github/* @sbidari @dylanhmorris @O957
+/.github/** @sbidari @dylanhmorris @O957
 /hub-config/* @sbidari @dylanhmorris @O957
 /auxiliary_data/weekly-model-submissions/ @sbidari @dylanhmorris @O957
 /model-output/CovidHub-baseline/ @sbidari @dylanhmorris @O957


### PR DESCRIPTION
When I marked as ready-for-review #1158 , which targets a file `.github/workflows`, no reviewers were automatically selected. I noticed this line

```
/.github/* @sbidari @dylanhmorris @O957
```

in the `CODEOWNERS` file. `/.github/*` only selects reviewers for files (e.g. `dependabot.yaml`) in `.github`, not files within folders in `.github`. This PR updates `/.github/*` to `/.github/**`, which recursively gets all files in `.github`.