### PR TITLE
Fix Empty Reference Date Handling For Baseline And Ensemble Forecast Workflow

### DIFF
--- a/.github/workflows/create-baseline.yaml
+++ b/.github/workflows/create-baseline.yaml
@@ -35,4 +35,4 @@ jobs:
       with:
         disease: "covid"
         github_token: ${{ steps.get_token.outputs.token }}
-        reference_date: ${{ inputs.reference_date }}
+        reference_date: ${{ inputs.reference_date || 'latest' }}

--- a/.github/workflows/create-ensemble.yaml
+++ b/.github/workflows/create-ensemble.yaml
@@ -35,4 +35,4 @@ jobs:
       with:
         disease: "covid"
         github_token: ${{ steps.get_token.outputs.token }}
-        reference_date: ${{ inputs.reference_date }}
+        reference_date: ${{ inputs.reference_date || 'latest' }}


### PR DESCRIPTION
This PR fixes empty reference date handling using <https://github.com/CDCgov/hubhelpr/pull/133>.