### PR TITLE
Adding Delphi to the hub developers

### DIFF
--- a/auxiliary-data/hub_developers.json
+++ b/auxiliary-data/hub_developers.json
@@ -10,5 +10,17 @@
     "organization": "CDC",
     "url": "https://github.com/CDCgov/cfa-forecast-hub-reports",
     "description": "Weekly summarized COVIDHub data"
+  },
+  {
+    "name": "Delphi Epidata",
+    "designated_contacts": [
+      {
+        "contact_name": "Adam Johns et al.",
+        "contact_email": "delphi-production@andrew.cmu.edu"
+      }
+    ],
+    "organization": "Delphi",
+    "url": "https://delphi.cmu.edu/",
+    "description": "Mirror and archive datasets"
   }
 ]


### PR DESCRIPTION
Since we're mirroring and archiving the data provided here I figured we should be included in this list. Thanks for building a warning system

edit: there's a PR with this exact text b/c we accidentally force-pushed over the update