### PR TITLE
Update The Passing Of Excluded Locations

### DIFF
--- a/.github/workflows/update-target-data.yaml
+++ b/.github/workflows/update-target-data.yaml
@@ -40,4 +40,7 @@ jobs:
         api_key_secret: ${{ secrets.NHSN_API_KEY_SECRET }}
         legacy_file: "true"
         nssp_update_local: ${{ inputs.nssp_update_local || 'true' }}
+        # JSON array (e.g., '["VI", "GU"]') excludes from all targets.
+        # JSON object (e.g., '{"all": ["VI"], "wk inc covid hosp": ["GU"]}')
+        # supports target-specific exclusions.
         excluded_locations: '["VI", "GU", "AS", "MP", "UM"]'


### PR DESCRIPTION
This PR updates, based on incoming changes in <https://github.com/CDCgov/hubhelpr/pull/178>, the way in which location-exclusions are passed in `covid19-forecast-hub` workflows.