### PR TITLE
Add RespiLens developers to `hub_developers.json`

### DIFF
--- a/auxiliary-data/hub_developers.json
+++ b/auxiliary-data/hub_developers.json
@@ -29,6 +29,10 @@
       {
         "contact_name": "Emily Przykucki",
         "contact_email": "emily.przykucki@gmail.com"
+      },
+      {
+        "contact_name": "Joseph Lemaitre",
+        "contact_email": "jo.lemaitresamra@gmail.com"
       }
     ],
     "organization": "ACCIDDA",

--- a/auxiliary-data/hub_developers.json
+++ b/auxiliary-data/hub_developers.json
@@ -22,5 +22,17 @@
     "organization": "Delphi",
     "url": "https://delphi.cmu.edu/",
     "description": "Mirror and archive datasets"
+  },
+  {
+    "name": "RespiLens",
+    "designated_contacts": [
+      {
+        "contact_name": "Emily Przykucki",
+        "contact_email": "emily.przykucki@gmail.com"
+      }
+    ],
+    "organization": "ACCIDDA",
+    "url": "https://github.com/ACCIDDA/RespiLens",
+    "description": "RespiLens is a responsive web app to visualize respiratory disease forecasts in the US, focused on accessibility for state health departments and the general public."
   }
 ]


### PR DESCRIPTION
Added @jcblemai and I as developers that use the covid19-forecast-hub. 