### PR TITLE
Update Repository Name CovidHub Reports To Cfa Forecast Hub Reports

### DIFF
--- a/.github/workflows/dispatch-cfa-forecast-hub-reports.yaml
+++ b/.github/workflows/dispatch-cfa-forecast-hub-reports.yaml
@@ -1,4 +1,4 @@
-name: "Send a dispatch to covidhub-reports"
+name: "Send a dispatch to cfa-forecast-hub-reports"
 
 on:
   workflow_dispatch:
@@ -20,11 +20,11 @@ jobs:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: CDCgov
-          repositories: covidhub-reports
+          repositories: cfa-forecast-hub-reports
 
       - name: "Repository Dispatch"
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ steps.get_token.outputs.token }}
-          repository: CDCgov/covidhub-reports
+          repository: CDCgov/cfa-forecast-hub-reports
           event-type: ensemble-added

--- a/src/get_forecast_data.R
+++ b/src/get_forecast_data.R
@@ -23,7 +23,7 @@
 #'
 #' To run:
 #' Rscript src/get_forecast_data.R --reference-date 2024-12-21
-#' --base-hub-path "." --hub-reports-path "path/to/covidhub-reports"
+#' --base-hub-path "." --hub-reports-path "path/to/cfa-forecast-hub-reports"
 #' --horizons-to-include 0 1 2
 
 # set up command line argument parser

--- a/src/get_webtext.R
+++ b/src/get_webtext.R
@@ -1,7 +1,7 @@
 #' Rscript to generate texts for the visualization webpage
 #' To run:
 #' Rscript src/get_webtext.R --reference-date "2025-02-22"
-#' --hub-reports-path "../covidhub-reports"
+#' --hub-reports-path "../cfa-forecast-hub-reports"
 
 parser <- argparser::arg_parser(
   "Generate text for the webpage."
@@ -23,7 +23,7 @@ parser <- argparser::add_argument(
   parser,
   "--hub-reports-path",
   type = "character",
-  default = "../covidhub-reports",
+  default = "../cfa-forecast-hub-reports",
   help = "path to COVIDhub reports directory"
 )
 


### PR DESCRIPTION
This PR updates the name of the repository `covidhub-reports` to `cfa-forecast-hub-reports` in workflows and R files in this repository. Originally, `covid19-forecast-hub`, upon having the ensemble forecast merged on a given week, dispatched a data file to `covidhub-reports`; since STF now maintains `rsv-forecast-hub`, `covidhub-reports` has been changed to `cfa-forecast-hub-reports`, so the references `covid19-forecast-hub` in to `covidhub-reports` must be updated as well.