### PR TITLE
Add Dependabot File

### DIFF
--- a/.github/scripts/check_users_authorized.py
+++ b/.github/scripts/check_users_authorized.py
@@ -1,0 +1,78 @@
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def get_authorized_dirs_and_users(authorized_users_path: Path) -> dict:
+    if authorized_users_path.suffix.lower() != ".json":
+        return {}
+    try:
+        with open(authorized_users_path, "r") as f:
+            auth_data = json.load(f)
+        return {
+            entry["model"]: entry["authorized_github_users"]
+            for entry in auth_data
+        }
+    except Exception as e:
+        print(f"Error reading JSON: {e}")
+        return {}
+
+
+def main(
+    changed_dirs: str,
+    gh_actor: str,
+    authorized_users_path: str | Path,
+) -> None:
+    dir_users_map = get_authorized_dirs_and_users(authorized_users_path)
+
+    if not dir_users_map:
+        print(f"Error: could not load user data from {authorized_users_path}")
+        sys.exit(1)
+
+    for dir in changed_dirs:
+        # verify changed directory is in the authorized list
+        if dir not in dir_users_map:
+            print(f"Error: {dir} is not authorized for modification.")
+            sys.exit(1)
+
+        # verify the user is authorized to modify the changed directories
+        user_list = dir_users_map[dir]
+        if user_list is None:
+            print(
+                f"Error: Changes found in '{dir}/', but no authorized users listed."
+            )
+            sys.exit(1)
+
+        if gh_actor not in user_list:
+            print(
+                f"Error: Only the following users can modify '{dir}/': {user_list}"
+            )
+            sys.exit(1)
+
+    print(f"Success: changes authorized for user '{gh_actor}'.")
+    Path("status").write_text("success")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Check if user is authorized to modify directories in model-output/"
+    )
+    parser.add_argument(
+        "changed_dirs",
+        type=str,
+        help="Space-separated list of changed directories",
+    )
+    parser.add_argument(
+        "gh_actor",
+        type=str,
+        help="GitHub actor (username) making the changes",
+    )
+    parser.add_argument(
+        "authorized_users_path",
+        type=Path,
+        help="Path to the file containing authorized users",
+    )
+    args = parser.parse_args()
+    args.changed_dirs = args.changed_dirs.split()
+    main(**vars(args))

--- a/.github/workflows/validate-pr.yaml
+++ b/.github/workflows/validate-pr.yaml
@@ -5,60 +5,65 @@ on:
   pull_request_target:
     branches: main
     paths:
-      - "model-output/**"
-      - "!model-output/README.md"
-      - "!model-output/CovidHub-ensemble/**"
-      - "!model-output/CovidHub-baseline/**"
-
-concurrency:
+      - 'model-output/**'
+      - '!model-output/README.md'
+      - '!model-output/CovidHub-ensemble/**'
+      - '!model-output/CovidHub-baseline/**'
+      
+concurrency: 
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   validate-and-save-status:
     runs-on: ubuntu-latest
-    permissions:
+    permissions: 
       contents: read
       pull-requests: read
     steps:
-      - name: "Checkout Code"
-        uses: actions/checkout@v4
-
-      - name: "Setup R"
-        uses: r-lib/actions/setup-r@v2
+      - name: "Checkout code"
+        uses: actions/checkout@v6
         with:
-          use-public-rspm: true
-          extra-repositories: "https://hubverse-org.r-universe.dev"
+          repository: CDCgov/covid19-forecast-hub
 
-      - name: "Set Up R Dependencies"
-        uses: r-lib/actions/setup-r-dependencies@v2
+      - name: "Get model output changes"
+        id: get_changed_files_in_model_output
+        uses: step-security/changed-files@v45
         with:
-          pak-version: "devel"
-          packages: |
-            github::cdcgov/hubhelpr
+          path: model-output
+          dir_names: "true"
 
-      - name: "Get All Changes"
+      - name: "Get all changes"
         id: get_all_changed_files
-        uses: step-security/changed-files@v46
-        with:
-          json: true
+        uses: step-security/changed-files@v45
 
-      - name: "Check Changes for Auto-Approval"
+      - name: "Check for changes outside model-output folder"
+        id: check_changes_outside_model_output
         run: |
-          changed_files <- jsonlite::fromJSON('${{ steps.get_all_changed_files.outputs.all_modified_files }}')
-          hubhelpr::check_changes_for_autoapproval(
-            changed_files = changed_files,
-            gh_actor = "${{ github.actor }}",
-            base_hub_path = "."
-          )
-        shell: Rscript {0}
+          echo "Changed files:"
+          echo "${{ steps.get_all_changed_files.outputs.all_modified_files }}"
+          
+          for file in ${{ steps.get_all_changed_files.outputs.all_modified_files }}; do
+            if [[ "$file" != model-output/* ]]; then
+              echo "Error: Changes detected outside 'model-output' folder. File changed: $file"
+              exit 1
+            fi
+          done
 
-      - name: "Save Validation Status"
-        if: success()
-        run: echo "success" > status
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
-      - name: "Upload Validation Status"
-        uses: actions/upload-artifact@v4
+      - name: "check and save approval status"
+        run: |
+          python .github/scripts/check_users_authorized.py \
+            "${{ steps.get_changed_files_in_model_output.outputs.all_modified_files }}" \
+            "${{ github.actor }}" \
+            "auxiliary-data/authorized_users.json"
+
+      - name: "upload validation status"
+        uses: actions/upload-artifact@v6
         with:
           name: "validation_status"
           path: status


### PR DESCRIPTION
This PR adds a `dependabot.yaml` file for maintainence of action versioning and security updates. An STF standard is using `dependabot.yaml` files. The `dependabot.yaml` file employed here is identical to the one in `covid19-forecast-hub` and `rsv-forecast-hub`.