### PR TITLE
Add Ensemble Forecast For Reference Date 2026-05-09

### DIFF
--- a/auxiliary-data/weekly-model-submissions/2026-05-09-models-submitted-to-hub.csv
+++ b/auxiliary-data/weekly-model-submissions/2026-05-09-models-submitted-to-hub.csv
@@ -1,0 +1,21 @@
+model_id,designated_model,target
+CADPH-CovidCAT_Ensemble,TRUE,wk inc covid hosp
+CEPH-Rtrend_covid,TRUE,wk inc covid hosp
+CFA-EpiAutoGP,TRUE,wk inc covid hosp
+CFA_Pyrenew-Pyrenew_HE_COVID,TRUE,wk inc covid hosp
+CFA_Pyrenew-Pyrenew_H_COVID,FALSE,wk inc covid hosp
+CMU-TimeSeries,TRUE,wk inc covid hosp
+CovidHub-baseline,FALSE,wk inc covid hosp
+CovidHub-ensemble,FALSE,wk inc covid hosp
+Google_SAI-Ensemble,TRUE,wk inc covid hosp
+OHT_JHU-nbxd,TRUE,wk inc covid hosp
+UGA_flucast-INFLAenza,TRUE,wk inc covid hosp
+UM-DeepOutbreak,TRUE,wk inc covid hosp
+UMass-ar6_pooled,TRUE,wk inc covid hosp
+UMass-gbqr,TRUE,wk inc covid hosp
+CFA_Pyrenew-Pyrenew_E_COVID,TRUE,wk inc covid prop ed visits
+CFA_Pyrenew-Pyrenew_HE_COVID,TRUE,wk inc covid prop ed visits
+CMU-TimeSeries,TRUE,wk inc covid prop ed visits
+CovidHub-baseline,FALSE,wk inc covid prop ed visits
+CovidHub-ensemble,FALSE,wk inc covid prop ed visits
+UGA_flucast-INFLAenza,TRUE,wk inc covid prop ed visits

--- a/model-output/CovidHub-ensemble/2026-05-09-CovidHub-ensemble.csv
+++ b/model-output/CovidHub-ensemble/2026-05-09-CovidHub-ensemble.csv
@@ -1,0 +1,11892 @@
+reference_date,location,horizon,target,target_end_date,output_type,output_type_id,value
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.01,30.874174
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.025,34.033418
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.05,36.655942
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.1,39.22895
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.15,41.443611
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.2,43.21004
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.25,44.578842
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.3,46.008517
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.35,47.274125
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.4,48.487728
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.45,49.957241
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.5,51.072509
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.55,52.275427
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.6,53.411433
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.65,54.752498
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.7,56.005823
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.75,57.563275
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.8,59.402838
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.85,61.778983
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.9,64.767001
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.95,69.77637
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.975,73.246445
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.99,80.365481
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.01,18.52415931936207
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.025,21.65960728954519
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.05,25.11924209609884
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.1,29.511559587614364
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.15,32.765223649961406
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.2,34.7827966660104
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.25,36.31607380669366
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.3,37.98822115222934
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.35,39.417440549960276
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.4,40.87680655424222
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.45,43.48969725210341
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.5,45.880262818047754
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.55,47.20947402794506
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.6,50.49555981682724
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.65,51.85620225467326
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.7,53.3611558390913
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.75,55.14399006600938
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.8,57.58331336503707
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.85,59.7031888828144
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.9,63.46670479587009
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.95,68.2673845718912
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.975,74.3054412111687
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.99,86.86128508216278
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.01,12.066237474740657
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.025,15.182831836726578
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.05,19.40816699086818
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.1,24.568200116173415
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.15,28.126109664501442
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.2,31.415438
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.25,33.484210000000004
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.3,36.036962
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.35,37.763200999999995
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.4,40
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.45,42
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.5,43
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.55,44.5
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.6,46
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.65,48
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.7,49.5
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.75,51.5
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.8,54
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.85,64.41528871635077
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.9,66.51694629364805
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.95,73.44123137814816
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.975,82.76146582237901
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.99,95.9952468052796
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.01,6.888888888888889
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.025,10.72457969402808
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.05,14.79634110290994
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.1,22.15240393258088
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.15,26.479585886858445
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.2,28
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.25,31.604399
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.3,33
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.35,35
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.4,36
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.45,38
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.5,40
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.55,41
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.6,43
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.65,45.00678823641893
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.7,47
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.75,58.20173036035574
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.8,65.4774848658413
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.85,70.99
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.9,75.33
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.95,82.18
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.975,88.53
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.99,101.90896483124409
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.01,4.888888888888889
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.025,7.704133877213147
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.05,13.265756399547113
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.1,18
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.15,20.033799
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.2,25.00979
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.25,29
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.3,31
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.35,33
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.4,35.58060051371816
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.45,41.81481090952372
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.5,43.31541551855469
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.55,44.40015709047629
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.6,50.63436748628185
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.65,53.356710390491166
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.7,59.99752464279375
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.75,63.14
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.8,66.14
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.85,69.8
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.9,74.63
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.95,82.3
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.975,89.47
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.99,109.72829210523483
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0.53988778
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0.78331282
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.05,1.0387321
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.1,1.3147504
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.15,1.5365487
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.2,1.8078536
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.25,2.0214294
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.3,2.2227421
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.35,2.416894
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.4,2.53
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.45,2.57
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.5,2.61
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.55,2.65
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.6,2.7
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.65,2.74
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.7,2.79
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.75,2.8768002117734244
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.8,3.432715400941879
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.85,3.846454784611372
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.9,4.412994647922531
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.95,5.547352617625406
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.975,6.570813256303538
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.99,7.057140788226954
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.0628790216434068
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.2558533940415436
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.05,0.47749160355287695
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.1,0.9064061364162058
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.15,1
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.2,1.0924053417513584
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.25,1.3134642962853822
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.3,1.5064286945647751
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.35,1.8888888888888888
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.4,2
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.45,2
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.5,2.017018610109034
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.55,2.3822193625356034
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.6,2.564755190733921
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.65,3.0055515998442504
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.7,3.3956727976138392
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.75,3.8036064390674618
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.8,4.131022472890054
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.85,4.7286470849163535
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.9,5.224003261954088
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.95,6.474650261865598
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.975,7.23463376388742
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.99,8
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.01,0
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.025,0.0439801648624482
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.4247287660527965
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.1,0.6337381337568625
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.15,1
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.2,1
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.25,1.0047464135554187
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.3,1.0994719387792498
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.35,1.161795536846989
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.4,2
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.45,2
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.5,2.1
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.55,2.1727392217596764
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.6,2.675
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.65,3
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.7,3
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.75,3.778562163211708
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.8,4
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.85,4.609154360122759
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.9,5.4204601658248635
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.95,7.3225764394171335
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.975,7.958802211148747
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.99,9.004999999999995
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.09353262061427256
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.05,0.2083452345604399
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.1,0.39545085687625503
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.15,1
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.2,1
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.25,1
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.3,1
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.35,1
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.4,1.2930696028923805
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.45,1.99
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.5,2.07
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.55,2.15
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.6,2.24
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.65,3
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.7,3.480613324096076
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.75,3.796332321415501
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.8,5.242335427342531
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.85,6.222222222222222
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.9,7.0157794801426805
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.95,7.771680879133913
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.975,8.326455313954561
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.99,10
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.059703559146676
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.1418822000782216
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.1,0.26067317226267495
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.15,0.3451133791503533
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.2,1
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.25,1
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.3,1
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.35,1
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.4,1.6030825785332332
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.45,2
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.5,2.7830800249830667
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.55,3.1902063016253734
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.6,3.430016606780036
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.65,4.161805378847429
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.7,4.542840582105597
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.75,5.09437218498284
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.8,5.6773218830356145
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.85,7
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.9,7.5733212685784554
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.95,7.857675719797015
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.975,10
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.99,12
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.01,15.62
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.025,16.82
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.05,17.91
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.1,19.24
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.15,20.18
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.2,22.55562761237853
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.25,24.345361647611725
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.3,26.0052315932779
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.35,27.558228289804735
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.4,28.300419320624666
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.45,28.991382218687324
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.5,29.468421052631584
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.55,30.564728892423794
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.6,31.668206
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.65,32.201668
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.7,32.821406
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.75,33.455107
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.8,34.276442
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.85,35.224013
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.9,36.191398
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.95,37.888721
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.975,39.23843
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.99,41.257501
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.01,11.61111111111111
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.025,13.885
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.05,15.559999999999999
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.1,17.950000000000017
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.15,19.5
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.2,21.160018124939434
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.25,22.697851348288438
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.3,24.573104096077415
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.35,25.61111111111111
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.4,26.944444444444443
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.45,27.833333333333336
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.5,28.666666666666664
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.55,29.5
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.6,30.244444444444444
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.65,31.11111111111111
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.7,32.55555555555556
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.75,34.000168271934186
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.8,35.96097465975522
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.85,38.8669844966674
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.9,45.37498015809179
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.95,50.46334198133334
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.975,61.25138888888888
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.99,66.13293577380952
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.01,8.787672700078893
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.025,12
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.05,13.75
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.1,15.71
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.15,17.721894703702382
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.2,20.31537440626801
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.25,22.055555555555557
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.3,23.22222222222222
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.35,24.72222222222222
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.4,26.72222222222222
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.45,28.72222222222222
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.5,30.22222222222222
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.55,31.833333333333336
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.6,33.333333333333336
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.65,34.388888888888886
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.7,35.888888888888886
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.75,38.16666666666667
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.8,41.59489999065721
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.85,44.72222222222222
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.9,51.31376513088368
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.95,60.204727909036265
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.975,75.73992972222223
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.99,95.66701896355866
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.01,6.252847969805129
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.025,11
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.05,12.84
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.1,14.91
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.15,17
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.2,19
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.25,20
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.3,21
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.35,22
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.4,26
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.45,27.88888888888889
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.5,29.444444444444443
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.55,30.555555555555557
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.6,31.599999999999998
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.65,32.888888888888886
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.7,34.55555555555556
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.75,37.111111111111114
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.8,39.96823830023968
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.85,54.701370652320136
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.9,61.58112137940118
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.95,76.4583930599573
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.975,104.60786990402939
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.99,124.51665466666668
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.01,5.823711737436516
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.025,9.62374008311063
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.05,12.994444444444445
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.1,15
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.15,17.140983088790524
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.2,19.11
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.25,20.48
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.3,21.78
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.35,23.04
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.4,24.29
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.45,26
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.5,30.11111111111111
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.55,35
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.6,40
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.65,47
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.7,48.871197634825165
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.75,49.17667071206684
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.8,60.66103033714136
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.85,78.73805643574697
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.9,89.79817940401855
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.95,95.28969311183468
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.975,112.41728864562806
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.99,161.89238393252623
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.01,5.3518742
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.025,5.763366
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.05,6.2402019
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.1,6.7606702
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.15,7.1578999
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.2,7.455745
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.25,7.7673089
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.3,8.0340168
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.35,8.2851253
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.4,8.5868372
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.45,8.7976596
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.5,8.9989427
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.55,9.250842
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.6,9.6015804
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.65,9.9229034
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.7,10.228106899871008
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.75,11.465735971409764
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.8,13.01003804184715
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.85,14.55933775841887
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.9,15.31
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.95,16.28
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.975,17.16
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.99,18.24
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.01,2.3283333333333345
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.025,2.7777777777777777
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.05,3.678787871205193
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.1,4.720087696603848
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.15,6.006849955523723
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.2,6.2524680121697624
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.25,6.8885023499999996
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.3,7.147216748061727
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.35,7.7141500999999995
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.4,7.8570209
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.45,8.511656
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.5,8.777777777777779
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.55,9.45349907424761
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.6,10
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.65,10.591087302261704
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.7,11.315391288353496
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.75,12.083148008912467
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.8,13.045163389307666
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.85,14.047615429260901
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.9,15.587222222222223
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.95,18.503185763360804
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.975,21.66834104975212
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.99,25.389092087624224
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.01,1.6111111111111112
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.025,2.666666666666667
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.05,3.1817234348934704
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.1,4.2297116
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.15,4.711328618653061
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.2,5.1662592499999995
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.25,5.435481055555556
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.3,6.123332749999999
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.35,7.049296701428569
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.4,7.5368580000000005
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.45,8.229531699999999
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.5,8.751964402694412
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.55,9.869023039482006
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.6,10.415864683037519
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.65,11.388268629757938
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.7,11.430636160302422
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.75,12.277970192647775
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.8,13.403017444231118
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.85,14.774250192594998
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.9,16.650555555555556
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.95,20.742914495332705
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.975,24.235984047813396
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.99,29.4223316392139
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.01,1
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.025,1
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.05,2.5555555555555554
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.1,3.3333333333333335
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.15,4.111111111111111
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.2,4.555555555555555
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.25,5
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.3,5.5312141
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.35,6.0233827
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.4,7.130562781176464
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.45,8.741496811439104
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.5,9
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.55,10
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.6,10
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.65,11
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.7,11.11111111111111
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.75,12.444444444444445
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.8,13.911111111111117
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.85,15.57
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.9,17.08
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.95,21
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.975,25
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.99,31.40341077843476
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.01,1
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.025,1
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.05,2.4444444444444446
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.1,3.2974579
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.15,3.9016278
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.2,4.3421167
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.25,4.8301693
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.3,5.269563
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.35,6.222222222222222
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.4,8
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.45,8
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.5,9
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.55,9
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.6,10
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.65,11
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.7,11.444444444444445
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.75,13.11111111111111
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.8,14.444444444444445
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.85,15.89
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.9,18
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.95,24
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.975,30
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.99,37
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.01,94.5
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.025,100.75
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.05,106.4
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.1,113.24
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.15,118.06
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.2,124.18014718390287
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.25,134.14307970710476
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.3,141.99736937471715
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.35,149.76542113626383
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.4,153.43607843137255
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.45,156.77158900070606
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.5,159.0947368421053
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.55,164.60785544373846
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.6,171.75058823529415
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.65,178.2657
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.7,180.39444
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.75,182.54262
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.8,185.37467
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.85,188.3537
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.9,192.19891
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.95,198.87856
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.975,204.977
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.99,211.56681
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.01,83.38
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.025,93
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.05,101.74012339309424
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.1,115
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.15,120.55555555555556
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.2,126
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.25,131
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.3,136
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.35,141
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.4,145
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.45,150
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.5,154
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.55,159
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.6,163
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.65,168
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.7,174.16272122026453
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.75,183.23622217761542
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.8,187.5629152851582
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.85,201.134387050737
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.9,210
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.95,234.46851315265957
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.975,265.44503
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.99,281.27986
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.01,67.22222222222223
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.025,80
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.05,94.49
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.1,104.8
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.15,112.28
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.2,118.53
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.25,124.13
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.3,129.34
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.35,134.33
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.4,139.22
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.45,144.08
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.5,160.2514952857142
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.55,160.7292516645361
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.6,169.11111111111111
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.65,174.44444444444446
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.7,183
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.75,194
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.8,208
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.85,223
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.9,239.5097731753359
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.95,280
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.975,339.82020912312777
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.99,353.0793702857143
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.01,56.09337913847219
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.025,76.77777777777777
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.05,93.58111111111111
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.1,110.15166666666667
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.15,119.79166666666666
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.2,126.90166666666667
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.25,134.03055555555557
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.3,140.71555555555557
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.35,146.20277777777778
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.4,152.42944444444444
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.45,157.79166666666669
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.5,166.51357982539682
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.55,172.04627852175787
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.6,177.36226712302383
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.65,193.1054129302357
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.7,209.87399148894838
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.75,221.432609839085
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.8,235.503612450431
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.85,253.2435624265795
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.9,278.0245256276965
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.95,318.2664375233675
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.975,377.20694444444445
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.99,443.8002513766917
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.01,47.49891437703295
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.025,73.67794093441577
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.05,92.64444444444445
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.1,109.45388888888888
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.15,119.88222222222223
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.2,128.98388888888888
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.25,136.75111111111113
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.3,143.78666666666666
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.35,149.90222222222224
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.4,156.2288888888889
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.45,161.94944444444445
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.5,170.77034898412708
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.55,186.87339425083707
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.6,190.56311222772504
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.65,215.2640344804085
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.7,227.63342051555082
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.75,238.5265635535006
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.8,251.47262422584146
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.85,272.36137594884553
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.9,306.23811190087247
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.95,358.95804777775754
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.975,412.1222222222222
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.99,528.867255025632
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.01,10.641055
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.025,11.538737
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.05,12.323345
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.1,13.274603
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.15,13.87442
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.2,14.390382
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.25,14.955961
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.3,15.45067
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.35,15.899211
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.4,16.410886
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.45,16.83686
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.5,17.259234
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.55,17.625965
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.6,18.052456
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.65,18.952418826305642
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.7,20.56
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.75,21.12
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.8,21.75
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.85,22.5
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.9,23.48
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.95,25
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.975,26.38
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.99,28.06
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.01,3.5
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.025,6
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.05,7.111111111111111
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.1,10.642372120224767
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.15,12.224108055555554
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.2,13.230514055555556
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.25,14.721905704988215
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.3,15.56835233688929
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.35,16.685915472109862
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.4,17.767303637355873
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.45,18.331377820496222
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.5,18.89
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.55,19.705
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.6,20.535
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.65,20.884999999999998
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.7,21.765
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.75,22.185000000000002
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.8,23.44777777777778
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.85,25.371111111111112
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.9,27.918888888888887
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.95,31.837145371125672
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.975,37.577730122991724
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.99,46.67666119863446
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.01,3.0128204814628585
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.025,5.611111111111111
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.05,7
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.1,9.00573892659924
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.15,10.976887737626676
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.2,12.550228474318715
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.25,14.274233011752791
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.3,15.877777777777776
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.35,16.72222222222222
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.4,17.75915150584221
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.45,20.28
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.5,21.68
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.55,22.595
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.6,23.53
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.65,24.494999999999997
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.7,26
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.75,27.064999999999998
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.8,28.77777777777778
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.85,31.5
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.9,35.56111111111112
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.95,42.83611111111111
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.975,51.391666666666666
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.99,63.11026597349857
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.01,3
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.025,5.444444444444445
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.05,6.777777777777778
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.1,9.555555555555555
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.15,11
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.2,13.940081691787
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.25,16.59
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.3,17.57
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.35,18.51
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.4,21.06778296080013
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.45,24.867642
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.5,26.903269
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.55,28
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.6,30
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.65,33
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.7,35
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.75,37.6845086987842
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.8,42
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.85,46
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.9,49.81813427051764
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.95,57.97422171581979
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.975,71
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.99,83.44444444444444
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.01,2.3532597
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.025,4.596262480775214
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.05,6.444444444444445
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.1,8.666666666666666
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.15,12.361401854096716
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.2,15.518918
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.25,18.42
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.3,20.212504
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.35,22.39623
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.4,24.918547
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.45,27
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.5,30
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.55,33
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.6,36
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.65,38.666574453037875
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.7,40.01325962791355
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.75,41.194658755320525
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.8,49.710673334475075
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.85,52.00694307471375
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.9,57.35215935296919
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.95,67.03496128818342
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.975,84.24598030487405
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.99,106.5612432541492
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.01,9.6665335
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.025,10.133072
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.05,10.561266
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.1,11.201895
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.15,11.618203
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.2,11.942141
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.25,12.284701
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.3,12.573617
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.35,12.837554
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.4,13.081891
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.45,13.34977
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.5,13.575698
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.55,13.843909
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.6,14.360108285603335
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.65,15.273830961808265
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.7,16.51656335140148
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.75,17.814405090845856
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.8,19.504292908462666
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.85,20.22
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.9,21.15
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.95,22.59
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.975,23.9
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.99,25.51
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.01,2.6447510219894053
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.025,5.355868584617309
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.05,6.555555555555555
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.1,7.611111111111111
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.15,8.5
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.2,8.833333333333332
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.25,9.71089985976326
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.3,10.177314227569711
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.35,10.96608669022362
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.4,11.474237438969457
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.45,11.98244165289032
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.5,12.779612566969773
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.55,13.402191547103708
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.6,13.865029475952099
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.65,15.22031933884983
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.7,16.59445000047786
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.75,17.465225766064133
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.8,19.141492506106516
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.85,20.848491716539304
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.9,22.577746233892938
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.95,25.48
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.975,29.725234043058535
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.99,34.80484140616434
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.01,2.2068931665051505
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.025,4.166666666666666
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.05,4.666666666666666
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.1,5.777777777777778
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.15,6.611111111111111
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.2,7.467362896983959
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.25,8.317266430048507
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.3,9.125700123528993
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.35,9.905755265371496
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.4,10.542945553027852
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.45,11.234064559801435
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.5,13.097931149788465
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.55,13.834363454422542
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.6,14.844614715296306
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.65,15.807970122136588
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.7,16.80008030970075
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.75,18.084172564878344
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.8,19.205595962776428
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.85,21.11111111111111
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.9,23
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.95,29.4
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.975,33.49281460251457
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.99,40.19589660532508
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.01,1
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.025,3.6666666666666665
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.05,4.8973029
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.1,5.8766486
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.15,6.5277237
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.2,7.1726738
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.25,7.7610456
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.3,8.590292764141426
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.35,9.444444444444445
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.4,10.222222222222221
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.45,11.11111111111111
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.5,14
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.55,15
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.6,16
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.65,17
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.7,18
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.75,19
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.8,20
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.85,22
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.9,24.77777777777778
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.95,30.444444444444443
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.975,36.41
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.99,47.81852083766628
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.01,1
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.025,3.3642286
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.05,4.1134094
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.1,4.9666345
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.15,5.7771684
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.2,6.423625
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.25,6.9847971012736
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.3,9.11111111111111
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.35,9.777777777777779
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.4,10.444444444444445
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.45,11.555555555555555
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.5,14
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.55,15
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.6,16
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.65,17
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.7,18
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.75,20
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.8,21
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.85,23
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.9,26.555555555555557
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.95,33.33888888888888
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.975,38.76
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.99,54.212648765680534
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.01,2.8160789897635023
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.025,3.324002421382235
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.05,4.2061912
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.1,4.7998533
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.15,5.1626843
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.2,5.5149544
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.25,5.8835531
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.3,6.232125
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.35,6.5020369
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.4,6.8340649000000004
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.45,6.993683750736036
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.5,7.057894736842105
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.55,7.195760693708408
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.6,7.372412444058924
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.65,7.584684400333049
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.7,7.913160493281842
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.75,8.236813005551815
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.8,8.730202054311812
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.85,9.288381300002959
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.9,10.173039466253861
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.95,12.351996996882079
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.975,13.944418631249341
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.99,14.646964488497364
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.01,1.1666666666666665
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.025,1.657707917908337
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.05,2.280290338158683
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.1,3.0168662583210124
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.15,3.6746762427742583
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.2,4.089672496826261
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.25,4.374968604785893
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.3,4.703494370240351
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.35,5.106064735385624
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.4,5.470471486257607
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.45,5.611111111111111
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.5,6
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.55,6
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.6,6.5
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.65,7
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.7,7.392062995921152
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.75,7.597161297022227
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.8,8.745502174377677
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.85,9.126714232631706
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.9,10
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.95,11.613888888888887
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.975,13.11111111111111
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.99,16.451111111111103
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.8888888888888888
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.025,1.2222222222222223
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.05,2.0555555555555554
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.1,2.4572222222222226
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.15,3.107769493774849
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.2,3.5858077440464107
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.25,4.053077674390793
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.3,4.350834866285902
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.35,4.681076341651666
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.4,5.151658581925476
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.45,5.343630806598668
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.5,5.967550000641207
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.55,6
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.6,6.747724892492961
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.65,6.908727971538439
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.7,7.096945367653012
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.75,7.812228230731724
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.8,8.56475134575316
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.85,10.166666666666668
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.9,12.166666666666668
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.95,15.030487600462404
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.975,17.42229787600774
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.99,21.90679145687632
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.6666666666666666
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.025,1.2222222222222223
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.05,1.7777777777777777
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.1,2.32
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.15,2.9591000393003317
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.2,3.5744710164431033
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.25,4
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.3,4.4839233480985925
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.35,5
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.4,5
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.45,5
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.5,6
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.55,6
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.6,7
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.65,7.106421749023423
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.7,7.421412853336863
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.75,8
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.8,8.333333333333334
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.85,9.555555555555555
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.9,11.555555555555555
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.95,14.777777777777779
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.975,18.11111111111111
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.99,23.6456868696396
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.6666666666666666
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.025,1
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.05,1.7777777777777777
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.1,2.111111111111111
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.15,2.585117783972477
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.2,3
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.25,3.6258184995903746
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.3,4
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.35,4.415100890098783
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.4,5
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.45,5.377221693326093
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.5,5.725197235007457
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.55,6.053698466594885
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.6,6.514723389678616
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.65,7.081503431382181
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.7,7.619660207882389
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.75,8.177001722488937
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.8,8.558393956079666
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.85,9.777777777777779
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.9,12.222222222222221
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.95,16.11111111111111
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.975,20.22222222222222
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.99,25.384706627382705
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0.75795599
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0.92
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.05,1
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.1,1.11
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.15,1.19003906303762
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.2,1.3930159348814615
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.25,1.5793361994414081
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.3,1.7204275901626451
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.35,1.861021887966363
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.4,1.9366318482606095
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.45,2.0035139985078647
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.5,2.0526315789473686
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.55,2.1548193348254694
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.6,2.2868975635040965
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.65,2.4608531120336377
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.7,2.719572409837354
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.75,2.962330467225258
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.8,3.3085225266569998
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.85,3.70996093696238
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.9,4.2317341999481215
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.95,5.487375444822146
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.975,6.383684210526314
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.99,6.853496619259124
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.01,0
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.10086597718991785
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.05,0.2836150550755104
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.1,0.6066204998178049
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.15,0.940234285650305
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.2,1.0180313132232834
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.25,1.065
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.3,1.1
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.35,1.13
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.4,1.3314944470655918
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.45,1.4396112636253542
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.5,1.8104168034704675
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.55,2
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.6,2.1152159749257384
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.65,2.2591114175735356
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.7,2.437011791637875
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.75,3.1385836719769076
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.8,3.3676646069572804
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.85,4.182343660544436
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.9,4.566621959293707
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.95,5.779880406659377
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.975,7.01812317079057
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.99,9.23849453301689
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.01,0
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.025,0
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.06735957273560038
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.1,0.23972666455035152
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.15,0.3188744030690616
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.2,0.8680586801649621
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.25,1
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.3,1.065
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.35,1.1
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.4,1.235583599690273
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.45,1.4955192016485372
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.5,1.766837902729174
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.55,2.1898881529758922
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.6,2.408603621973177
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.65,2.651259202141305
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.7,2.9025669682383173
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.75,3.3009036014074153
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.8,3.9340837
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.85,4.2775391
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.9,5.5233835
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.95,7.232332417719221
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.975,8.134146042503158
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.99,9.904128903102016
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.025,0
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.05,0.08538278073181267
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.1,0.21815489562058746
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.15,0.45377788530452967
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.2,0.5702927800153801
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.25,1
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.3,1
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.35,1
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.4,1.37
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.45,1.754218905150407
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.5,2.298740600528313
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.55,2.6858289
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.6,3.0135795
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.65,3.3832531
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.7,3.8341528
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.75,4.4069108
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.8,5.1156923
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.85,6.1694243
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.9,7.98237
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.95,9.624509771013006
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.975,11.552968077159575
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.99,14.161291632630597
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.025,0
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.12384426208524257
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.1,0.2364385588984936
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.15,0.3197113319495327
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.2,0.4019242107915906
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.25,1
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.3,1
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.35,1
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.4,1.4293037136743276
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.45,1.9734404291680898
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.5,2.5048069858859914
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.55,2.9147324
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.6,3.2880603
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.65,3.6444268
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.7,4.1363172
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.75,4.685841
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.8,5.4807927
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.85,6.5207817
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.9,8.4414667
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.95,10.068021376798352
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.975,12
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.99,16.123796994821507
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.01,83.71
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.025,87.82
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.05,91.49
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.1,95.88
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.15,98.94
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.2,101.43
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.25,108.63823068228128
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.3,113.67328826290782
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.35,118.00114107988877
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.4,119.93861572055472
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.45,121.8067370469067
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.5,123.12631578947368
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.55,126.11326295309333
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.6,129.96961957356294
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.65,134.43948392011123
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.7,142.60167
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.75,144.53372
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.8,147.2456
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.85,150.32372
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.9,155.47277
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.95,162.51205
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.975,168.92469
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.99,175.5876
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.01,57.161773154238766
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.025,69.86500000000001
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.05,75.25
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.1,85.5
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.15,91
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.2,95.32222222222222
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.25,99.77777777777777
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.3,103.27777777777777
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.35,108.77271595488774
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.4,115.48514324515665
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.45,121.99074448433052
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.5,126.5
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.55,129.5
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.6,133.5
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.65,136.67500000000007
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.7,140.5
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.75,144.21348500425557
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.8,149.5
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.85,158.4613158551428
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.9,169.04981268682627
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.95,181.63212207433884
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.975,212.3384861111111
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.99,247.52592555555555
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.01,44.07762945957933
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.025,57.16666666666667
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.05,64.78999999999999
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.1,72.16
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.15,78.095
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.2,83.5
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.25,89
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.3,95.1042848165755
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.35,101.11111111111111
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.4,106.55555555555556
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.45,112.5
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.5,118
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.55,123
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.6,129.19999999999993
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.65,136
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.7,143.5
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.75,151.5
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.8,158.4335878955435
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.85,170.81536280477317
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.9,182.71992619429506
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.95,214.47910312621894
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.975,249.37595663897216
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.99,312.6901114236091
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.01,37.111111111111114
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.025,50.333333333333336
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.05,58.94
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.1,66.35
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.15,71.78
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.2,76.36
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.25,84.96783668529629
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.3,90.70000000000005
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.35,95
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.4,100
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.45,112.55555555555556
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.5,116.11111111111111
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.55,120
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.6,129
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.65,141
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.7,152
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.75,166
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.8,182
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.85,204
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.9,218.04172106265992
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.95,243.42997829577502
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.975,274.3666666666666
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.99,357.7270351176363
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.01,35.888888888888886
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.025,47
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.05,53
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.1,62.41
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.15,68.09
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.2,72.9
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.25,81
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.3,86
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.35,91
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.4,96
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.45,101
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.5,120
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.55,124.38333333333334
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.6,129.88888888888889
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.65,136.44444444444446
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.7,151
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.75,167
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.8,187
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.85,215
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.9,255
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.95,282.4480242793253
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.975,323.21486181919835
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.99,411.57344543219125
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.01,30.500199
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.025,32.354729
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.05,33.988277
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.1,35.921045
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.15,37.449472
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.2,38.488744
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.25,39.47664
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.3,40.489873
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.35,41.431063
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.4,42.209345
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.45,43.083638
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.5,43.828669
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.55,44.683449
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.6,45.645506
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.65,46.448825
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.7,47.427712
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.75,48.77398103241293
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.8,53.4375815627393
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.85,58.35016880471681
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.9,64.17453900256594
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.95,72.02
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.975,74.57
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.99,77.63
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.01,13
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.025,17.666666666666664
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.05,20.93494762432779
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.1,25.344751634081764
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.15,28.833333333333336
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.2,30.166666666666664
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.25,32.111111111111114
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.3,33.611111111111114
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.35,35.993938075067575
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.4,37.786266
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.45,38.843821
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.5,39.898069
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.55,41.0560165
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.6,42.674292
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.65,44.10680721837918
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.7,46.34611566361143
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.75,47.466809462560526
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.8,49.2239
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.85,52.11730289150783
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.9,55.611111111111114
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.95,64.8692734668983
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.975,73.8907354635942
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.99,83.54373055079111
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.01,8.5
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.025,13.18532900037746
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.05,18.333333333333332
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.1,21.944444444444443
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.15,25.050335166666667
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.2,26.832326555555554
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.25,28.68095
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.3,31.131258850385507
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.35,33.11711599775755
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.4,35.335812110099894
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.45,36.715112000000005
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.5,39.5
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.55,41.145059084731415
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.6,43
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.65,45
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.7,47
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.75,49
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.8,51.5
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.85,55.77777777777778
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.9,61.025471588302636
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.95,71.9764843999335
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.975,78.92028159615901
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.99,100.94761420222017
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.01,8.555555555555555
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.025,12
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.05,15.222222222222221
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.1,18.655555555555555
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.15,21.76111111111111
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.2,24.11111111111111
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.25,26.961195
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.3,29.036958
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.35,31.160105
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.4,32.950767
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.45,38
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.5,40
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.55,42
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.6,43
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.65,45
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.7,47
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.75,50
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.8,53.167796
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.85,59.888888888888886
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.9,67.11
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.95,76.46818
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.975,92.2472268965865
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.99,136.7666061629258
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.01,6
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.025,8.433221152621583
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.05,14.516615
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.1,17.744959
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.15,20.665132
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.2,23.11111111111111
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.25,25.206098
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.3,27.555555555555557
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.35,29.342319
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.4,31.885731
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.45,34.048896
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.5,40
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.55,41
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.6,43
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.65,46
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.7,49.083469
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.75,53.539055
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.8,58.458217
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.85,63.111111111111114
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.9,75.46704
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.95,89.582577
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.975,103.6500756997547
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.99,153.23666666666665
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.05,0.13729967
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.1,0.44486984
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.15,0.73039792
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.2,0.93750414
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.25,1.181699520350167
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.3,1.469962740161626
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.35,1.753125
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.4,1.9021489577538069
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.45,2.0270115200152956
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.5,2.1561675
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.55,2.40031
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.6,2.8139294736187423
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.65,3.3031249999999996
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.7,3.59
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.75,3.65
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.8,3.8219619
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.85,4.3021701
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.9,4.8644668
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.95,6.0720664
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.975,7.1097892
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.99,7.9773496
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.01,0
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.025,0
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.05,0.17613144825324425
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.1,0.6168553669626815
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.15,0.9956447912313394
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.2,1.3005651209468918
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.25,1.6182617665259826
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.3,1.8246013131249088
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.35,1.9973618733617329
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.4,2.182326977695936
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.45,2.4759172344970004
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.5,3.0294420163278852
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.55,3.1863656644444083
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.6,3.3484850277777776
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.65,3.5966174
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.7,3.8437238000000002
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.75,4.0927707
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.8,4.38535435
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.85,4.670330978741086
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.9,5.520103743257497
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.95,6.902465160846178
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.975,8.130538985838012
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.99,9.934609001350822
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.01,0
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.025,0
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.11431604918075434
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.1,0.31285451228944505
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.15,0.5815885254109721
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.2,0.9600488265191394
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.25,1.2296113486762168
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.3,1.6491517128966495
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.35,1.82621345
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.4,1.9793265
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.45,2.177516988194476
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.5,2.4928295589285723
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.55,3.0506845499999997
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.6,3.3461741554590403
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.65,3.915463815714352
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.7,4.2562144
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.75,4.567857894861589
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.8,4.664502048662586
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.85,5.030805646998667
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.9,6.48652465
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.95,8.580077816293983
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.975,9.902832666381022
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.99,12.380315388368015
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.025,0
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.05,0
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.1,0.41890708371848717
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.15,0.6822533260221022
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.2,0.9458181181536718
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.25,1.1082853491213436
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.3,1.3883406
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.35,1.7401163
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.4,2.1677702
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.45,2.5220894
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.5,2.947193
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.55,3.4398042
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.6,3.9757724
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.65,4.561969
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.7,5.12927
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.75,5.8908147
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.8,6.7777431
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.85,7.366684899232586
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.9,9.2649132
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.95,12.016483
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.975,14.338392326161271
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.99,15.396944870952378
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.025,0
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.05,0
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.1,0
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.15,0.23218758
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.2,0.8698724563202376
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.25,1.0078965
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.3,1.4210381
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.35,1.8992592
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.4,2.2750491
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.45,2.7383753
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.5,3.2724114
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.55,3.84
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.6,4.2847431
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.65,4.8912193
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.7,5.66567
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.75,6.5723235
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.8,7.6085654
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.85,9.1388333
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.9,11.06363
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.95,14.469954
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.975,17.819831
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.99,21.285323000000002
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.01,1.5
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.025,1.66
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.05,2.8797406118460245
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.1,5.0130452875516145
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.15,5.645147628941056
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.2,6.326951951387956
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.25,6.85877415648653
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.3,7.234581867822097
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.35,7.628529082765106
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.4,7.822259521305064
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.45,8.004253871032326
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.5,8.115789473684211
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.55,8.353523906745455
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.6,8.648328713989056
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.65,8.996470917234895
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.7,9.54808479884457
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.75,10.19122584351347
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.8,11.211509587073584
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.85,12.217352371058945
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.9,13.48998501547869
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.95,16.970259388153973
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.975,19.847179730592615
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.99,21.08772911828655
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.01,1.08
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.025,1.5638888888888889
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.05,2.0981891746382475
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.1,2.888888888888889
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.15,3.7200394048703966
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.2,4.069983690060186
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.25,4.270623828675277
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.3,4.912453006590415
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.35,5.044362139478494
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.4,5.722222222222222
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.45,6
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.5,6.232429473809519
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.55,6.87039112871455
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.6,7
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.65,8
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.7,8
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.75,8.555555555555555
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.8,9
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.85,9.833333333333332
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.9,10.944444444444445
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.95,13.05673906048075
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.975,15.795885646746267
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.99,20.141379510868195
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.6018240289700026
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.025,1.08
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.05,1.3657814483718864
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.1,2.417797786579276
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.15,3
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.2,3.4786727249222533
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.25,4.056532423751312
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.3,4.567791957124201
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.35,5.006008830938528
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.4,5.699681669388588
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.45,6.236512666749931
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.5,6.722222222222222
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.55,6.888888888888889
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.6,7.611111111111111
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.65,7.944444444444445
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.7,8.777777777777779
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.75,9.555555555555555
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.8,10.055555555555555
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.85,11.222222222222221
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.9,13.166666666666668
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.95,15.777777777777779
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.975,19.34787539857787
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.99,23.702899969854315
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.85
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.025,1.07
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.05,1.29
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.1,2.311948120574255
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.15,2.9833333333333325
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.2,3.4444444444444446
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.25,3.888888888888889
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.3,4.222222222222222
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.35,5
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.4,6
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.45,6
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.5,7
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.55,7
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.6,8
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.65,9
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.7,10
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.75,11
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.8,12
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.85,13
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.9,15
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.95,18.333333333333332
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.975,23.77777777777778
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.99,30.980961448718396
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.93
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.025,1
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.05,1
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.1,2
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.15,2.02
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.2,3.2222222222222223
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.25,3.7777777777777777
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.3,4.111111111111111
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.35,4.555555555555555
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.4,5.222222222222222
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.45,6
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.5,6.222222222222222
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.55,7
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.6,8
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.65,9
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.7,10
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.75,11
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.8,12
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.85,14
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.9,17
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.95,20.555555555555557
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.975,26.666666666666668
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.99,34.49597314966315
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.01,27.050038
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.025,28.543149
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.05,30.06756
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.1,31.731522
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.15,33.122597
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.2,34.17111
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.25,35.122008
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.3,35.875768
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.35,36.67894
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.4,37.336404
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.45,38.177932
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.5,38.824752
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.55,39.606355
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.6,40.388502
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.65,41.219697
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.7,43.407999999999994
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.75,49.546791167396094
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.8,57.269253336239125
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.85,63.48121290465151
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.9,77.51930951783758
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.95,96.85
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.975,103.09
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.99,110.77
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.01,9.055555555555555
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.025,13.673498385030117
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.05,18.426283784593515
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.1,23.18575722222222
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.15,24.87341872222222
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.2,26.466865333333335
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.25,27.884978277777776
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.3,29.262466166666666
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.35,30.40718588888889
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.4,32.204908555733354
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.45,34.19113893325709
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.5,37.41625765318824
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.55,39.683933125418434
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.6,41.874413469740674
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.65,43.683454180004546
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.7,46
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.75,48
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.8,50.5
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.85,52.80047388467125
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.9,57.27777777777778
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.95,65.2449574576233
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.975,76.13705422122753
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.99,93.78007558809516
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.01,6.5
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.025,10.305832908683726
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.05,15.052777777777777
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.1,18.3287435
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.15,19.9911445
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.2,22.12967
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.25,23.634542500000002
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.3,25.729321243705538
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.35,28.307624062730913
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.4,30.055555555555557
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.45,32.44444444444444
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.5,37.11602290565583
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.55,39.5
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.6,41.5
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.65,44
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.7,46.5
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.75,49.5
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.8,53
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.85,57.44444444444444
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.9,65.5
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.95,75.60161240805351
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.975,97.16666666666666
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.99,122.15864188816366
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.01,5
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.025,7.8307492475147775
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.05,13.102526
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.1,15.530722
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.15,16.943484
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.2,18.63381857170168
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.25,22.994880057160735
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.3,27
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.35,28.22222222222222
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.4,37
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.45,39
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.5,41
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.55,42
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.6,44
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.65,46
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.7,48
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.75,50
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.8,57
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.85,65
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.9,77
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.95,87.10494772465644
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.975,117
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.99,144.88888888888889
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.01,2
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.025,7.655596151125463
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.05,9.8919121
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.1,12.052082
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.15,14.627212123817186
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.2,20.660896594017693
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.25,26.194444444444443
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.3,28.22222222222222
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.35,29.77777777777778
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.4,31.77777777777778
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.45,39
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.5,41
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.55,43
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.6,44
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.65,46
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.7,49
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.75,52
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.8,58
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.85,70
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.9,86
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.95,106.84135843686691
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.975,146
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.99,178
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.01,10.84
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.025,12.17
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.05,13.42
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.1,15.039404471174198
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.15,17.623596491216748
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.2,19.294658859949543
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.25,21.22111305501748
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.3,22.72947886614769
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.35,24.353942660425755
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.4,24.976902
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.45,25.468578
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.5,26.059935
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.55,26.67257
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.6,27.370978
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.65,28.028081
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.7,28.626501
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.75,29.311862
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.8,30.194681
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.85,31.002546
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.9,32.349524
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.95,34.319417
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.975,37.19
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.99,40.87
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.01,6.9388460019867
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.025,10.192222222222222
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.05,11.722222222222221
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.1,13.719999999999999
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.15,15.465
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.2,16.61
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.25,17.755515648378612
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.3,19.166666666666664
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.35,20.11111111111111
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.4,21
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.45,21.944444444444443
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.5,22.95
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.55,24.035
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.6,25.540856499999997
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.65,26.698098
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.7,28.045899
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.75,29.395
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.8,30.5
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.85,33.26113060665071
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.9,36.023691307413266
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.95,42.37555555555556
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.975,50.81861111111111
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.99,59.45151535787654
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.01,4.582175144705461
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.025,7.35
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.05,8.690000000000001
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.1,10.897683491073249
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.15,13.074788968271744
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.2,15.092371636773379
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.25,16.92177277777778
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.3,17.87263877777778
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.35,18.895724333333334
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.4,19.88454738888889
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.45,20.850123944444444
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.5,21.837726444444442
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.55,22.85942
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.6,24.080942333333333
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.65,26.18611111111111
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.7,28.5
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.75,30
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.8,33
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.85,36.33333333333333
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.9,41
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.95,48.942865961815954
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.975,59.918055555555554
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.99,74.89111111111112
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.01,4.69585777706781
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.025,7.43
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.05,9.15
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.1,11.535711
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.15,12.789446
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.2,14.666666666666666
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.25,15.555555555555555
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.3,16.444444444444443
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.35,17.666666666666668
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.4,18.77777777777778
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.45,20
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.5,21.22222222222222
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.55,25
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.6,27
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.65,28
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.7,29
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.75,31
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.8,36
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.85,42
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.9,48.41
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.95,57.82
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.975,67.15
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.99,97.38596500109034
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.01,4.372361284714007
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.025,6.4475376
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.05,8.0035686
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.1,9.8976261
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.15,11.347381
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.2,14.666666666666666
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.25,15.555555555555555
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.3,16.88888888888889
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.35,18
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.4,19.11111111111111
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.45,20.394444444444446
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.5,24
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.55,26
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.6,27
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.65,28
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.7,30
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.75,32
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.8,38
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.85,46
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.9,56.43
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.95,67.7
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.975,78.92
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.99,116.80741098395985
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.01,4.6805719
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.025,5.2629591
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.05,6.1111214
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.1,6.901302
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.15,7.4947257
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.2,8.0350629
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.25,8.4849077
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.3,8.8872292
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.35,9.3594022
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.4,9.6619017
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.45,10.050977
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.5,10.416481
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.55,10.785682
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.6,11.237924
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.65,11.690771
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.7,12.150785
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.75,12.747259
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.8,13.493576811320397
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.85,15.195870988021653
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.9,18.551571940858235
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.95,19.88
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.975,21.08
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.99,22.55
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.01,1.2222222222222223
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.025,2.457850518521444
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.05,3.649541051461211
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.1,4.772222222222222
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.15,5.333333333333334
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.2,6
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.25,6.263888888888889
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.3,7.111111111111111
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.35,7.374773692998646
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.4,8.055555555555555
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.45,8.705491919346311
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.5,9.785615343341119
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.55,10.720634745726558
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.6,11.244715038307525
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.65,11.677808500000001
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.7,12.5133645
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.75,13.006797055555555
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.8,14.00301961111111
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.85,14.956236555555556
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.9,16.605917055555558
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.95,20.048819166666664
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.975,23.767307666666667
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.99,26.80935812193325
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.7588331400246522
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.025,2.180841431787495
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.05,3.6008564361789857
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.1,4.5
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.15,4.777777777777778
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.2,5.655555555555557
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.25,5.833333333333334
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.3,6.555555555555555
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.35,6.916365325440033
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.4,8.327022408393479
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.45,9.471998713351358
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.5,9.997844976310432
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.55,10.604938956018582
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.6,11.643032999999999
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.65,12.0086585
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.7,13.003853
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.75,14.051921499999999
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.8,15.047863388888889
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.85,16.641555722222222
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.9,19.056761055555555
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.95,23.7052905
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.975,29.33158538888889
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.99,33.67548106213411
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.01,1.1111111111111112
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.025,2
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.05,3
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.1,4
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.15,5
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.2,6
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.25,6
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.3,7
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.35,7.622589778215354
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.4,8
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.45,9
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.5,10.896269
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.55,11.719565
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.6,12.778575
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.65,13.809244
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.7,14.989359
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.75,16.216363
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.8,17.94066
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.85,20.283573
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.9,23.652056
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.95,29.649762
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.975,35.26597782436508
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.99,40.47
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.01,1.1111111111111112
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.025,1.8888888888888888
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.05,2.8371688
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.1,3.4444444444444446
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.15,4.333333333333333
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.2,5
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.25,5.644096337742507
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.3,7
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.35,7
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.4,8
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.45,8
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.5,10.582042
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.55,11.583819
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.6,12.660759
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.65,13.874246
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.7,15.244593
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.75,16.639499
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.8,18.803056
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.85,22.049779
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.9,26.899408
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.95,35.42
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.975,39.59
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.99,45.42395137422363
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0.06052631578947366
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0.06413043478260867
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.05,0.121
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.1,0.49090909090909096
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.15,0.565
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.2,0.6769230769230767
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.25,1.1930070868406046
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.3,1.803986038033939
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.35,2.32957
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.4,2.4584515
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.45,2.6083994
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.5,2.7408836
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.55,2.8924303
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.6,3.0679922
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.65,3.2237691
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.7,3.4099681
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.75,3.6453839
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.8,3.9280105
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.85,4.2739245
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.9,4.7178587
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.95,5.5088403
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.975,6.0335074
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.99,6.8535151
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.014891736618074365
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.056311980777911386
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.05,0.29490958455174976
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.1,0.7257822958083754
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.15,1.0064625998352696
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.2,1.2663476130160871
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.25,1.4651017971688716
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.3,1.6962474900210842
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.35,1.8995389301435446
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.4,2.0927016914900705
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.45,2.8114854613238194
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.5,3.199868588888889
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.55,3.617164131169419
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.6,4.302130888922087
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.65,4.889286064784242
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.7,5.51972056952063
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.75,6.343975824546358
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.8,7.2653021378659854
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.85,8.30764884707258
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.9,9.170087478591736
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.95,11.478631797959434
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.975,13
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.99,15.175866498723042
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.005
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.025,0.01
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.1430799923894027
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.1,0.5363341918920065
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.15,0.7476452025027002
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.2,0.9979665079483668
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.25,1.265945183384241
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.3,1.546886697892716
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.35,1.7690172232744046
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.4,2.37242287512106
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.45,2.462966486429732
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.5,3.465541342950614
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.55,3.8682567386426943
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.6,4.811157506806586
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.65,5.306788094000009
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.7,6.392236086247783
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.75,7.054209348440084
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.8,8
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.85,9
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.9,10
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.95,12
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.975,14.0305675
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.99,20.272345633516487
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.01
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.03
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.05,0.14019747
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.1,0.31987768
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.15,0.47608134
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.2,0.69690831
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.25,0.93266795
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.3,1.1506064
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.35,1.3991389
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.4,1.9058042818124061
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.45,2.610303999905301
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.5,3.640738661064022
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.55,4.939575303520121
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.6,6
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.65,7
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.7,7.777777777777778
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.75,8.666666666666666
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.8,10
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.85,11
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.9,12
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.95,14.937727
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.975,20.668677
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.99,29.591788
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.0022942903
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.02232827
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.069458434
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.1,0.19377165
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.15,0.36602817
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.2,0.54624405
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.25,0.7492336
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.3,0.98880463
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.35,1.5895610838787508
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.4,2.2793542036992194
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.45,3.4728811273257043
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.5,5.185974972317094
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.55,5.888888888888889
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.6,6.555555555555555
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.65,7.666666666666667
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.7,8
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.75,9
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.8,10
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.85,11
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.9,13.114923
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.95,19.432157
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.975,27.204231
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.99,41.617074
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.01,15.020223
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.025,16.737106
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.05,18.187575
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.1,20.236039
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.15,21.58
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.2,22.39
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.25,23.1
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.3,23.76
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.35,24.39
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.4,24.99
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.45,25.59
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.5,26.19
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.55,26.8
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.6,27.44
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.65,28.11
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.7,28.82
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.75,29.62
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.8,30.52
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.85,32.38935739724663
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.9,36.33047323823435
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.95,39.781877
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.975,42.243631
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.99,46.442804
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.01,7.012326270468136
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.025,9.444444444444445
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.05,10.944444444444445
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.1,13.11111111111111
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.15,14.222222222222221
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.2,15.72155722651894
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.25,17.042636501377515
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.3,18
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.35,19
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.4,20
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.45,21
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.5,21.069299353571427
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.55,22.48637085869523
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.6,24.898201361216316
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.65,25.498932716722464
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.7,26.915
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.75,27.994999999999997
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.8,29.66
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.85,30.334377012786447
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.9,33.035
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.95,37.16274902259018
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.975,41.51260579462959
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.99,55.267281971495066
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.01,5
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.025,6.277777777777778
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.05,7.611111111111111
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.1,9.722222222222221
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.15,12.00504138102906
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.2,13.724586101136898
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.25,15.329682100466055
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.3,16.666666666666668
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.35,17.27777777777778
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.4,18.166666666666664
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.45,19
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.5,22.57105127142857
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.55,23.71
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.6,24.765
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.65,25.86
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.7,27.509999999999998
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.75,29.244999999999997
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.8,31.095
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.85,34.135000000000005
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.9,37.525
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.95,40.9252279824018
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.975,49.747690393473434
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.99,65.38561479529992
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.01,4.666666666666667
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.025,6.111111111111111
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.05,7.438888888888889
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.1,9
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.15,11.044245419558369
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.2,14.027834906130312
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.25,16
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.3,17
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.35,18
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.4,19
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.45,20
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.5,24.6
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.55,25.83
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.6,27.12
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.65,28.51
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.7,30.04
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.75,31.77
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.8,33.8
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.85,38
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.9,44
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.95,50.37469330062316
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.975,58.02366279229276
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.99,76.37373737357595
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.01,4.111111111111111
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.025,5.444444444444445
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.05,6.555555555555555
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.1,8.444444444444445
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.15,10.339547185975714
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.2,13.7199789456242
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.25,16
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.3,17
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.35,18
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.4,22.31263524583759
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.45,24.05
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.5,25.36
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.55,26.74
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.6,28.2
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.65,29.77
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.7,31.52
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.75,33.49
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.8,35.81
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.85,40
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.9,50
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.95,62.95450962034659
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.975,64.57471768574926
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.99,86.38064553397288
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.01,15.14816
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.025,16.974051
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.05,18.748259
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.1,21.004988
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.15,22.356683
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.2,23.770117
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.25,24.864032
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.3,25.818179
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.35,26.868599
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.4,27.808078
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.45,28.731748
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.5,29.731555
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.55,30.7601
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.6,31.598441
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.65,32.56418
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.7,33.511643
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.75,34.667518
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.8,35.861853
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.85,37.37
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.9,38.44
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.95,43.55502041282789
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.975,47.659629
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.99,51.075039
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.01,7.722222222222222
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.025,9.735736723429309
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.05,12.19635877706269
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.1,14.692451350926719
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.15,16.376699446148265
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.2,18.14015499326435
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.25,21.961308419299673
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.3,23.851486637705055
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.35,24.711054043833187
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.4,26.561947060675717
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.45,27.43277985198722
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.5,28.73400730353001
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.55,29.646323136965854
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.6,30.450605745036402
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.65,32.284236157046934
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.7,33.1823057675999
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.75,34.44771634595847
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.8,36.93
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.85,38.055
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.9,39.875
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.95,42.135000000000005
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.975,46.44135167083873
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.99,58.629715006649036
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.01,6.111111111111111
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.025,8.581944444444444
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.05,10.333333333333332
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.1,13.31911618759371
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.15,15.671334640003845
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.2,18.02952004727515
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.25,19.481142356840543
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.3,21.072070962997202
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.35,23.83438857874082
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.4,24.895702891391238
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.45,27.222882614294868
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.5,28.54144088214285
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.55,29.26055033080317
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.6,31.154115444188555
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.65,31.8106262004384
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.7,35.95432515349252
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.75,37.292822398143414
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.8,38.920101615790465
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.85,40.12472966375873
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.9,44.874151849353815
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.95,50.1717122913622
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.975,58.664690162174196
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.99,69.61333333333333
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.01,6
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.025,7.111111111111111
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.05,9.444444444444445
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.1,12.666666666666666
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.15,15.373591733975086
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.2,18.153663072886474
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.25,20.973815770183656
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.3,24.053956068930848
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.35,25.63
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.4,26.61
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.45,27.58
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.5,31.74796985714288
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.55,34
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.6,36
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.65,38
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.7,41
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.75,44
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.8,47
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.85,51
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.9,57
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.95,65.0732213241096
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.975,71.3544556435554
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.99,83.22999999999999
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.01,5
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.025,7
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.05,8.444444444444445
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.1,11.437343544008167
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.15,15.4561998433889
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.2,18
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.25,20
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.3,22
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.35,24
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.4,26
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.45,27.94
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.5,30
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.55,33
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.6,35
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.65,38
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.7,41
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.75,44
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.8,49
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.85,54
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.9,61
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.95,72
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.975,82
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.99,98.64421593778248
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0.066604721
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0.18573207
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.05,0.33063323
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.1,0.53607149
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.15,0.64106128
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.2,0.76162569
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.25,0.87091874
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.3,0.97542031
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.35,1.0640259
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.4,1.1506073000000001
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.45,1.2430513
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.5,1.3545492
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.55,1.4562377
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.6,1.5767925
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.65,1.7251840810380341
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.7,2.16
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.75,2.25
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.8,2.35
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.85,2.47
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.9,2.6728313
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.95,3.2891816
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.975,3.8819098
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.99,4.655792
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.01,0
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.025,0
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.05,0
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.1,0.013967898
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.15,0.37469950728976276
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.2,0.48724939138582624
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.25,0.6419802217807427
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.3,1
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.35,1
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.4,1.0779971281546952
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.45,1.193661641161512
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.5,1.4941576333333333
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.55,1.7523428393536338
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.6,2.0555555555555554
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.65,2.331666666666667
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.7,2.613864031925751
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.75,2.82790675
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.8,3.4085434343006966
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.85,3.8389125
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.9,4.7910955
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.95,6.000098449999999
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.975,7.2329217
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.99,9.003501317807686
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.01,0
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.025,0
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.05,0
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.1,0
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.15,0.32723329718347816
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.2,0.7914047369501934
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.25,1
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.3,1
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.35,1
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.4,1.2222222222222223
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.45,1.5297292930378261
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.5,1.9444444444444444
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.55,2.0555555555555554
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.6,2.5072222222222225
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.65,2.855
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.7,2.935
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.75,3.08676645
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.8,3.8526917000000003
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.85,4.2091141
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.9,5.44835605
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.95,7.146530908426604
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.975,8.679948770039758
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.99,10.218393076626814
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.025,0
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.05,0
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.1,0
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.15,0.6666666666666666
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.2,0.8888888888888888
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.25,1
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.3,1
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.35,1
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.4,2
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.45,2
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.5,2.111111111111111
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.55,2.3333333333333335
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.6,3
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.65,3
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.7,3.13
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.75,4
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.8,4.2684926
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.85,5.4723018
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.9,7.555727
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.95,10.49812752181218
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.975,15.273869409654935
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.99,15.98054707639981
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.025,0
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.05,0
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.1,0.11431863055750702
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.15,0.6666666666666666
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.2,0.8888888888888888
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.25,1
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.3,1
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.35,1
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.4,1.9172778391302205
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.45,2.111111111111111
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.5,2.2222222222222223
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.55,2.5555555555555554
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.6,3.111111111111111
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.65,3.51
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.7,3.75
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.75,4.02
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.8,4.8640571
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.85,6.5035463
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.9,8.8424085
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.95,11.65625993687761
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.975,16.70333744132982
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.99,19.392224104610086
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.01,12.49
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.025,13.33
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.05,14.1
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.1,15.02
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.15,15.67
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.2,16.2
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.25,16.67
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.3,17.1
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.35,17.522834270962598
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.4,18.29102755384705
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.45,18.91959109172124
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.5,19.321052631578947
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.55,20.057631130500987
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.6,21.00309009321177
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.65,21.977227
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.7,22.450194
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.75,23.022164
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.8,23.668894
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.85,24.377478
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.9,25.475156
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.95,26.981459
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.975,28.131502
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.99,30.419434
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.01,4.658819617850361
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.025,8.3905624
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.05,9.61111111111111
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.1,11.666666666666668
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.15,12.665
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.2,13.672202309728622
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.25,14.76774138553957
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.3,16.430740248991057
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.35,17.516796785125592
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.4,18.48800838888889
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.45,19.389989833333335
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.5,20.378782166666667
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.55,21.266461
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.6,22.16188727777778
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.65,23.161866166666666
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.7,24.11111111111111
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.75,24.833333333333336
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.8,26.11111111111111
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.85,28.166666666666664
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.9,30.41664922822006
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.95,37.4431810538322
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.975,41.80434080907172
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.99,51.91976342070343
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.01,3.9980838197308257
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.025,6.661306
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.05,8.35865205
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.1,10.041967
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.15,11.465
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.2,12.698991437988386
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.25,14.045136245658778
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.3,15.104284999999999
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.35,17.092059283783833
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.4,17.58970078743115
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.45,19.47047555743491
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.5,20.20549785714286
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.55,20.782788045739693
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.6,22.696896149076792
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.65,23.29175987494633
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.7,26.5137338246122
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.75,28.444444444444443
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.8,30.833333333333336
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.85,34.05555555555556
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.9,37.55555555555556
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.95,44.55555555555556
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.975,51.61604468143278
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.99,65.62305910716049
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.01,3.5694387
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.025,6
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.05,8
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.1,9
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.15,10.96
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.2,12.522337
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.25,14.150208
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.3,15.796041
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.35,17.22222222222222
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.4,18.57405440233399
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.45,19.22222222222222
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.5,21.07971855714283
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.55,22.59874929735156
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.6,22.855691711951724
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.65,25.539327316742835
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.7,27.037534713428663
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.75,36
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.8,38.90352469563811
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.85,44
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.9,50
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.95,59
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.975,67.57884133412901
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.99,83.77888888888889
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.01,3.039522898152406
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.025,6
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.05,7
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.1,9
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.15,10.236020279694849
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.2,12.09
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.25,13.643367
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.3,15.666666666666666
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.35,16.77777777777778
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.4,17.84444444444445
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.45,19
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.5,24.787784
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.55,27
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.6,30
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.65,33
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.7,36
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.75,40
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.8,45
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.85,52
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.9,60
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.95,70.12224912467812
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.975,77.58832932253968
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.99,92.44555555555556
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.01,11.120760869565217
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.025,13.082543934715858
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.05,17.061570874766844
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.1,21.665028386831466
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.15,23.625818120623343
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.2,25.16873489380898
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.25,26.933795120382705
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.3,28.216553768266426
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.35,29.295670190705476
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.4,29.999459391244674
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.45,30.629628353424906
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.5,31.143421052631577
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.55,32.0628716465751
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.6,33.14338374601023
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.65,34.31729855929452
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.7,36.20744623173357
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.75,38.23682987961729
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.8,40.58011126003717
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.85,43.11449437937665
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.9,47.134517067713986
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.95,55.43592912523315
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.975,61.60956132844203
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.99,65.62205414078106
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.01,8.16073573066097
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.025,11.222222222222221
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.05,13.555555555555555
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.1,16.9995591562259
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.15,19.455062589964957
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.2,22.11809711318547
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.25,24
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.3,25
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.35,26
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.4,27
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.45,28
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.5,32
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.55,33.39
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.6,34.56
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.65,35.82
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.7,37
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.75,38.7
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.8,40
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.85,42.57
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.9,45.37
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.95,49.8
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.975,61.39722222222221
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.99,76.99675958303317
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.01,7.222222222222222
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.025,9.555555555555555
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.05,11.666666666666666
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.1,14.444444444444445
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.15,17.213503641938914
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.2,20.43047088629722
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.25,23
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.3,24
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.35,26
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.4,28
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.45,30
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.5,31.72
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.55,33.13
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.6,34.62
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.65,36.21
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.7,37.96
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.75,39.92
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.8,42.2
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.85,45
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.9,49.542335770604026
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.95,64.23046465590477
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.975,72.60032674937801
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.99,94.22444444444444
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.01,6.055555555555555
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.025,8.333333333333332
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.05,9.886111111111111
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.1,13.049034042176018
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.15,16.456544008255413
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.2,19
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.25,20.5
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.3,22.5
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.35,24
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.4,26
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.45,29.075
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.5,30.869999999999997
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.55,33.2
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.6,35.58
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.65,38.03
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.7,40.58
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.75,44.265
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.8,48.155
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.85,53.370000000000005
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.9,60.185
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.95,72.53373842465257
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.975,85.66944444444445
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.99,108.61031233306278
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.01,4.166666666666666
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.025,6.333333333333334
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.05,8
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.1,12.706174936389036
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.15,15.947015343543388
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.2,18.044444444444444
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.25,19.77777777777778
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.3,21.261111111111113
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.35,22.833333333333336
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.4,24.11111111111111
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.45,27.389299918233814
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.5,30.955
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.55,32.394999999999996
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.6,35.39
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.65,38.97
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.7,42.165
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.75,46.025
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.8,51.120000000000005
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.85,58.105000000000004
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.9,67.28999999999999
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.95,81.3376754193642
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.975,101.30694444444444
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.99,128.74111869158344
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.01,8.28
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.025,9.51
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.05,10.69
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.1,13.979621213719222
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.15,17.592381296734224
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.2,20.288266617228498
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.25,23.34106
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.3,24.515004
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.35,25.335069
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.4,26.488151
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.45,27.453866
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.5,28.417394
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.55,29.399275
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.6,30.63002
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.65,31.779409
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.7,33.239216
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.75,34.697071
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.8,36.383337
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.85,38.541642
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.9,40.703149
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.95,45.269143
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.975,48.7423
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.99,52.792016
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.01,6.8423023999999995
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.025,9.9282075
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.05,11.480480499999999
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.1,13.5
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.15,14.5
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.2,15.5
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.25,17
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.3,20.5
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.35,21.7672165
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.4,23.671233613678496
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.45,25.639660043308346
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.5,27.640633166666667
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.55,28.845079555555557
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.6,30.19404022222222
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.65,32.049825722222224
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.7,33.884377
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.75,36.113549388888885
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.8,38.66093616666667
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.85,41.94444444444444
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.9,46.548853
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.95,54.7560733719794
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.975,64.34859447629599
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.99,80.2307908281299
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.01,3.5
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.025,6.22053245
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.05,7.6707334
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.1,9.642972499999999
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.15,11.21
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.2,12.995000000000001
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.25,14.697848548624663
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.3,17.365073348760554
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.35,20.125676789586556
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.4,23.437468095102584
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.45,25.415639628933352
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.5,27.31224311111111
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.55,28.497135358368233
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.6,30.183252669976778
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.65,33.300849166666666
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.7,35.80538322222222
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.75,38.83333333333333
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.8,41.611111111111114
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.85,45.33333333333333
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.9,50.44444444444444
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.95,63.770329405051704
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.975,77.91576800655751
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.99,103.33646006544316
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.01,1.34414587352494
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.025,3.7210208
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.05,5.4213422
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.1,8.7413324
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.15,11.453489
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.2,13.311353
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.25,16.071342
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.3,18.69
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.35,20.865162
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.4,22.87936
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.45,25.492192
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.5,28
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.55,31.127281
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.6,34.517892
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.65,36
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.7,38
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.75,41
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.8,43
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.85,48
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.9,55.666666666666664
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.95,73.4215586116203
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.975,99.78888888888888
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.99,133.44908
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.91535014
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.025,2.054507
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.05,3.8810448
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.1,7.1837562
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.15,9.8996718
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.2,12.776004
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.25,15.041048
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.3,20.96
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.35,22.89
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.4,24.86
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.45,27.484568
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.5,31.241598
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.55,33
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.6,35
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.65,37
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.7,39.57
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.75,43.11
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.8,47.36
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.85,52.74
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.9,62
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.95,86.83927940059984
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.975,116
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.99,155
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.01,11.794954851058854
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.025,14.033495756341933
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.05,17.699076498169923
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.1,21.850914481974872
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.15,23.4150234899072
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.2,24.6131016471164
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.25,25.978501429462106
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.3,27.104374974597878
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.35,28.07037021630505
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.4,28.726219263839134
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.45,29.36571042192892
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.5,29.914736842105263
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.55,30.625678466959975
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.6,31.44583955969028
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.65,32.33595790869495
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.7,33.618291692068794
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.75,35.18879023720456
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.8,36.95997527596052
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.85,39.0309140100928
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.9,41.64999460893422
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.95,47.545923501830075
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.975,52.11124108576333
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.99,55.261132105462885
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.01,6.8327404919712125
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.025,9.607844561899578
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.05,12.084884342024402
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.1,15
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.15,17
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.2,19.48414982036445
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.25,21.220680611953423
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.3,22.847792880187495
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.35,24.36036227328875
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.4,25.81119737521582
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.45,27.202279394529416
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.5,28.657567538111646
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.55,30
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.6,31
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.65,31
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.7,32
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.75,33
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.8,34
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.85,35
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.9,36
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.95,43.39806697293767
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.975,51.724999999999994
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.99,61.52501560441446
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.01,3.888888888888889
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.025,6.222222222222222
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.05,9.050782653373238
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.1,12.681518640789609
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.15,15
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.2,17
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.25,21.3415930066035
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.3,22.427764130471388
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.35,23.51525833524355
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.4,27.977690430843328
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.45,29
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.5,30
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.55,31
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.6,32
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.65,33
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.7,34
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.75,36
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.8,37
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.85,39
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.9,42
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.95,45.00555555555555
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.975,56.94722222222222
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.99,67.6
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.01,5.840962110342114
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.025,7.333333333333334
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.05,9.5
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.1,12.26808598267878
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.15,14.526763057011678
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.2,17.1411746439572
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.25,19.195623401140672
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.3,21
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.35,22.66386945856506
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.4,24.703558543915914
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.45,29.09881524017144
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.5,31.675
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.55,32.935
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.6,34.730000000000004
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.65,36.585
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.7,38.019999999999996
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.75,40.07
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.8,42.79
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.85,45.785
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.9,49.28
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.95,55.989999999999995
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.975,62.19666666666667
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.99,78.17448618448219
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.01,5.166666666666667
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.025,6.611111111111111
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.05,8.555555555555555
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.1,11.625816403558375
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.15,14.513892217016156
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.2,16.5
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.25,17.5
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.3,19
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.35,20.5
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.4,23.807482499686067
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.45,26.60345160160438
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.5,30.935
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.55,32.775
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.6,34.66
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.65,36.614999999999995
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.7,38.665
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.75,41.345
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.8,44.225
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.85,47.925
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.9,52.7
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.95,60.385000000000005
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.975,67.4
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.99,83.63132328082632
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.01,5.05
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.025,5.53
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.05,5.98
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.1,7.1705691849160775
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.15,8.124037657225887
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.2,8.962606504341394
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.25,9.951211124791408
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.3,10.615620619030633
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.35,11.362620641809627
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.4,11.661077536365536
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.45,11.941043425604983
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.5,12.142105263157893
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.55,12.523956574395017
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.6,13.015000895007015
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.65,13.52800435819037
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.7,14.447046047636032
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.75,15.390455541875259
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.8,16.212035
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.85,17.037825
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.9,18.215765
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.95,20.250443
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.975,22.347929
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.99,24.91693
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.01,2.0850013065521296
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.025,3.403450824628426
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.05,4.154999999999999
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.1,5.261791553267139
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.15,6.297562196643176
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.2,7.054148500640792
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.25,7.716097982416067
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.3,8.30348251661612
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.35,8.888043544359867
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.4,9.338929621058316
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.45,10.262115626429466
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.5,11.254772388248881
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.55,11.889463825395602
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.6,12.376261388888889
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.65,13.082840277777777
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.7,13.686172555555554
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.75,14.354923743317734
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.8,15.263479333333333
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.85,16.501936
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.9,17.954863222222222
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.95,21.10110261111111
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.975,23.972779
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.99,26.751776066307222
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.01,1.6790291629261267
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.025,2.8083333333333336
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.05,3.5633333333333335
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.1,4.575
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.15,4.835
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.2,5.5600000000000005
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.25,5.907126958935835
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.3,6.658045091442686
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.35,7.611111111111111
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.4,8.208298351158316
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.45,9.377999325282527
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.5,10.5586445
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.55,11.193489777777778
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.6,11.942911166666667
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.65,12.6688695
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.7,13.393542777777778
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.75,14.476154170000044
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.8,15.839188111111111
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.85,17.453409333333333
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.9,19.550284666666666
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.95,23.151379
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.975,26.839994410320337
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.99,30.506363919615303
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.01,1.6666666666666667
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.025,2.4381093452489697
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.05,3.01
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.1,3.72
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.15,4.29
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.2,4.78
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.25,5.24
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.3,6.663733731158676
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.35,7.777777777777778
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.4,8.883372488604651
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.45,10.018781
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.5,10.740297
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.55,11.523032
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.6,12.358343
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.65,13.192392
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.7,14.211863
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.75,15.354847
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.8,17.115729
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.85,19
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.9,21
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.95,25.555555555555557
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.975,31.667245
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.99,33.45600803362639
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.01,1.3327759237046437
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.025,2.2222222222222223
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.05,2.76
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.1,3.51
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.15,4.1
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.2,4.62
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.25,5.12
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.3,6.304640807196922
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.35,7.666666666666667
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.4,8.6503251
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.45,9.4368045
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.5,10.326801
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.55,11.263867
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.6,12.306359
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.65,13.768138
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.7,14.991657
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.75,16.403923
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.8,18
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.85,19
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.9,22.11111111111111
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.95,28.88888888888889
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.975,36.117315143220885
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.99,39.07946586108598
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.01,15.07
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.025,16.42
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.05,17.391548
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.1,18.489257
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.15,19.155725
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.2,19.754601
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.25,20.284476
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.3,20.773971
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.35,21.218776
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.4,21.713138
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.45,22.171846
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.5,22.541557
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.55,22.978934
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.6,23.458835
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.65,23.894624
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.7,25.94694624876101
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.75,28.561202602539694
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.8,30.52
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.85,31.8
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.9,33.46
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.95,36.05
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.975,38.44
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.99,41.37
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.01,5.7316179546120605
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.025,9.620059042715397
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.05,11.608333333333334
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.1,12.944444444444445
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.15,14.5
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.2,15.31699790020142
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.25,15.769815316706893
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.3,16.853579293636816
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.35,17.86661604085414
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.4,18.779918024252318
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.45,19.830637822506745
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.5,20.708888260546125
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.55,21.42467907634156
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.6,22.447275834497482
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.65,23.331738361875253
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.7,24.37023427777778
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.75,25.584243555555556
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.8,28.874590868662562
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.85,31.416846186211238
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.9,35.04386336790128
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.95,39.852160425508686
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.975,49.028999428426474
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.99,54.47292658381016
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.01,4.4960333059004665
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.025,7.573462275296089
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.05,9
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.1,11.661990409607917
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.15,13.219196636583192
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.2,14.397504783297194
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.25,15.438483918148805
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.3,16.962039832852618
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.35,17.860704764145183
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.4,18.741185515651072
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.45,19.746437781713368
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.5,20.834227372903293
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.55,21.905971740024363
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.6,23.35389225849714
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.65,25.920672502123445
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.7,26.830953449979685
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.75,29.175502225010536
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.8,33.169466013196214
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.85,35.24431857742272
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.9,37.97614579400941
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.95,43.81420523337205
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.975,57.04194444444444
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.99,70.4157316410701
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.01,3
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.025,7.1018145892864295
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.05,10
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.1,11.273719818045173
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.15,13.333333333333334
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.2,14.444444444444445
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.25,16.059369335785583
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.3,17.433131016929867
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.35,19.03506863908928
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.4,20.210122387074918
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.45,22.044003252170445
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.5,23.918685
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.55,25.560542
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.6,27.204718
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.65,28.699473
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.7,30.616365
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.75,38.89
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.8,41.57
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.85,44.89
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.9,48.38037921744995
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.95,51.407882
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.975,63.74
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.99,81.67666666666666
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.01,2
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.025,7
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.05,9
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.1,11.431219929014071
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.15,12.88888888888889
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.2,14.381185995255986
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.25,17.005234
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.3,18.636276
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.35,20.234815
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.4,21.815244
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.45,23.679283
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.5,25.705782
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.55,28.358283
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.6,30.519683
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.65,37.29
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.7,39.61
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.75,42.24
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.8,45.35
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.85,49.2
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.9,54.43
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.95,63.376526950145305
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.975,82.237333
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.99,100.50163
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.01,1.9210381
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.025,2.2387257
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.05,2.6593898
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.1,3.142565
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.15,3.5367741
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.2,3.9075174
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.25,4.2009705
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.3,4.5068952
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.35,4.7781773
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.4,5.0770992
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.45,5.3433181
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.5,5.6243539
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.55,5.9175858
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.6,6.2820355
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.65,6.675343
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.7,7.0485058
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.75,7.5330617
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.8,8.0535204
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.85,8.634422
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.9,9.6788372
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.95,11.264759
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.975,12.807783
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.99,14.592883
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.820076502302173
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.025,1.2803051258146794
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.05,2.166666666666667
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.1,2.4444444444444446
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.15,3.1973082
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.2,3.411855051251072
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.25,4.0748616
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.3,4.2831285999999995
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.35,4.950177050000001
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.4,5.406254483333333
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.45,5.6838980285714324
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.5,6.111111111111111
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.55,6.450032828571423
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.6,6.655184123749656
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.65,7.277777777777778
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.7,7.722284999999999
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.75,8.003720300000001
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.8,8.2797365
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.85,9.265204449999999
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.9,10.379408999999999
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.95,11.814131
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.975,13.021971
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.99,15.71597911110106
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.49836694123449743
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.025,0.7617259115808377
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.05,1.6889089656706133
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.1,2.2330175659215343
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.15,3.14444385
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.2,3.3242017500000003
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.25,4.00551125
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.3,4.191985600000001
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.35,4.36937845
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.4,5.06370605
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.45,5.24716405
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.5,6.333333333333334
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.55,6.701017555555556
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.6,7.209054783333333
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.65,7.862037572222222
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.7,8.55991391111111
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.75,9.34068975
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.8,10.2737077
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.85,11.2791685
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.9,12.913562500000001
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.95,14.714255999999999
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.975,16.6427805
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.99,19.215939575521052
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.16946270544544298
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.025,1
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.05,1
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.1,2.309871715927786
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.15,3
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.2,3.4116249
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.25,4
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.3,4.1946916
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.35,4.6462832
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.4,5.555555555555555
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.45,6.111111111111111
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.5,6.666666666666667
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.55,7.222222222222222
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.6,7.666666666666667
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.65,8.444444444444445
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.7,9.11111111111111
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.75,9.88888888888889
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.8,11
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.85,12.88888888888889
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.9,16.22222222222222
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.95,20.77777777777778
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.975,25
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.99,28
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.4444444444444444
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.025,1
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.05,1.3375611025922773
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.1,2
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.15,2.8786806
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.2,3.111111111111111
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.25,3.7777777777777777
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.3,4.2156035
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.35,4.666666666666667
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.4,5.222222222222222
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.45,5.6619089
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.5,6.2275245
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.55,6.888888888888889
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.6,7.555555555555555
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.65,8.222222222222221
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.7,9.333333333333334
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.75,10.222222222222221
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.8,11.555555555555555
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.85,13.444444444444445
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.9,17.444444444444443
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.95,22.338888888888885
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.975,28.613888888888887
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.99,35.19841223571429
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.01,1.6031139
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.025,1.9599007
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.05,2.2285919
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.1,2.5961681
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.15,2.9173735
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.2,3.2299349
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.25,3.4221032
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.3,3.6244096
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.35,3.8037884
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.4,4.0056092
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.45,4.2405438
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.5,4.4622924
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.55,4.7017552
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.6,4.9187018
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.65,5.1862466
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.7,5.667437351516407
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.75,6.328507386805617
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.8,7.304985679916664
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.85,8.537083333333333
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.9,9.5
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.95,10.22
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.975,10.88
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.99,11.69
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.028997248095698782
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.6403711681633495
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.05,1.2648176090956507
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.1,2
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.15,2.111111111111111
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.2,2.2222222222222223
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.25,2.833333333333333
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.3,3.0555555555555554
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.35,3.458033244976944
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.4,4.0663639499999995
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.45,4.588175837625361
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.5,4.8490075
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.55,5.29547477152526
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.6,5.666666666666666
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.65,5.833333333333334
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.7,6.062394905555555
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.75,6.581383188888889
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.8,7.316047688888888
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.85,8.057289333333333
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.9,9.245229511111111
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.95,11.339761859518063
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.975,12.641819923617009
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.99,15.414213687417021
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.013316533534993413
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.025,0.5036920315567347
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.05,1.2222222222222223
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.1,1.7777777777777777
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.15,1.9444444444444444
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.2,2.111111111111111
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.25,2.7222222222222223
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.3,3.0752447379064884
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.35,3.495059422401681
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.4,4.1475349
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.45,4.390756161111112
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.5,5.065649919047618
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.55,5.6293903
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.6,5.82408075
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.65,6.5167482
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.7,6.833333333333334
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.75,7.190562816666667
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.8,8.222222222222221
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.85,9.14402398888889
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.9,10.693097444444444
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.95,13.328821999999999
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.975,14.966983
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.99,18.253899071420896
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.02411088545606232
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.7777777777777778
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.05,1.1111111111111112
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.1,1.9365437
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.15,2
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.2,2.3333333333333335
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.25,3
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.3,3.2892448480225087
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.35,3.7750987
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.4,4.1188247
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.45,4.4515625
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.5,6
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.55,6
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.6,7
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.65,7
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.7,8
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.75,8
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.8,9
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.85,10.333333333333334
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.9,12.88888888888889
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.95,17.5
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.975,19.51
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.99,22.08
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.07836925415538766
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.10837434448139381
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.05,1
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.1,1.4444444444444444
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.15,2
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.2,2.111111111111111
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.25,2.9126173316081765
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.3,3.129732
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.35,3.4633553
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.4,4
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.45,4.2016588
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.5,6
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.55,7
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.6,7
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.65,8
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.7,8
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.75,9
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.8,10
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.85,11.11111111111111
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.9,14.222222222222221
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.95,19.77777777777778
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.975,22.52
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.99,26.155245
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.01,1.4
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.025,1.58
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.05,1.76
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.1,1.98
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.15,2.8622274926900886
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.2,3.6626602627635796
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.25,4.799271832080267
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.3,5.1681825
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.35,5.5048542
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.4,5.813181
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.45,6.1287634
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.5,6.4387606
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.55,6.8084241
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.6,7.2091096
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.65,7.664278
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.7,8.055637
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.75,8.5815649
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.8,9.0594693
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.85,9.705047
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.9,10.464504
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.95,11.746323
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.975,13.140698
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.99,14.706734
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.9444444444444444
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.025,1.175
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.05,1.876424577634936
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.1,2.420823861677225
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.15,2.8219168280625535
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.2,3.5098434218306824
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.25,3.9455400761049435
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.3,4.493456587137942
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.35,5.0110239801676055
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.4,5.363062547871563
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.45,5.944444444444445
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.5,6.440462025692917
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.55,6.833333333333334
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.6,7.055555555555555
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.65,7.666666666666666
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.7,8
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.75,8.666666666666668
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.8,9.277777777777779
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.85,10.11111111111111
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.9,11.666666666666668
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.95,15.040557886997917
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.975,17.87145311017045
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.99,22.60242283370959
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.5585394277777778
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.025,1
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.05,1.6524016733805997
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.1,2.366329957610899
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.15,2.9444444444444446
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.2,3.302550797657644
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.25,4
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.3,4.222222222222222
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.35,5
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.4,5.38574859994695
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.45,6.166666666666666
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.5,6.5
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.55,7.333333333333334
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.6,7.611111111111111
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.65,8.38888888888889
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.7,8.7896358373945
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.75,9.53634108176568
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.8,11.08244240878469
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.85,12.046093737376266
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.9,13.77012305513708
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.95,17.155656837774025
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.975,21.118667136014306
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.99,29.25864929348983
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.086184733
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.67450206
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.05,1.5184284868498872
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.1,2.0930907
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.15,2.43
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.2,3.2613384242409147
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.25,3.7777777777777777
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.3,4.555555555555555
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.35,5.222222222222222
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.4,6
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.45,6.7062126
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.5,7.222222222222222
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.55,7.777777777777778
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.6,8.444444444444445
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.65,9
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.7,10.11111111111111
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.75,11.88888888888889
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.8,13.222222222222221
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.85,15.333333333333334
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.9,18.91321
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.95,22.474612996526066
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.975,27.13520735515929
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.99,36.00185536827474
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.1356203926756892
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.35571759
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.05,1
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.1,1.5921103
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.15,2.4548198
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.2,3.2847466
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.25,3.888888888888889
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.3,4.6517169
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.35,5
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.4,5
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.45,7.111111111111111
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.5,7.444444444444445
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.55,8.333333333333334
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.6,8.777777777777779
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.65,9.666666666666666
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.7,11.222222222222221
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.75,13
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.8,15
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.85,17.11111111111111
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.9,22.77777777777778
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.95,27.37565445720005
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.975,31.751553680426934
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.99,44.13687010952426
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.01,3.6273533
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.025,4.1750806
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.05,5.2056381
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.1,6.1844908
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.15,7.0051684
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.2,7.6365746
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.25,8.154501
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.3,8.649058
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.35,9.1399484
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.4,9.6048987
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.45,10.049077
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.5,10.522853
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.55,11.03483
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.6,11.654699
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.65,12.343164
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.7,12.933992
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.75,13.723775
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.8,14.598124
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.85,15.660089
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.9,17.136346
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.95,19.157687
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.975,20.755154
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.99,23.826145
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.01,1.414493812161596
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.025,2.3582500679181724
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.05,2.8540206564610453
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.1,3.8480751547784564
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.15,4.772806943688517
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.2,5.52834500586704
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.25,5.874818889220144
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.3,7.13285645
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.35,7.433294075167071
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.4,8.036535163690512
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.45,8.558296000913757
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.5,9.125475037950526
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.55,9.749198483047014
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.6,10.390463045220137
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.65,11.115783505621838
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.7,11.873134340492726
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.75,12.701760302254385
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.8,13.815337587464072
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.85,14.537262062438899
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.9,16.500422
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.95,18.177709999999998
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.975,19.416714777777777
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.99,23.643159166666667
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.8888888888888888
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.025,1.6111111111111112
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.05,2.246843833333333
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.1,2.978829619567332
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.15,3.5946544366445057
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.2,4.217882022824291
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.25,4.839000628737109
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.3,5.872993788742858
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.35,6.225489872915626
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.4,6.972083808946062
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.45,7.65200456426447
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.5,8.347015730740061
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.55,9.15652301099264
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.6,10.03817246494383
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.65,11.11499842514409
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.7,11.940831866947569
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.75,13.086267654458824
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.8,14.671690533788638
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.85,15.504822
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.9,17.255172
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.95,19.889741830413527
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.975,22.010934499999998
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.99,26.391483690795184
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.01,1
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.025,1.4901419
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.05,1.9340447
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.1,2.5314921
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.15,3.1436449
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.2,3.6377881
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.25,4.1733245
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.3,5.173445407808331
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.35,6
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.4,7
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.45,8.523861176921855
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.5,9.91794965964624
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.55,10.613119436051836
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.6,12.772789886521663
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.65,14
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.7,15
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.75,16
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.8,17
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.85,18
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.9,20
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.95,23
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.975,26
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.99,29.556666666666665
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.73021932
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.025,1.1029605
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.05,1.5181128
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.1,2.0502120346523824
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.15,2.58313087149984
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.2,3.39693852046629
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.25,4.100994506151525
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.3,5
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.35,6.252088882095256
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.4,7.958343075899902
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.45,9.280848590386816
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.5,10
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.55,11
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.6,12
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.65,13
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.7,14
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.75,15
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.8,16
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.85,18
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.9,20
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.95,23
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.975,27
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.99,32.89111111111111
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.01,42.56
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.025,45.22
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.05,47.63
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.1,54.525725631103235
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.15,57.610642430714975
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.2,61.10701809042497
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.25,63.59558
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.3,64.598164
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.35,65.493585
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.4,66.529895
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.45,67.434061
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.5,68.249456
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.55,69.245021
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.6,70.064702
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.65,71.110757
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.7,72.262403
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.75,73.350028
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.8,74.666052
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.85,76.114212
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.9,78.195384
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.95,81.490373
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.975,84.293598
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.99,88.32
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.01,27.48298107188053
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.025,31.611111111111114
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.05,36.82388888888889
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.1,41.32666270238671
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.15,45.87249243228095
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.2,49
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.25,51.039850212501236
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.3,53.33462642740046
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.35,55.520677712486304
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.4,57.57400722962477
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.45,59.58444907775696
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.5,62.02717320583099
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.55,64.10792460616
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.6,65.96770737461418
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.65,68.05826941588153
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.7,70.87290045426536
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.75,73.6929785938907
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.8,77.63981401469006
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.85,87.0011337346462
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.9,90.7762955
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.95,96.2101615
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.975,105.118275
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.99,125.2508761111111
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.01,22.291111111111114
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.025,27.104166666666668
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.05,31.776111111111113
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.1,36.64069239099541
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.15,42.111111111111114
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.2,45.266666666666666
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.25,47.77777777777778
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.3,50.20046836576611
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.35,53.069104050166466
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.4,55.50687864682321
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.45,57.50037612220858
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.5,59.85622611308375
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.55,62.05749488136345
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.6,64.82079710083565
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.65,67.92701179528424
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.7,71.0357217638144
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.75,75.331071500373
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.8,78.91775235646583
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.85,83.99699521169407
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.9,96.11551213228302
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.95,113.39687905646379
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.975,126.68079373993133
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.99,152.7738088174106
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.01,21.01
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.025,24.46
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.05,28.105555555555554
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.1,34.099999999999994
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.15,40
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.2,43
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.25,46
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.3,49
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.35,51
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.4,54
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.45,56
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.5,58
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.55,61
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.6,64
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.65,67
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.7,70
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.75,82.98134014186827
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.8,108.36884
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.85,115.45977
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.9,126.35859
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.95,138.77213405576816
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.975,155.95012279152073
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.99,187.62995
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.01,17
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.025,20.444444444444443
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.05,25.11111111111111
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.1,30.444444444444443
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.15,36
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.2,41
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.25,44
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.3,47
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.35,49
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.4,52
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.45,54
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.5,57.63568511223493
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.55,67.77437558869833
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.6,78.0486142715615
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.65,88
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.7,95
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.75,104
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.8,114
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.85,128
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.9,145
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.95,163.1106392024163
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.975,181.09631077706575
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.99,227
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0.96139556
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.025,1.207715
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.05,1.4966151
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.1,1.9132549
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.15,2.251044
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.2,2.5442751
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.25,2.8095138
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.3,3.0472298
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.35,3.2730853
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.4,3.5538013
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.45,3.7805617
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.5,3.9872361
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.55,4.2023838
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.6,4.4662367
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.65,4.8201989
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.7,5.119614
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.75,6.23664528769758
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.8,7.746659033999647
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.85,8.76
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.9,9.33
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.95,10.23
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.975,11.07
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.99,12.11
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.017786040747459434
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.5294421683345849
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.05,0.9429359020749649
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.1,1.2850050265761932
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.15,1.8888888888888888
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.2,2.0555555555555554
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.25,2.292739014698415
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.3,3.0079908267636073
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.35,3.2903166055555557
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.4,3.5966215524414165
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.45,4
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.5,4.055555555555555
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.55,4.829032183333334
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.6,4.959894046675058
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.65,5.416248891876139
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.7,6.0079793171469245
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.75,6.604195385641551
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.8,7.423554011111111
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.85,8.419082472846029
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.9,9.753272194444445
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.95,11.951360471377878
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.975,13.755498139544247
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.99,16.021820213023855
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.01113519472517708
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.025,0.3558250728084219
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.8837262487491933
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.1,1.2777777777777777
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.15,2.04010575
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.2,2.2111111111111117
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.25,2.5
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.3,3.0555555555555554
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.35,3.1407538081872994
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.4,3.6340695611820504
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.45,4.136941599870441
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.5,4.845226707541613
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.55,5.295059649689254
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.6,5.890702771424988
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.65,6.35193674650096
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.7,7.122026822222223
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.75,7.755477844444445
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.8,8.722235307115426
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.85,10.095301917211838
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.9,12.291244333333333
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.95,15.079364361917012
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.975,17.625218993271545
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.99,21.023043054339144
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.04065408727376437
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.07865844510573841
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.05,0.90177156
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.1,1.7260691
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.15,2
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.2,2.4444444444444446
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.25,2.7777777777777777
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.3,3
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.35,3.4068645589300863
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.4,4
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.45,5.112893655619052
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.5,6.173695807491458
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.55,7.017978573269996
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.6,8.1319831
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.65,8.5064069367417
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.7,9.815443781013693
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.75,10.475854478136288
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.8,11.394119979614919
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.85,12.561054055218825
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.9,14.79
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.95,18.207804089975916
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.975,25.05833333333333
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.99,27.546048304005947
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.030379415
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.13165942150255047
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.68714142
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.1,1
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.15,2
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.2,2
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.25,3
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.3,3.0012613508822374
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.35,3.83333628361991
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.4,4.074608253914709
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.45,6.457529129622301
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.5,7.5362340199564954
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.55,7.743717084815964
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.6,9.172940805839994
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.65,9.241739582388545
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.7,11.044496026554095
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.75,11.573021393650043
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.8,13.020429615345925
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.85,14.09076034604903
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.9,17.08
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.95,21.11111111111111
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.975,26.88960365987735
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.99,34.12576330294199
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.01,94.92
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.025,100.34
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.05,105.21
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.1,113.52935001859085
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.15,120.6948491240493
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.2,126.15457386176627
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.25,132.66215739259007
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.3,138.01934461889397
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.35,142.06483886262743
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.4,143.47296187918008
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.45,145.279616179288
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.5,146.11578947368417
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.55,149.4114949318231
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.6,153.18507733650617
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.65,157.46016113737255
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.7,162.71806
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.75,164.77858
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.8,166.98762
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.85,169.67732
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.9,172.7396
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.95,178.05061
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.975,181.05744
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.99,185.6852
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.01,66.10261791965395
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.025,79.16318941182698
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.05,90.67288451311134
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.1,100.71666666666667
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.15,106.76944444444445
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.2,111.16666666666666
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.25,114.70833333333334
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.3,118.5
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.35,121.38888888888889
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.4,125.0222222222223
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.45,128.47605285748162
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.5,136
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.55,139.5238134960241
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.6,143.30554774184836
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.65,146.68693159028555
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.7,151.83495107698428
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.75,156.97406282854985
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.8,163.6633510642955
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.85,168.0458391309529
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.9,177.73241500000017
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.95,191.9574711111111
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.975,209.3398561111111
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.99,237.67771064365215
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.01,54.72026382085188
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.025,69.49636421626107
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.05,78.94444444444444
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.1,88.55
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.15,95.27777777777777
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.2,99.93333333333334
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.25,104.16666666666666
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.3,108.77777777777777
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.35,112.38888888888889
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.4,119.5
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.45,123.5
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.5,127
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.55,132
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.6,136.05370700221363
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.65,141.98627053901083
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.7,147.37753363449218
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.75,155.69827720405777
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.8,163.13392272388413
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.85,172.9341083050645
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.9,187.40131559002262
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.95,207.20938339703625
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.975,233.12619
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.99,274.3312872222222
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.01,46
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.025,58.77777777777778
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.05,69.4388888888889
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.1,80.77777777777777
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.15,87.76111111111112
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.2,93.22222222222223
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.25,97.11111111111111
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.3,102.11111111111111
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.35,109
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.4,114
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.45,119
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.5,124
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.55,128
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.6,134
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.65,139
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.7,145
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.75,152
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.8,160.90072503326684
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.85,176.62083399244747
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.9,198.93663113766672
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.95,236.35996862506008
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.975,267.0388485104266
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.99,322.93468
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.01,39.65503818758576
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.025,55.05277777777778
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.05,65.55000000000001
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.1,75.1
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.15,82.53888888888889
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.2,87.3111111111111
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.25,94.39647629158716
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.3,100
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.35,105
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.4,110
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.45,115
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.5,121
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.55,126
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.6,131
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.65,137
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.7,143
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.75,150
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.8,159
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.85,175.48798587419327
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.9,200.85886972183908
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.95,233.9128829165349
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.975,281.03849330619096
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.99,388.4318427396863
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.01,49.594378
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.025,54.993754
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.05,59.758528
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.1,65.738601
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.15,69.449374
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.2,72.379362
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.25,75.181095
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.3,77.93102
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.35,80.726698
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.4,83.11941
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.45,85.628403
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.5,87.973302
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.55,90.316833
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.6,92.769738
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.65,95.646431
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.7,98.185001
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.75,101.15225
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.8,104.04487
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.85,108.29647
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.9,113.28631
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.95,120.57938
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.975,129.47067345127226
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.99,135.8191282891518
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.01,33.220787033666895
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.025,39.07038902883065
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.05,44.41832839611004
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.1,53.907945130558076
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.15,58.19279148852539
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.2,61.85013953574165
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.25,65.05306031543645
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.3,68.8528570013005
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.35,72.13958522675122
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.4,75.40529412920822
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.45,78.63653743345373
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.5,81.8384379784394
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.55,85.04078355423765
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.6,88.6628031828512
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.65,92.4449047072556
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.7,95.08546999615072
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.75,98.67544349388508
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.8,101.44155766309868
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.85,104.13949709860437
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.9,111.22683231457573
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.95,118.87128290473439
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.975,127.95296256545222
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.99,148.98055555555555
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.01,23.97854795780019
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.025,29.54200121657245
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.05,34.84099215620857
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.1,42.51988193996772
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.15,47.21269917062345
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.2,52.971764
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.25,58.824296270641725
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.3,62.00138335784116
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.35,68.9006320914192
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.4,72.70592661978411
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.45,78.00293139555245
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.5,82.68900780742823
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.55,87.75570881705596
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.6,93.00487822845673
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.65,97.28456626426271
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.7,102.15794266351142
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.75,107.11509313861367
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.8,111.345
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.85,116.86500000000001
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.9,122.28978016628263
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.95,131.53167196019484
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.975,145.87526434434983
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.99,169.71646345679596
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.01,12.666666666666666
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.025,20.989427764921764
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.05,27.966093903994278
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.1,40.64023771506295
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.15,48
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.2,51
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.25,54
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.3,57
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.35,61.913614
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.4,68.935663
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.45,75.618811
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.5,82
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.55,86
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.6,92.08
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.65,95.48
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.7,100
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.75,105
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.8,112
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.85,120
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.9,131
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.95,147
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.975,162
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.99,189.25919464521937
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.01,11.666666666666666
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.025,17.31696219762195
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.05,25.391785381372394
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.1,38
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.15,44
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.2,48
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.25,51
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.3,54
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.35,59.471423
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.4,65
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.45,69
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.5,74
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.55,79
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.6,91.64
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.65,95.41
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.7,99.51
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.75,104.1
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.8,110
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.85,120
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.9,133
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.95,155
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.975,175
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.99,207.89654147706202
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.01,1.48
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.025,1.65
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.05,1.9703563
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.1,2.4864326
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.15,2.9262279
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.2,3.2151318
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.25,3.5492151
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.3,3.8062204
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.35,4.1048266
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.4,4.4098293
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.45,4.7196706
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.5,5.027073
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.55,5.132803339593871
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.6,5.285806252088253
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.65,5.437366611709545
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.7,5.768997611445611
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.75,6.045408119638675
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.8,6.40147445349943
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.85,6.908628969054766
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.9,7.559286555284578
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.95,8.682543296308435
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.975,9.633314724904277
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.99,10.133366642720247
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.6400653933333333
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.9825508199999999
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.05,1.2196852055555556
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.1,1.81471585
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.15,1.95
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.2,2.514957406827617
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.25,2.915823731665997
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.3,3
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.35,3.4143379140366994
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.4,3.9842388919176317
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.45,4
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.5,4.723192410215589
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.55,5.005353487781004
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.6,5.182645336623214
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.65,5.86354547700992
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.7,6.148211145487284
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.75,6.910461501265612
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.8,7.2823484999999994
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.85,8.178741200000001
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.9,9
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.95,10.48687
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.975,12
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.99,14.001666666666665
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.1527227332904491
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.025,0.5811357433333333
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.958266975
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.1,1.1668180525771632
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.15,1.7581081833333334
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.2,2
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.25,2.10973498306775
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.3,2.56729864128235
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.35,3.059155176477814
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.4,3.2756973641479004
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.45,4.055823942835533
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.5,4.26284885
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.55,4.535552355555556
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.6,5.2251358
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.65,5.4518714500000005
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.7,6.2000326
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.75,6.5
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.8,7.4795801
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.85,8.5
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.9,9.11111111111111
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.95,11.277777777777779
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.975,13.555555555555555
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.99,15.69448636424536
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.26983719
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.05,0.8888888888888888
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.1,1.080334
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.15,1.3333333333333333
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.2,1.8888888888888888
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.25,1.983359519944239
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.3,2.6183590930606404
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.35,2.88
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.4,3.09
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.45,3.819408593155074
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.5,4.5023483
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.55,5
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.6,5.574416
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.65,6
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.7,6.6808186
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.75,7
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.8,8
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.85,8
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.9,9.222222222222221
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.95,12.11111111111111
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.975,15.555555555555555
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.99,16.95183043900274
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.14137032990724518
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.34326457
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.1,0.89007089
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.15,1.2222222222222223
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.2,1.4444444444444444
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.25,1.8888888888888888
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.3,2.5182960685907947
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.35,2.820846122857973
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.4,3.5370468
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.45,3.9359639
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.5,4.3978068
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.55,5
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.6,5.7725635
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.65,6
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.7,7
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.75,7
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.8,8
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.85,8
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.9,10.11111111111111
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.95,13.227777777777773
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.975,16.94722222222222
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.99,18.718816777361337
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.01,28.53
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.025,31.4
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.05,34.07
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.1,36.816298
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.15,38.665011
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.2,40.116609
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.25,41.349694
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.3,42.532024
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.35,43.518782
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.4,44.755551
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.45,45.785852
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.5,46.75691
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.55,47.683052000000004
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.6,49.087574
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.65,50.29544
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.7,54.62935524750817
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.75,59.8496136155422
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.8,62.54
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.85,65.43
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.9,69.21
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.95,75.16
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.975,80.65
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.99,87.45
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.01,12.222222222222221
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.025,19
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.05,23.22222222222222
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.1,28.54444444444444
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.15,31.203230701633004
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.2,35.269898814330254
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.25,38.92788169874333
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.3,41.96849550817889
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.35,45.20583604381921
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.4,48.587659787147444
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.45,51.262486
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.5,54.566482320598325
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.55,57.26026898975328
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.6,60.81438658425176
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.65,64.24943525449241
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.7,66
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.75,69.335101
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.8,73.641175
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.85,79.689189
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.9,84.65116698775064
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.95,87.66666666666667
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.975,109.87697
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.99,123.45589276026439
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.01,10.333333333333334
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.025,17
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.05,20
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.1,26.87148948226678
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.15,30.555555555555557
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.2,34.249791
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.25,37.796563
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.3,41.996021
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.35,45.899746
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.4,50.067557
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.45,53.608291
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.5,64.53999347619049
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.55,69.36541794603409
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.6,74.04561077640645
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.65,79.22
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.7,83.36
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.75,86.751893
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.8,93.46
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.85,100
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.9,109.13
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.95,116.56280732679586
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.975,137.52
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.99,171.5722222222222
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.01,8.078092168030004
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.025,15.666666666666666
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.05,19
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.1,24.444444444444443
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.15,28.444444444444443
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.2,32.333333333333336
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.25,35.536917
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.3,40.585007
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.35,45.364067
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.4,49.992996
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.45,55.603369
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.5,72.1908716904762
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.55,74.61807779601767
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.6,86.25
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.65,90.93
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.7,98.050221
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.75,103.33347321906022
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.8,122
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.85,130
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.9,138.8862052483014
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.95,150.20916850285633
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.975,174
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.99,192.22444444444443
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.01,7.29100668057636
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.025,14.777777777777779
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.05,18.37930957898765
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.1,23.555555555555557
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.15,26.555555555555557
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.2,30.444444444444443
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.25,33.333333333333336
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.3,37.655128
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.35,44.58251
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.4,54.17736590031719
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.45,73.89965262835199
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.5,82.95743490635229
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.55,90.74
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.6,95.76
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.65,101.19
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.7,108.19526966536957
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.75,114
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.8,135.84382077765682
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.85,154.0474322219577
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.9,154.10363878436914
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.95,173.70436534106005
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.975,218
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.99,240
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.01,2.2500924
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.025,2.8532156
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.05,3.2704571
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.1,3.8366303
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.15,4.2611799
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.2,4.6790695
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.25,5.0542022
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.3,5.4004894
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.35,5.6807066
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.4,5.9623934
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.45,6.3229412
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.5,6.6361104
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.55,6.9965704614282265
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.6,7.7333336282273795
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.65,8.634065399774414
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.7,9.2
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.75,9.61
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.8,10.09
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.85,10.66
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.9,11.43
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.95,12.65
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.975,13.79
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.99,15.266095
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.6979053427976936
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.025,1.5834135687241995
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.05,2.4597582222222223
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.1,3.233261616666667
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.15,3.7215044944444444
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.2,4.252292422222222
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.25,4.692360094444444
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.3,5.07635215914429
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.35,5.860344311893047
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.4,6.438349758576848
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.45,7.0549511768568465
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.5,7.811725610346885
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.55,8.295008551023319
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.6,9.027391985320646
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.65,9.61111111111111
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.7,10.38888888888889
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.75,11.37888888888889
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.8,11.722222222222221
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.85,12.722222222222221
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.9,14.545
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.95,16.625
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.975,18.665
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.99,22.762636599804836
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.48075021531576734
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.025,1.1188403813229506
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.05,1.9286712000000001
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.1,2.7741492
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.15,3.0985499
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.2,3.90984015
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.25,4.1963817
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.3,4.833940785038806
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.35,5.687299670389139
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.4,6.894517374143799
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.45,7.7641528436576674
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.5,8.333333333333334
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.55,9.11111111111111
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.6,9.61111111111111
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.65,10.5
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.7,11
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.75,11.944444444444445
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.8,13.166666666666668
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.85,14.53857
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.9,17.072490055555555
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.95,20.588832500000002
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.975,23.952177
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.99,29.1519225
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.56898613
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.94905003
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.05,1.3825896
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.1,2.1732232
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.15,2.9067407
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.2,3.6358492
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.25,4.795033924049379
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.3,5.777777777777778
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.35,6.222222222222222
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.4,6.777777777777778
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.45,7.555555555555555
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.5,9
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.55,10
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.6,10.446294
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.65,11.64679
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.7,13.014996
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.75,14.789061
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.8,16.798014
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.85,19.376421
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.9,22.47
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.95,26.6434666596203
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.975,33.931498
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.99,41.102448
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.17317252157846763
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.75102753
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.05,1.2799371
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.1,2.1814661
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.15,2.9735485
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.2,3.995401397968713
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.25,5.333333333333333
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.3,5.888888888888889
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.35,6.606547
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.4,7.5893831
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.45,8.801246
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.5,10.130138
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.55,11.357003
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.6,13.114556
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.65,14.86248
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.7,16.478359
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.75,19.186628
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.8,22.049322
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.85,25.526851
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.9,28.649404346132794
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.95,32
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.975,42.61388888888889
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.99,58.22999999999999
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.01,2.5087181
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.025,3.1529615
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.05,3.41
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.1,3.7
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.15,3.91
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.2,4.08
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.25,4.362268411882068
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.3,5.2597363471096665
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.35,6.162060522929538
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.4,6.5658102594755885
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.45,6.940885982641284
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.5,7.205263157894736
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.55,7.771891795136492
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.6,8.482817191504802
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.65,9.47231447707046
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.7,10.187721
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.75,10.762192
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.8,11.371565
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.85,12.183229
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.9,13.231427
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.95,14.585447
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.975,15.745853
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.99,17.110415
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.01,1.2222222222222223
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.025,1.3888888888888888
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.05,2.4871402025562883
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.1,3.1994768818720365
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.15,3.7922639981064994
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.2,4.384247424976346
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.25,4.919523495517195
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.3,5.788905891371149
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.35,6.166666666666666
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.4,7
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.45,7.197222222222223
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.5,7.944444444444445
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.55,8
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.6,8.333333333333332
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.65,8.886399968009748
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.7,9.277777777777779
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.75,10.166666666666668
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.8,11.222222222222221
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.85,12.166666666666668
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.9,14.033993293092813
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.95,17.588984266289952
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.975,20.385401640589016
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.99,24.39089757813139
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.6137683390892859
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.025,1.4444444444444444
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.05,2.2260270239216706
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.1,2.9412698488519737
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.15,3.645
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.2,4.577238933691902
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.25,5.465704672401047
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.3,6.333333333333334
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.35,6.666666666666666
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.4,7.263899391319544
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.45,7.833333333333333
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.5,8.136993168571431
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.55,8.96100175366075
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.6,9.290628828397454
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.65,10
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.7,11.298786495943508
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.75,12.444444444444445
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.8,13.622222222222224
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.85,14.38888888888889
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.9,16.77777777777778
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.95,20.44249591099137
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.975,23.167828835310935
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.99,26.378268520210312
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.22135076005580737
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.025,1
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.05,1.646606361447504
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.1,2.836827887965431
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.15,3.22
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.2,4.910079643944147
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.25,6.222222222222222
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.3,7.222222222222222
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.35,7.777777777777778
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.4,8.555555555555555
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.45,9.333333333333334
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.5,9.777777777777779
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.55,10.444444444444445
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.6,11.11111111111111
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.65,11.777777777777779
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.7,13.527388662391118
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.75,14.443386682459128
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.8,15.444444444444445
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.85,17.666666666666668
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.9,22.22222222222222
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.95,31
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.975,40.623984
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.99,42.01565757619047
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.2403769004945253
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.025,1
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.05,1.3952363849488345
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.1,2.84
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.15,3.78297798994392
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.2,5.493527196309227
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.25,6.555555555555555
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.3,7.333333333333333
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.35,8.11111111111111
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.4,8.88888888888889
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.45,9.777777777777779
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.5,11.475859264066688
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.55,14
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.6,15
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.65,16
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.7,17
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.75,18
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.8,20
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.85,22
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.9,25.08612209626525
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.95,34.82230292451112
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.975,46.67222222222222
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.99,54.480241930733314
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.01,69.37222598337434
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.025,75.91982669625231
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.05,87.065877
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.1,92.69459
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.15,96.721422
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.2,99.913423
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.25,102.60629
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.3,105.32893
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.35,107.94042
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.4,110.24363
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.45,112.49391
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.5,114.8077
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.55,116.98956
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.6,119.17199
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.65,121.61746
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.7,124.1255
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.75,127.60103
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.8,131.28932
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.85,135.87104
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.9,140.4835
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.95,148.11359
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.975,156.76059
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.99,165.09605
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.01,44.88333333333333
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.025,53.06944444444444
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.05,60.20912018441014
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.1,71.11523618197819
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.15,78.69603135784338
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.2,84.81703793738139
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.25,88.76314127777778
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.3,92.07600838888888
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.35,95.4926462358096
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.4,98.46278566666666
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.45,107.38888888888889
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.5,110.15829798576563
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.55,113.92591743677553
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.6,117.7614646188266
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.65,122.07757976946398
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.7,126.64833829573554
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.75,131.19910994436663
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.8,137.69776501084948
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.85,144.5
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.9,152.5
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.95,163
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.975,175.81805555555553
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.99,199.55666666666667
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.01,33.617777777777775
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.025,40.55361111111111
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.05,48.302741999999995
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.1,58.09220596758044
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.15,66.81539932718731
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.2,71.72223883333334
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.25,75.60537144444444
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.3,79.66522172222221
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.35,83.38170644444443
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.4,87.56286921497193
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.45,92.96719971410747
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.5,102.85716257570076
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.55,106.85912523127624
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.6,112.4038114197244
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.65,117.83111091499674
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.7,123.10065399119122
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.75,129.9155788073294
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.8,136.25118651545557
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.85,143.08690637049344
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.9,155.412831141756
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.95,180.02808413091307
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.975,203.85587214953168
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.99,241.22555555555556
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.01,27.64
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.025,33.53
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.05,39.41
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.1,49.025693
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.15,54.605404
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.2,60.391472
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.25,65
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.3,71
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.35,76.11111111111111
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.4,84
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.45,91
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.5,97
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.55,105
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.6,113
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.65,122
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.7,127
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.75,132
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.8,139.20000000000027
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.85,147
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.9,158.58340007335804
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.95,190.8483066749282
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.975,217.28709328007315
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.99,292.6755573315806
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.01,20.393021
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.025,26.357393
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.05,32.997523
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.1,44.48630103611333
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.15,52.55555555555556
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.2,57.77777777777778
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.25,61.888888888888886
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.3,67.07777777777778
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.35,76.12
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.4,81.22
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.45,86.41
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.5,91.8
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.55,97.46
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.6,105
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.65,115
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.7,124
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.75,131
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.8,137
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.85,147.8
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.9,164.52
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.95,192.15
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.975,226.65492813579118
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.99,327.6488442291461
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.01,2.6653306
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.025,3.0742183
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.05,3.4865003
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.1,3.9672987
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.15,4.3626988
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.2,4.6577357
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.25,4.935106
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.3,5.1997703
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.35,5.4194316
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.4,5.6322837
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.45,5.868152
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.5,6.1084592
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.55,6.377891
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.6,6.6527182
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.65,7.0245743
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.7,7.3331375
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.75,7.7946008
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.8,8.2010596
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.85,8.61
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.9,8.99
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.95,9.57
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.975,10.926676933089103
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.99,11.589215221806672
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.9444444444444444
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.025,1.1642360677632517
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.05,1.8811822536446394
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.1,2.628675597213719
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.15,2.9861950443631193
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.2,3.610068805981113
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.25,3.716635297682391
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.3,3.833333333333333
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.35,4.483146874881915
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.4,4.624026975301398
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.45,5
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.5,5.9617928
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.55,6
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.6,6.3850584571102775
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.65,6.888970811164388
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.7,7.1538913
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.75,7.84858735
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.8,8.622209250000001
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.85,8.910148249999999
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.9,9.8249369
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.95,11.514444444444445
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.975,12.5935705
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.99,14.434812
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.8333333333333333
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.025,1
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.05,1.6715642287636423
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.1,2
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.15,2.7222222222222223
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.2,2.833333333333333
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.25,3.0555555555555554
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.3,3.666666666666667
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.35,3.7777777777777777
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.4,4
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.45,4.428343351865028
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.5,5.095544805082277
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.55,5.627971340585379
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.6,5.861180455675103
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.65,6.515174755555556
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.7,7.185177899999999
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.75,7.9303709
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.8,8.74768995
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.85,9.696524
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.9,10.689361944444444
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.95,12.362128
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.975,13.958218500000001
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.99,16.012615500000003
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.5555555555555556
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.025,1
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.05,1
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.1,2
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.15,2.3333333333333335
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.2,2.5555555555555554
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.25,3
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.3,3.111111111111111
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.35,3.381113623176196
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.4,4.261954931857306
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.45,5
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.5,5
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.55,6
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.6,6
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.65,7
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.7,7.8684727
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.75,8.5035122
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.8,9.3489032
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.85,10.490454
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.9,11.5
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.95,14.005555555555551
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.975,16.451359
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.99,20.345141
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.17353155459653313
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.025,1
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.05,1
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.1,1.8888888888888888
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.15,2
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.2,2.6444444444444457
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.25,2.7777777777777777
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.3,3.111111111111111
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.35,3.4120959860905278
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.4,4
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.45,5
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.5,5
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.55,6
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.6,6.832652342462424
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.65,7
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.7,7.795778221862262
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.75,9.13
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.8,9.77
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.85,10.57
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.9,11.777777777777779
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.95,15
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.975,18.909465
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.99,22.275861172241328
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.01,19.444277
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.025,21.367797
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.05,22.500739
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.1,24.176866
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.15,25.396894
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.2,26.254897
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.25,27.219668
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.3,28.017327
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.35,28.897791
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.4,29.666622
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.45,30.279709
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.5,30.869319
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.55,31.598601
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.6,32.365969
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.65,33.120287
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.7,34.039663
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.75,35.211209
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.8,36.562983
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.85,38.13841084867228
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.9,41.01666227584469
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.95,45.47
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.975,47.24
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.99,50.080047
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.01,8.642584098738162
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.025,11.730965732334912
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.05,14.63141198255019
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.1,17.803164940061524
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.15,19.790492347546774
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.2,21.658886240355578
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.25,23.00824259131442
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.3,24.50420148024802
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.35,25.894094891330276
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.4,30.573925848517764
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.45,31.606355501129002
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.5,33.91511631765398
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.55,35.583052059954326
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.6,36.98652045661389
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.65,37.94309733960644
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.7,39.26665612720734
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.75,40.765
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.8,41.885000000000005
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.85,43.125
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.9,44.59
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.95,47.80590003329121
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.975,52.8625
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.99,65.93937133166887
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.01,7.388333333333334
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.025,10.166666666666668
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.05,12.333333333333332
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.1,15.94809392749707
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.15,18.598791972296
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.2,20.960108921898822
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.25,23.013761602978292
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.3,24.657010796848567
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.35,26.13051291574246
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.4,31.007468444644665
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.45,31.94566708229388
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.5,34.49587773233468
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.55,35.701511203420395
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.6,36.28175683890613
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.65,40.93
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.7,42.065
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.75,43.769999999999996
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.8,45.585
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.85,47.565
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.9,49.85
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.95,53.864999999999995
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.975,59.40138888888882
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.99,75
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.01,6.111111111111111
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.025,8.4795536
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.05,11
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.1,13.11111111111111
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.15,17.8817339730855
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.2,21.443262945444175
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.25,25.36444229581298
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.3,28.686629478172463
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.35,30.55
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.4,31.74
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.45,32.92
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.5,40
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.55,42
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.6,44
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.65,45
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.7,47
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.75,50
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.8,52
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.85,55
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.9,59
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.95,65
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.975,70
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.99,85.44777777777777
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.01,5.444444444444445
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.025,7.719444444444444
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.05,9.6530492
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.1,13.133242783582364
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.15,18.595131143427338
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.2,22.67030806827904
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.25,26.815433595136238
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.3,29.69
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.35,31.03
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.4,32.34
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.45,37
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.5,39
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.55,41
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.6,43
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.65,45
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.7,47
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.75,50
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.8,53
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.85,56
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.9,61
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.95,69
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.975,75
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.99,94.57333333333332
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0.17537799
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.05,0.384883
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.1,0.5068226424627981
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.15,0.8372039204195121
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.2,1.0902278419907756
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.25,1.3790815099877136
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.3,1.5397703
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.35,1.7209731
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.4,1.9021191
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.45,2.0186865951153212
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.5,2.063157894736842
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.55,2.195757849329123
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.6,2.352496416921304
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.65,2.5883391955151573
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.7,2.985750107076871
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.75,3.4459184900122852
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.8,3.9572796
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.85,4.4580985
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.9,5.174995539355383
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.95,6.3553089
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.975,7.451054
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.99,8.23417131632899
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.01,0
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.025,0
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.05,0.20208718486018912
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.1,0.5085161728794734
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.15,0.6634917483333334
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.2,0.8486229129095048
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.25,0.9794123924652265
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.3,1.0555555555555556
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.35,1.261903745500705
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.4,1.3935881408673503
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.45,1.590043376247484
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.5,1.9468719444444444
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.55,2.1048410807462354
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.6,2.5254681277777777
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.65,2.8713771993699586
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.7,3.198559785949123
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.75,3.7392270466242
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.8,4.379946478350737
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.85,4.961491028668663
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.9,6
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.95,7.450397324627412
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.975,8.841348100231794
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.99,10.620496918909044
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.01,0
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.025,0
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.09826047748012186
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.1,0.27390109087314346
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.15,0.5682186742899136
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.2,0.6952391679655582
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.25,0.8339688825239222
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.3,1.0078114500000002
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.35,1.2079784558197524
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.4,1.390715705709201
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.45,1.7633026241600005
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.5,2.042613050793651
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.55,2.3547239722222226
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.6,2.7145956482571933
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.65,3.320327216605884
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.7,3.7777777777777777
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.75,4.611111111111111
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.8,5
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.85,6
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.9,6.898414738888889
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.95,8.411173029213039
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.975,11.078018475816632
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.99,14.320230833707324
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.025,0
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.05,0
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.1,0.2733971554298652
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.15,0.3912621597433723
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.2,0.52717551
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.25,0.75709939
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.3,0.94781325
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.35,1.2190441
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.4,1.39
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.45,1.714342549757487
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.5,2.2222222222222223
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.55,2.5555555555555554
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.6,2.7777777777777777
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.65,3.2222222222222223
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.7,3.6666666666666665
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.75,4.444444444444445
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.8,5
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.85,6
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.9,7
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.95,8.5504509
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.975,10.525668
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.99,13.271536
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.025,0
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.13524773436630955
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.1,0.23476173318042906
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.15,0.3271871823436908
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.2,0.44061947
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.25,0.64502497
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.3,0.88799794
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.35,1.1759502
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.4,1.4398669
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.45,1.86
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.5,2.5555555555555554
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.55,3
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.6,3.5555555555555554
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.65,3.7777777777777777
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.7,4
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.75,5
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.8,5.0336473
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.85,6
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.9,7.7220898
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.95,10.14738
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.975,12.906557
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.99,17.605632
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.01,21.98
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.025,23.58
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.05,26.30163903143827
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.1,34.409082
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.15,36.333718
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.2,38.195704
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.25,39.795274
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.3,41.074919
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.35,42.280548
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.4,43.633802
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.45,44.902105
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.5,46.030075
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.55,47.199898
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.6,48.47794606835576
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.65,49.86411531827157
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.7,51.64647
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.75,53.174864
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.8,55.064222
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.85,57.793134
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.9,60.953558
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.95,65.072503
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.975,69.95565
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.99,76.51545
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.01,17.335
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.025,19.88888888888889
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.05,22.333333333333336
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.1,25.71666666666667
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.15,27.880555555555553
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.2,29.333333333333336
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.25,30.666666666666664
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.3,32.33333333333333
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.35,33.44444444444444
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.4,34.76510021756036
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.45,36.05987018762873
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.5,37.63793528746062
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.55,38.580875345697166
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.6,39.75794380212823
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.65,44.43959208314534
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.7,45.965532235790185
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.75,47.84075088371625
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.8,50.27598906115088
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.85,53.43579168888573
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.9,57.16784535535338
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.95,64.32492110681443
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.975,71.52783153575756
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.99,87.72530094444444
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.01,10.925
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.025,14.135
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.05,16.406076
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.1,20.062154938646785
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.15,23.444444444444443
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.2,25.5
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.25,26.88888888888889
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.3,28.427777777777777
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.35,29.607247319544214
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.4,32.73235372222222
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.45,34.41719855555556
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.5,36.077459306091555
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.55,37.936779
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.6,39.8742185
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.65,42.006038000000004
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.7,44.314728
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.75,47
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.8,50
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.85,53
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.9,58.5
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.95,67.7279231902437
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.975,78.55249798673663
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.99,101.30141601075178
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.01,7.4169609
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.025,9.5814822
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.05,12.053154
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.1,16.04399
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.15,18.341218
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.2,20.948783
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.25,23.22386
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.3,25.329444
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.35,27.11111111111111
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.4,28.77777777777778
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.45,31.570657
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.5,33.669515
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.55,35.85057
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.6,38.849876
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.65,41.947558
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.7,45.470458
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.75,49
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.8,52
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.85,54
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.9,58
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.95,67.04480059053586
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.975,80.50277777777778
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.99,110.8199973303969
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.01,3.8434954
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.025,5.9864229
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.05,8.9573112
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.1,12.8
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.15,14.761155
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.2,16.980781
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.25,19.019012
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.3,21.049966
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.35,23.186522
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.4,25.400534
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.45,29
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.5,30.666666666666668
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.55,33.018041
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.6,37.353122
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.65,40.576969
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.7,45.113977
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.75,49
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.8,52
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.85,55
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.9,60
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.95,69.77777777777777
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.975,86.44999999999999
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.99,120.37908184906493
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.01,53.336148
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.025,60.102285
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.05,65.445651
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.1,72.131008
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.15,76.480203
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.2,80.892318
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.25,84.209222
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.3,87.370407
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.35,89.35
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.4,91.21
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.45,93.03
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.5,94.86
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.55,96.71
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.6,101.07658575384303
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.65,108.22040282477474
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.7,112.81874
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.75,116.81703
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.8,120.49471
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.85,125.84237
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.9,131.89362
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.95,142.89271
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.975,152.00022
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.99,167.74157
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.01,23.88888888888889
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.025,50.464107
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.05,59.008712
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.1,66.75
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.15,70.72
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.2,74.01
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.25,76.93
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.3,79.64
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.35,82.22
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.4,85.70123183083832
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.45,94.6255556567564
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.5,98
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.55,101
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.6,103
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.65,106
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.7,106.64924374774853
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.75,108.34502162297316
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.8,116
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.85,121
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.9,134.67777777777778
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.95,171.88888888888889
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.975,201.05410851512812
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.99,235.8258507142857
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.01,18.694371119428332
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.025,36.579382
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.05,45.493224
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.1,55
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.15,59
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.2,63.111111111111114
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.25,67.66666666666667
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.3,74.48
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.35,77.71
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.4,81.33333333333333
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.45,91.6259253619048
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.5,98
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.55,101.74140349523805
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.6,108
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.65,114
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.7,120
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.75,125.21872626582488
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.8,132.92254388697532
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.85,134.28748166701482
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.9,155.94444444444446
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.95,188.17965384606205
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.975,215.25809028468987
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.99,291.02431661179463
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.01,14.35045201895022
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.025,24.88888888888889
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.05,37.665104
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.1,47
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.15,54.44444444444444
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.2,60
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.25,66
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.3,72
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.35,78
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.4,83
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.45,88.44444444444444
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.5,96
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.55,103
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.6,109
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.65,118
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.7,126
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.75,137
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.8,149
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.85,164
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.9,180.1264440947964
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.95,218
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.975,247
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.99,333.53603495872045
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.01,10.867383209566029
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.025,22.77777777777778
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.05,31.383172
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.1,42.333333333333336
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.15,51.888888888888886
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.2,59.08888888888888
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.25,65.22222222222223
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.3,69.44
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.35,73.34
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.4,84.22222222222223
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.45,89
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.5,93.11111111111111
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.55,98
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.6,107
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.65,118
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.7,128
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.75,142
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.8,159
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.85,179
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.9,207
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.95,248.3886006038123
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.975,294.8293883306123
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.99,391.022331229605
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.01,1.202647
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.025,1.5721437
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.05,1.8805419
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.1,2.3120937
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.15,2.6196554
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.2,2.8688399
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.25,3.0759387
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.3,3.2802294
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.35,3.4952822
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.4,3.7387655
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.45,3.9384792
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.5,4.1710892
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.55,4.41
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.6,4.6658062
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.65,4.9531176
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.7,5.2794255
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.75,5.5462033
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.8,5.9492761
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.85,6.3482949
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.9,6.9500595
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.95,7.8955473
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.975,9.0070332
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.99,10.443688
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.403619591994379
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.5821103123861505
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.05,1
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.1,1.573000427351348
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.15,2.1161514401456074
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.2,2.637004194143092
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.25,3
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.3,3.571455672222222
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.35,3.874143694283807
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.4,4.383517400000001
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.45,4.6184706
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.5,5
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.55,5.185935305555555
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.6,5.440624511111111
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.65,5.972943344444445
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.7,6.410907816666667
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.75,6.941732144444445
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.8,7.83183185
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.85,8.7211566
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.9,9.85820915
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.95,11.138193000000001
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.975,12.3588625
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.99,15.616560260977057
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.008150326760843884
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.025,0.48780871769019785
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.05,1
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.1,1.7945808032216486
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.15,2.2054674
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.2,2.9624356
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.25,3.1816692
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.3,3.786773238888889
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.35,4.182909780385634
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.4,4.72509075
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.45,5
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.5,5.147993630952379
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.55,6
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.6,6.166666666666666
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.65,7.055555555555555
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.7,7.888888888888889
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.75,8.444444444444445
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.8,9.376322250000001
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.85,10.4281525
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.9,12.410384
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.95,15.570277
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.975,18.783927
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.99,23.242679999999993
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.019091222787726885
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.07558349730982211
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.05,1
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.1,1.455882751661611
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.15,2.1898522
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.2,2.6364954
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.25,3.303121
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.3,3.9217719
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.35,4.555555555555555
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.4,5
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.45,5.09
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.5,6
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.55,6.333333333333333
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.6,7
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.65,7.666666666666667
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.7,8.666666666666666
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.75,10.11111111111111
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.8,11.444444444444445
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.85,13.222222222222221
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.9,16.208375
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.95,21.286897
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.975,25.764514
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.99,33.966163
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.06640833490499304
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.41707582
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.72929053
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.1,1.4016795
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.15,2.0598115
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.2,2.6378626
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.25,3.2565189
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.3,4.0336503
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.35,4.777777777777778
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.4,5.04
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.45,5.28
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.5,6.333333333333333
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.55,6.777777777777778
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.6,7.333333333333333
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.65,8.222222222222221
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.7,9.222222222222221
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.75,10.333333333333334
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.8,12.333333333333334
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.85,14.555555555555555
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.9,20.311364
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.95,27.160186163163146
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.975,30.56663013817512
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.99,41.07113447921699
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.05,0.033
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.1,0.03684210526315789
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.15,0.092565527
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.2,0.24438872
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.25,0.40586511
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.3,0.53616061
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.35,0.67529601
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.4,0.74
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.45,0.77
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.5,0.81
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.55,0.84
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.6,0.88
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.65,0.92
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.7,0.96
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.75,1.01
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.8,1.06
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.85,1.260423233587193
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.9,1.7836116534921593
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.95,2.7314735435281348
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.975,3.6376910532163604
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.99,4.036877305240447
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.01,0
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.025,0
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.05,0
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.1,0
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.15,0
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.2,0.02435841495483232
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.25,0.12652565124294837
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.3,0.20809866450986847
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.35,0.6283333333333333
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.4,0.7050935738888888
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.45,0.885545554260309
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.5,0.9660761
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.55,1.0555846
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.6,1.1563519
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.65,1.2600840500000001
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.7,1.8446549
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.75,1.992885
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.8,2.1995761
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.85,2.9272621
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.9,3.24031495
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.95,4.1473896
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.975,4.928704295864827
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.99,6.123947602846442
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.01,0
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.025,0
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.05,0
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.1,0
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.15,0
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.2,0.005670535286340327
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.25,0.03499946872553369
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.3,0.10690856750646555
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.35,0.17285364091877506
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.4,0.26307313622167244
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.45,0.32945729259066536
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.5,0.89138518
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.55,0.975391675
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.6,1.0614441000000001
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.65,1.2058301391011013
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.7,1.549777624090527
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.75,1.9104953787641592
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.8,2.4048409032499034
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.85,2.8892014
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.9,3.6772587000000003
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.95,4.7634356
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.975,5.287827500000001
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.99,6.3558584071508815
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.025,0
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.05,0
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.1,0
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.15,0
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.2,0.05066263824592511
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.25,0.09538249405739188
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.3,0.09601136094401092
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.35,0.1532044
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.4,0.28930449
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.45,0.44909336
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.5,0.66
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.55,0.79349598
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.6,0.96191448
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.65,1.2176861014663165
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.7,1.9225011814654507
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.75,2.4874048917329077
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.8,3
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.85,3
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.9,4
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.95,5
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.975,6
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.99,8.00798650780015
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.025,0
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.05,0
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.1,0
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.15,0
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.2,0.07923479030379438
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.25,0.11608827578559958
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.3,0.11621412723469238
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.35,0.12371789743781036
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.4,0.17628803
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.45,0.63
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.5,0.7
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.55,0.78
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.6,1.4741058523590878
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.65,2
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.7,2
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.75,3
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.8,3
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.85,3
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.9,4
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.95,5.359798
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.975,6.8875727
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.99,9.50735420071591
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.01,32.875062
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.025,35.348852
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.05,37.360581
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.1,40.004443
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.15,41.93661
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.2,43.758989
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.25,44.971624
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.3,46.28602
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.35,47.301349
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.4,48.509315
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.45,49.651829
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.5,50.73
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.55,51.6
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.6,52.49
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.65,53.43
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.7,54.44
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.75,55.54
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.8,58.04305662095125
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.85,61.576695
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.9,64.451212
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.95,68.255682
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.975,72.117993
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.99,76.236037
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.01,16.341299792665446
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.025,22.844147976536412
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.05,25.720233937110365
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.1,29.943841896155284
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.15,32.66974040085587
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.2,37.634582149042295
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.25,40.11466034358803
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.3,42.16588225956751
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.35,44.12669797587253
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.4,45.81964667260495
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.45,47.43381217658539
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.5,49.21146765124999
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.55,50.99553542506631
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.6,52.614999999999995
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.65,53.775
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.7,54.985
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.75,56.265
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.8,57.66
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.85,61.20479602047046
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.9,64.86980226895218
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.95,71.7787581863671
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.975,83.72204993428846
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.99,101.41876679824094
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.01,12.16359560452457
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.025,18.54954972621338
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.05,22.18385452564999
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.1,26.894594933899967
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.15,30.227991963015235
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.2,36.05730403305492
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.25,38.76422890892791
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.3,41.003526
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.35,43.191303000000005
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.4,45.294791000000004
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.45,47.1462525
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.5,49.675000999999995
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.55,51.965
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.6,53.72
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.65,55.525
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.7,57.394999999999996
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.75,59.86
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.8,61.97
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.85,64.815
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.9,70.03369935892029
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.95,82.00341468666505
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.975,91.88429445106381
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.99,117.84388888888887
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.01,12.861383
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.025,17.240538
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.05,20.257439
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.1,25
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.15,30.403123
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.2,33.899513
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.25,37.159098
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.3,40.623759
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.35,43.862935
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.4,47.442771
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.45,51.085581
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.5,55.289195
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.55,59
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.6,61
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.65,64
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.7,68
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.75,71
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.8,75
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.85,80
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.9,87
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.95,98
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.975,106
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.99,123.71104776958497
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.01,10.474418
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.025,14.092688
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.05,17.640231
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.1,23.578609160068854
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.15,30.148854380965492
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.2,34.01
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.25,36
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.3,38.43425
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.35,42.011007
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.4,46.804424
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.45,50.85047
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.5,54.719136
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.55,58
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.6,62
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.65,65
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.7,69
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.75,74
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.8,80
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.85,86
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.9,95
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.95,110
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.975,122
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.99,137.60780139251446
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.01,13.450116
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.025,14.76
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.05,15.55
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.1,16.51
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.15,17.260701984600498
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.2,19.637388579115246
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.25,21.797284903897793
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.3,22.976773
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.35,23.939819
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.4,24.734669
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.45,25.539665
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.5,26.448764
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.55,27.358399
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.6,28.277287
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.65,29.329934
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.7,30.474385
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.75,31.551124
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.8,32.616496
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.85,34.248286
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.9,36.096069
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.95,40.060678
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.975,42.508637
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.99,45.698476
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.01,9.555555555555555
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.025,11.966120547619045
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.05,14.090446
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.1,15.571897400661344
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.15,17.085984921061947
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.2,18.455982704054666
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.25,19.747333726190476
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.3,21.61111111111111
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.35,22.444444444444443
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.4,23.5
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.45,24.666666666666664
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.5,25.555555555555557
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.55,26.27583514231912
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.6,26.80106230798252
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.65,27.65750052401164
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.7,28.87801783745328
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.75,30.073166691961227
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.8,31.979609622674765
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.85,34.877806864773135
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.9,38.20943116307532
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.95,44.56020318251737
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.975,49.81790232102996
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.99,57.07318438325915
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.01,6.753955600440602
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.025,9.03749445
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.05,10.754999999999999
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.1,12.52998552416779
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.15,14.574751248440537
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.2,17.477847040357176
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.25,19.04771097054471
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.3,20.791471970415593
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.35,22.062899284430657
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.4,23.403591513157096
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.45,24.490830619541057
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.5,25.6860538007375
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.55,26.39908361708108
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.6,27.543396987303662
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.65,28.610388791112165
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.7,29.96925699296357
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.75,32.3743838706979
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.8,34.464954447229076
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.85,36.82676052798145
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.9,40.92361320183157
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.95,48.09828129431363
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.975,52.938358038200406
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.99,69.00455250608181
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.01,5.1333026
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.025,6.8443789
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.05,9.0648344
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.1,12.757301
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.15,15
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.2,17.388983
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.25,19.669294
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.3,21.911693
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.35,23.29444444444444
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.4,24.666666666666668
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.45,25.88888888888889
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.5,27
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.55,28.333333333333332
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.6,29.15555555555555
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.65,30.333333333333332
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.7,31.77777777777778
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.75,33.77777777777778
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.8,36.55555555555556
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.85,39.77777777777778
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.9,46.01111111111111
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.95,54.57264229599635
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.975,57.34649906330179
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.99,77.47939015251298
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.01,2.8009839
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.025,5.1301545
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.05,7.323035
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.1,11.760393287936502
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.15,14
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.2,16.782772
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.25,19.27773
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.3,21.870177
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.35,24
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.4,25.444444444444443
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.45,26.444444444444443
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.5,28.11111111111111
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.55,29.22222222222222
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.6,30.333333333333332
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.65,31.88888888888889
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.7,33.55555555555556
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.75,35.888888888888886
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.8,39.44444444444444
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.85,43.111111111111114
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.9,50.233333333333334
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.95,61.46967874969169
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.975,70.90313422722923
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.99,90.36956064630907
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.01,6.194658227742362
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.025,7.0522888563402795
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.05,8.314113146984786
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.1,9.88886241525178
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.15,10.51762710271776
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.2,10.988650055543552
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.25,11.485170047898594
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.3,11.922764565724968
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.35,12.331141424370259
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.4,12.63756936028918
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.45,12.942881922597893
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.5,13.18026315789474
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.55,13.500173632957665
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.6,13.84850907108337
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.65,14.241671075629743
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.7,14.786568767608365
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.75,15.358996618768074
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.8,16.04134994445645
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.85,16.81987289728224
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.9,17.920076978687618
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.95,20.688886853015212
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.975,22.588763775238668
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.99,23.990559163561983
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.01,2.2211111111111115
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.025,3
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.05,4.145049200544012
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.1,5.618274182238127
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.15,6.525971035487028
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.2,7.331942998957853
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.25,8.138139150031826
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.3,8.902640083850164
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.35,9.567350320170782
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.4,10.270128578151343
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.45,10.97923513184499
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.5,11.72978711032621
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.55,12
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.6,13
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.65,14
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.7,14
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.75,15
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.8,16
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.85,17
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.9,18
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.95,20
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.975,22.1374857036279
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.99,28.624294703308934
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.01,1.4444444444444444
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.025,2.2222222222222223
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.05,2.6666666666666665
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.1,4.011343745790014
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.15,5.398701911984747
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.2,6.61421939583631
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.25,7.706230846103237
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.3,8.894055604865672
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.35,9.948760511242286
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.4,11
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.45,11
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.5,12
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.55,12
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.6,13
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.65,14
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.7,14
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.75,15
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.8,16
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.85,17
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.9,19
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.95,21
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.975,25.666666666666668
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.99,33.888888888888886
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.01,2.2222222222222223
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.025,2.7777777777777777
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.05,3.7777777777777777
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.1,4.611111111111111
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.15,5.8264602153138
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.2,7.161695101679254
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.25,8
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.3,9
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.35,9.825000000000045
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.4,10
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.45,11
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.5,11.82924338095238
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.55,14.153910238325224
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.6,15.468609269967295
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.65,16.112250601053987
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.7,17.005527765102105
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.75,18.813754438390703
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.8,20.08415404626829
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.85,20.83744018459577
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.9,23.915
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.95,26.890555555555558
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.975,31.55388888888889
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.99,39.21035718344925
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.01,1.8333333333333335
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.025,2.6666666666666665
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.05,3.0555555555555554
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.1,3.9444444444444446
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.15,5.33118479797198
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.2,6.125580962012151
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.25,7.5
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.3,8.5
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.35,8.5
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.4,9.5
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.45,10.706786867504785
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.5,11.321508782142855
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.55,11.880221346780928
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.6,15.467130066612553
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.65,16.473958936874993
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.7,18.13367553907446
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.75,19.586801996133467
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.8,21.184091055115992
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.85,22.370427866887788
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.9,25.165
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.95,29.405
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.975,34.888333333333335
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.99,43.803755127383745
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.01,6.55
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.025,7.43
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.05,11.029528740770232
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.1,17.516917093826606
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.15,18.985704
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.2,19.720452
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.25,20.511571
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.3,21.179934
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.35,21.684801
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.4,22.245733
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.45,22.845789
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.5,23.478513
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.55,24.048346
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.6,24.747755
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.65,25.275302
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.7,25.987624
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.75,26.681394
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.8,27.504907
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.85,28.596816
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.9,29.754804
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.95,32.253749
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.975,33.994765
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.99,37.16681
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.01,6.133333333333333
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.025,7.769444444444445
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.05,9.962525931752932
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.1,13.000933276686814
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.15,14.911352691208283
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.2,16.11111111111111
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.25,17.26388888888889
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.3,17.61111111111111
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.35,18.444444444444443
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.4,19.27777777777778
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.45,19.833333333333336
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.5,20.77777777777778
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.55,21.77777777777778
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.6,23.43470186687985
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.65,24.503552030869102
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.7,25.1746781959724
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.75,27.555555555555557
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.8,29.22222222222222
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.85,30.72222222222222
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.9,33.66666666666667
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.95,40.6919147194443
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.975,45.71044192780854
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.99,56.86658102911626
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.01,5.5744444444444445
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.025,6.74
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.05,7.85
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.1,9.878921291697282
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.15,12.20550116141693
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.2,13.88888888888889
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.25,14.944444444444445
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.3,16.055555555555557
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.35,17
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.4,18
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.45,18.944444444444443
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.5,21.970957470238083
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.55,23.555555555555557
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.6,24.77777777777778
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.65,26
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.7,27.72222222222222
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.75,29.38888888888889
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.8,31.22222222222222
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.85,33.72222222222222
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.9,37.72222222222222
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.95,43.66666666666667
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.975,53.84779447722351
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.99,70.54354531523575
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.01,4.93
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.025,6.24
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.05,7.59
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.1,9.45
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.15,12.555555555555555
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.2,14.11111111111111
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.25,15.333333333333334
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.3,16.333333333333332
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.35,17.444444444444443
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.4,18.555555555555557
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.45,19.666666666666668
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.5,24
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.55,25
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.6,26
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.65,27
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.7,29
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.75,30
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.8,32
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.85,35.77777777777778
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.9,41.77777777777778
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.95,50.333333333333336
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.975,63.50277777777777
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.99,87.43203198207648
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.01,3.9481285
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.025,5.5365299
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.05,7.3320879
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.1,9.6399233
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.15,12.444444444444445
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.2,13.784712
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.25,15.669229
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.3,17.45
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.35,18.84
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.4,20.26
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.45,22
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.5,23.21
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.55,25
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.6,26.52
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.65,28.39
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.7,30.48
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.75,32.88
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.8,35.73
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.85,39.31
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.9,45.666666666666664
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.95,55.77777777777778
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.975,70.22222222222223
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.99,95.8146980340241
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0.26007752
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0.383633
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.05,0.54228626
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.1,0.79502547
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.15,1.0043982
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.2,1.225786
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.25,1.4298032
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.3,1.5
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.35,1.56
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.4,1.62
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.45,1.68
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.5,1.74
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.55,1.8
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.6,1.87
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.65,1.94
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.7,2.02
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.75,2.1
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.8,2.2
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.85,2.32
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.9,2.547394003636956
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.95,3.4679437947975233
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.975,4.247816275610801
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.99,4.6117726657613165
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.08362004208501676
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.19482909
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.05,0.3709346033832139
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.1,0.5555555555555556
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.15,0.7611111111111105
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.2,0.94186124
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.25,1.0297660083340687
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.3,1.1886731730177218
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.35,1.2887083598835425
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.4,1.6350218352761525
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.45,1.9445906
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.5,2.111111111111111
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.55,2.4444444444444446
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.6,2.5555555555555554
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.65,2.9757584
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.7,3.3152078
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.75,3.7219677
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.8,4.263939
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.85,4.8980175
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.9,5.7252602
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.95,7.076857
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.975,8.600758078515947
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.99,10
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.01,0
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.025,0
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.18261532
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.1,0.35098972
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.15,0.6643323686363038
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.2,0.7538472764605103
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.25,1
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.3,1.0424606
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.35,1.2143073
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.4,1.64
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.45,1.75
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.5,1.87
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.55,2.0867021
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.6,2.3940032
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.65,2.7381132
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.7,3.0956393
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.75,3.5021872
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.8,4.0629849
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.85,5.0508472295173945
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.9,6.634056462391443
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.95,7.9461573
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.975,9.2081926
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.99,10.854791679409725
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.025,0
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.05,0.1535275843668348
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.1,0.28008084
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.15,0.43133589
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.2,0.626807938220738
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.25,0.70308886
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.3,0.88389962
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.35,1.0949058
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.4,1.2696733
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.45,1.5184238
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.5,1.97
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.55,2.11
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.6,2.2902604
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.65,2.6099856620957502
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.7,3.4592578003002847
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.75,4.460053745742553
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.8,5
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.85,6
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.9,6.959588881776344
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.95,8
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.975,9.7058692
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.99,12.179946
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.025,0
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.074299746
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.1,0.24865739102724044
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.15,0.32159522
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.2,0.6856427537446923
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.25,0.773109729868452
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.3,0.8037239955847861
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.35,0.95587642
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.4,1.1504014
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.45,1.4761573791379468
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.5,1.99
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.55,2.15
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.6,2.34811674950355
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.65,3.241030291398421
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.7,4.322931399858707
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.75,5
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.8,5
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.85,6
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.9,7
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.95,8.3178707
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.975,11.832219599575133
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.99,13.687245
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.01,11.693247931339815
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.025,12.85547134995493
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.05,14.890297600045301
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.1,17.20947764945517
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.15,18.22485992827547
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.2,19.019615384615385
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.25,19.673129594483612
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.3,20.223842128307407
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.35,20.737850959324266
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.4,21.056004555194566
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.45,21.36063112089688
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.5,21.585789473684212
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.55,21.865757767992008
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.6,22.232132699707396
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.65,22.629336540675737
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.7,23.311824538359257
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.75,24.009370405516393
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.8,24.80076923076923
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.85,25.57139007172453
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.9,26.57991628993877
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.95,29.34120239995469
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.975,31.897160228992437
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.99,33.250882503442796
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.01,8.391538305689346
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.025,11.069152885166233
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.05,14.331016015120394
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.1,19.978283275762625
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.15,21.54130822908741
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.2,23.858860022923572
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.25,25.13512022119106
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.3,26.133914131076917
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.35,27.166666666666664
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.4,28.38888888888889
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.45,29.666666666666664
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.5,30.943848710464117
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.55,32.05555555555556
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.6,32.77777777777778
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.65,34.33333333333333
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.7,35.68333333333333
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.75,37.33333333333333
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.8,39.77777777777778
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.85,41.84166666666667
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.9,45.27942663588256
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.95,50.915941911703186
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.975,55.3969987627583
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.99,63.169952077634605
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.01,5.222222222222222
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.025,7.420317931658795
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.05,11.495510952884427
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.1,16.59587832792553
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.15,21.486533964782467
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.2,25.61944762034348
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.25,27.92894343890947
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.3,29.221672000269706
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.35,29.862824688164167
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.4,30.301267086373812
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.45,32.428521285821
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.5,35.42657098334958
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.55,36.28706222423533
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.6,37.51775657385669
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.65,38.98436370802179
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.7,41.55555555555556
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.75,43.72142259421246
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.8,47.111111111111114
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.85,50.611111111111114
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.9,56.13257514468309
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.95,63.38630310887371
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.975,76.09065185103452
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.99,91.72342031395948
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.01,4.166666666666666
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.025,6.111111111111111
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.05,10.220290827271631
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.1,14.829374503171834
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.15,19.679757281174645
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.2,23.662631776407437
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.25,26.120259357800855
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.3,28.325123590658205
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.35,30.724967273702845
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.4,31.393037789440108
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.45,33.659930923537786
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.5,39.0587038809809
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.55,41.02765342408982
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.6,42.64963599094772
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.65,44.352349564285305
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.7,48.368980318506686
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.75,51.097720802523284
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.8,53.356814859316856
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.85,57.7282042327765
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.9,63.00814635619488
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.95,75.76522768774035
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.975,86.44722222222222
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.99,102.94555555555556
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.01,3.5805555555555553
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.025,5.277777777777778
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.05,7.764747749920368
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.1,12.872531192919915
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.15,17.115199729690218
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.2,20.599190540962802
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.25,22.5
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.3,25
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.35,27.61111111111111
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.4,29.70070743653024
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.45,32.111111111111114
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.5,39.85861177735549
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.55,42.36808111854401
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.6,45.344258007383466
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.65,47.53907389206532
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.7,51.85022284735328
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.75,54.9474968458979
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.8,60.9280189022151
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.85,67.9612529585661
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.9,73.68802764808788
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.95,80.3234541845024
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.975,90.88888888888889
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.99,110.33444444444444
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.01,1075.95
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.025,1143.97
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.05,1204.77
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.1,1277.57
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.15,1328.33
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.2,1369.64
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.25,1405.76
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.3,1438.73
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.35,1469.75
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.4,1499.6
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.45,1528.86
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.5,1558.02
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.55,1587.56
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.6,1639.9519627069128
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.65,1695.7357
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.7,1708.3763
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.75,1722.0169
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.8,1762.95
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.85,1812.8
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.9,1876.83
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.95,1974.43
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.975,2061.72
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.99,2166.34
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.01,765.98
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.025,957.52
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.05,1035.99
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.1,1157.299312148616
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.15,1254.65463738002
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.2,1314
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.25,1363
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.3,1409
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.35,1452
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.4,1495
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.45,1536
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.5,1579
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.55,1623
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.6,1668
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.65,1714
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.7,1767
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.75,1807.6406058118278
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.8,1888
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.85,1984.8918
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.9,2064
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.95,2207.0838269641067
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.975,2339
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.99,2476
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.01,638.4763219854592
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.025,791.181991562698
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.05,917.49
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.1,1030.61
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.15,1112.15
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.2,1180.03
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.25,1240.47
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.3,1296.51
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.35,1347
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.4,1399
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.45,1453.65
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.5,1540
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.55,1614
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.6,1694
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.65,1780
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.7,1876
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.75,1982.4292000612697
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.8,2026.544932406268
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.85,2101.1411821375577
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.9,2198.507521139113
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.95,2711.3025
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.975,3079
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.99,3382
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.01,496.98855396921476
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.025,756.7484594314508
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.05,885.720170748947
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.1,1025.6200000000001
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.15,1098.08
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.2,1158.73
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.25,1215.95
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.3,1265.865
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.35,1313.9650000000001
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.4,1360.92
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.45,1408.7649999999999
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.5,1655.4783715401784
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.55,1835.2376
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.6,1909.0189402656265
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.65,2017.0943691722296
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.7,2130.3234428995256
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.75,2287.3879500000003
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.8,2404.6056506132463
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.85,2564.2933775110196
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.9,2748.4219643250062
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.95,3283.219436904549
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.975,3856.5672999999997
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.99,4395.878100232079
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.01,465.1463717098667
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.025,718.6769098409752
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.05,876.8446927866933
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.1,990.9100000000001
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.15,1070.44
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.2,1139.295
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.25,1199.005
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.3,1255.815
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.35,1310.775
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.4,1363.12
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.45,1560.926826269051
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.5,1823.3590267734376
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.55,1966.8667335452467
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.6,2027.3555107096215
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.65,2137.3198979316567
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.7,2242.399953513184
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.75,2410.539329543817
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.8,2596.6602209190787
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.85,2870.8902181862695
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.9,3143.320541105196
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.95,3790.076471327752
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.975,4570.825140215224
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.99,5226.6173963719975
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,9.085486207812805e-4
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0010832814187608142
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0011873693760956396
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0013186554219840254
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.001398562716668999
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0014743073319552502
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0015279196138960527
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0015889865436207117
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0016293451577572106
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0016690326907114158
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0017094291140159511
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.001761856020242398
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.001813228779695088
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0018575684826160521
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.001916620140037213
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.00197696905575252
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0020494915053978113
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0021252203138004693
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0022422164889795695
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0024396765001900808
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002679716917797825
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0030182205747311276
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0035124429807922987
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.791617637933877e-4
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,9.026157550423669e-4
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.923579371383384e-4
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.001105104452017489
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0011770066352754151
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0012465691184934814
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.001292794663181314
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0013481875444520766
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0013908877245769283
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0014316170925713426
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0014683237806258692
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.001516918098819678
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0015639199879516098
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0016053905679016302
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0016634121173493535
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.001724170642291114
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0017875302488249408
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0018510461262088336
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0019521701775777297
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.002097236938293021
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0023174951317593007
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002525086710498196
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0027715815875398717
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,4.503603191828261e-4
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,5.246448936498682e-4
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,6.024038242080392e-4
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,7.194719021659092e-4
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,8.008249604169315e-4
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,8.71077758540757e-4
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,9.412479455408398e-4
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0010037183099729824
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.001063295596820283
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.001123357238909673
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0011915199409058934
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0012640764892438224
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0013344422309285622
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0014059574971306823
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0014838407307091947
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0015659765331807766
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0016848187493072857
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0018121531650887725
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.001967823384264683
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.002199681044892155
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0026834558088599378
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.003113000708093159
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.003585329970596563
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,4.7590308192241125e-4
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,5.777371729005843e-4
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,6.796565235004405e-4
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,8.038760675279789e-4
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,9.079509939068797e-4
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,9.89663553605212e-4
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0010564392598862425
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.00112357295742042
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0011825351301721946
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.001248690800771799
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0013153225273249169
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.001388636159335065
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0014661137331108422
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0015442203371615342
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.001638758589005827
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0017431240584804852
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0018442359170027334
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001984268093030295
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.002190886113792952
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0024235382534952875
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0028077955293217428
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.003261155020062058
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0038159601480960968
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.0415830590228826e-4
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,4.884981055669836e-4
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.159463399475173e-4
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,7.530905240554632e-4
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,8.56229385776951e-4
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,9.413777795439034e-4
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0010298277155462773
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0011079025752570907
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0011785513118970214
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0012577302805730196
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0013461445834885345
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0014254958090173014
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0015150158810710507
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0016203173116775007
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.001734661433733759
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0018752555134634093
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.002020642952321689
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0021701586107324496
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0024321294612850266
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0027522913499895343
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.00330570449491343
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0038552001208218088
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004385122608671494
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0010872949318595426
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0012554151061265888
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0013701112393933285
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0015050057329782812
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0015914188846826748
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0016770929858086348
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0017380040159399957
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0018049268771264733
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0018534099770910178
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0019009688591902995
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001943274585070917
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.002003994477186122
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.002062569120949478
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0021118136416336092
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0021786070337689854
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0022416719097958864
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0023238172447639996
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002409285529509562
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.002541263250396922
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0027503326107589025
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0029999516578101864
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0033517526292645987
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0038202416938322285
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,3.616411901114612e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,4.711321975159761e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,5.168702851854042e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.240141431003781e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,7.046201997430328e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,8.070364577409859e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,8.519602362000352e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,9.618402606494821e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.001022114091517481
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0010994347926379544
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.001175379752680889
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0012537235209550267
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0013312898706463042
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.00140606467693423
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0014971240036249635
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0016046127101458619
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0017102861215870313
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0018249010871950388
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0019515834569822448
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.002130876592422736
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0024127769412972968
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002692972338914519
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0029997812599348687
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.5711208560417248e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.623750047074758e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,3.658304087141974e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,4.087787944945236e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.952651761897547e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,5.759346739613739e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,6.277851429895901e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,6.994248661004027e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,7.777584284913829e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,8.571102065220593e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,9.726272305805358e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0010561394848148356
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0011416969611690966
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0012601464252633447
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.001372971831692648
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0014939580400174929
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0016625122585641867
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0018301365401315784
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0020058441193617146
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0022546990410709762
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0026104245540496205
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0030515422402136814
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.003812560225098481
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.4687159623905336e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,4.146740982373696e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.02135869028202e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,5.934102892101172e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,6.708764688715084e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,7.213611656390444e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,7.682821182177806e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,8.124441984721161e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,8.549420302491152e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,8.997600380607016e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,9.403981300826904e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,9.862363002684795e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0010246419047283653
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.001065566337808071
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.001128955721555506
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.001194639221103011
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0012548713674608168
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.00135311551141415
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0014809255698640192
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0016536108352283344
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.001953927320321334
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.002279924918837848
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0027122514764303845
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.900189416139275e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.636320901460427e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.372491512290725e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,5.424011484610472e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,6.134739073205793e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,6.749577848246303e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,7.307593961556976e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,7.786155252555074e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,8.25777325917685e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,8.802542407832146e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,9.308518557516483e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,9.753932032901906e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.001023446810273194
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001083220616419053
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0011505617284193264
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0012307859510287667
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0013162465005610012
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0014038492204188954
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0015563162566174032
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0017789155123425302
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0021539461500016373
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0025464085447861823
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0029922349437194926
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,6.70712781365421e-4
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,8.424295396583232e-4
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,9.602458003085382e-4
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0011117818965252514
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0012076126205157836
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0012930875481289008
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.001362967725109958
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0014376017792193919
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0014844860616177555
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.001534330113643902
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0015784976946961397
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.001642404862447577
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0017012705512730068
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0017588720064084852
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.001821033041420545
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0018916146650603013
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0019677042557762116
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0020402785893371615
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0021594577643452785
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002351894150929927
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002566635702186253
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0029095179920022004
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0034107041079649166
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.862306373129471e-4
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,9.002291809675937e-4
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.963895538081388e-4
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.00111929328620713
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.001197107666986838
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.001263225252608144
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0013140627029371737
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0013705010338937978
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0014167304144087167
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.001459003573967809
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0015029484239540798
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0015482851701902546
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0015969153030679333
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.001645859445092033
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0016995947871538664
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0017548047464382597
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.001819802493154406
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.001884996951399365
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001987773481252262
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.00213402149725886
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0023370783246656926
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0024983585722819905
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0026910060366222
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.516577720448363e-4
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.740445463957459e-4
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,8.091433686243492e-4
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.510975194107743e-4
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0010683290149693123
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0011543720787321502
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0012261431437250656
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0012897055467459056
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.001362976428540056
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.001433646091607251
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0015139000195828881
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0015809407585259051
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.001653355352016943
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0017531684960812373
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.001867178047704227
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0019709675741462064
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0021042839919779214
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0022575493500939015
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0024290497728014265
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.002683903862192292
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.003188591627692709
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0036047825340766427
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.00415586119639864
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.6530573011286536e-4
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,4.574226547147625e-4
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.623128262243016e-4
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,6.825918986636315e-4
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,7.866156367239954e-4
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.703506263935431e-4
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,9.364188036482527e-4
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0010070766737194524
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0010628370429373716
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0011285486684499103
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0012026489558922694
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0012821987655745925
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0013671937446716256
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0014577569391788416
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.001556774696217361
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0016757236880755489
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0017862250184986867
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0019385754420528358
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0021714684743977574
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002421680031233569
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.002817282722049288
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.003330873124433768
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003916210404062518
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.0395183694694394e-4
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.8971041091063726e-4
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,5.129217811135608e-4
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,6.564766721040759e-4
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,7.624030769093982e-4
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,8.422013304419992e-4
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,9.284608059447082e-4
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.001009918996868454
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001086395236181527
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0011714406027902903
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0012729440779604437
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0013660053976470232
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0014724680787063873
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001598433356622785
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0017296065050907347
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0018916634852964046
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0020668598927573063
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0022264798708079305
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0025466221826571066
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002908841636145374
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0035469516170703384
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.004177119752914935
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004761054654848769
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0011474649846392269
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0013256827849222272
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.001442250057913641
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0015879817348581587
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.001678203063637534
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.001758457776038293
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0018202877051729921
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0018868759586077775
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0019304215906275825
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0019756843783698477
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.002016417062654724
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0020724753723943253
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0021247609112909154
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0021743413969259216
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.002231199760754659
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.002292893245445751
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.002362290056675271
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0024313171648071975
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0025404346878182328
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0027124012474703902
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0029129290086440827
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.003207266510447567
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0036219915537124654
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,6.270613135518667e-4
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,7.520003593452333e-4
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,8.769710626607935e-4
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0010410743721188714
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0011419773898711163
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0012230265875108933
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0012998799486172864
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.001381563558434852
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0014535438702891488
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.001514294228948174
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0015712180839837623
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0016244268486458608
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0016737699137495993
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0017262113136940307
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.001800750480203915
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0018718555234339795
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0019544227283806435
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.002040506574619883
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0021550509477046872
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.002347103576717361
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002596691439396212
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0029011375581930758
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.003237158322749795
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,4.4972793585853035e-4
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,5.72880244991374e-4
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,6.802952332528067e-4
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,8.43024934602843e-4
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,9.578619767862889e-4
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.001063855468286856
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0011605043733209895
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.001255867440134514
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0013514951706487127
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0014358855368705784
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0014967718329790126
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0015679058697780986
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0016588027667566755
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0017451004139472726
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0018715517719545749
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.002004646153029426
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.002147384016884959
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0023351131396314017
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0025450090045677693
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0028936814046424215
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0036375979529080704
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.004471130045776752
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.005467072315018079
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.965141859547167e-4
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.966179108962899e-4
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,8.096461741867909e-4
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,9.406824843851862e-4
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.0010503703891734252
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.001132204275783393
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0012007834389185516
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.001270460646755373
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0013299999257693753
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0013968359073144683
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0014672926770551873
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0015402543579156468
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0016144109112447508
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.001694061742780259
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0017878212462305591
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0018938251340144272
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0019958222690192526
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0021312470984343928
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.00233069875601413
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0025633327474461507
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.002912716314361845
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0033490950924476483
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0038322847599859076
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,5.235489440863102e-4
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,6.17349136965999e-4
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,7.455256278047627e-4
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,8.959220930352596e-4
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.0010036096886900225
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0010871360755857823
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0011710937520322908
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.001255510442827261
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0013258395653749063
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0014014192081284798
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0014935556054335413
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0015758472961733719
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0016620915790594706
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0017645438085225362
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0018783279628491495
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0020136343045126766
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.002153275478465449
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.002295502941350163
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0025435731675948784
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002834197528999679
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0033151764834413607
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0037929737354205307
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004282026268345331
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,2.3251899901002255e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,3.242037662688094e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,3.911729235746013e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,4.7852874195973533e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,5.360319452364021e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,5.874281749082171e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,6.298197609565877e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,6.746297912019774e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,7.059199427179463e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,7.382124978007846e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,7.668125124062525e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,8.061368048750596e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,8.433255243272178e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,8.807721957095634e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,9.202149651740249e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,9.654681850598984e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0010159543677171817
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0010662674355324713
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0011455274677350982
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.001270587677520242
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.001420927729966836
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0016502321594323887
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.00198349323052595
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,3.2010618140159537e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,3.7726716449159843e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,4.221979891585949e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,4.8780952342526566e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,5.285079078362563e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,5.630091816461431e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,5.929308812713111e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,6.242660436311695e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,6.478907607616368e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,6.723541135328908e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,6.97230575085473e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,7.219961202532233e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,7.484054412582185e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,7.747988627161519e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,8.051755801878381e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,8.347616934763702e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,8.705882194638644e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,9.091175126516003e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,9.644917719396303e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0010534966395666862
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0011597183160928423
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0012395102719114696
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.001364538684091998
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.9766727812192458e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.37570753186073e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.959751920463202e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.616216717163189e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.1594390845947344e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.564789867369352e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,4.914084188478575e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,5.260467786659781e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,5.604344317920078e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,5.936479202791286e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,6.295820501641973e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,6.635434831040504e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,7.02823011830978e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,7.500883812807075e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,7.987850203909485e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,8.505484686120188e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,9.186314292096972e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,9.990430189171472e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0010807190672078582
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0011912566725106248
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0013678492169499614
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0015357368129806882
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0017935856676229564
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,8.189129567170995e-5
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,1.3002492203588673e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,1.8082450524028104e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,2.4517779089735186e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,2.9926845483837486e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,3.4510638343575187e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,3.847253018245399e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,4.253841060641206e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,4.594686754216831e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,4.974004145145653e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,5.414019209256556e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,5.879456341690361e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,6.395090028619415e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,6.94341940838098e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,7.549855124819206e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,8.270492598166767e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,8.993663968911957e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,9.908850126157458e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0011353474143596179
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0013038891643230733
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0015711278807602606
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0019113154870189987
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0023185796348736297
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,6.955524902730562e-5
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.0686052820152076e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,1.601498180861848e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,2.3303045706492634e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,2.856732636392467e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,3.269764289461054e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,3.727730952156846e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,4.18709316041701e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,4.6414118744923295e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,5.127649008424703e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,5.680771999518491e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,6.221111599227932e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,6.816592236935262e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,7.526561220336609e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,8.317011827687782e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,9.305430859296634e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0010382884780247691
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0011456664452617806
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0013435161564102403
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0015795151729015222
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0020106199171289357
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.002446072728301446
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0028637660378305688
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,7.206393899566557e-4
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,8.725687561905729e-4
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,9.697899004906663e-4
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0010902096915580478
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0011648989268966904
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0012331141738059139
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0012887215302556715
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0013477095051576563
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0013853469841750247
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0014226714261347
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001457973899932052
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0015071668328978122
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0015537909084128462
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0015981189119384784
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0016453146069561877
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.00169878430304011
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0017567921989335995
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0018120555451429249
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0018997931696870171
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0020486637935494554
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002212355479340743
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002468671271176527
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.002843524703497934
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,4.1350839520226093e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,0.00047717753855608023
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,5.395203164277238e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.2617766548452e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,6.934005666663329e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.492428158601915e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,7.987285455373252e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,8.366366269743027e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,8.755698547106923e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,9.160340511626273e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,9.58930084647475e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,9.97715227063037e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0010376707790772726
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0010828598800532276
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0011263312856062426
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0011774116635758915
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.001233191098174637
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0013002181440991175
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0013758664057813026
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0014774655394881428
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0016331286719917682
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0017936387739607347
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.002013878225233535
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.5229787496477746e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,3.16278874174896e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,3.747170920752167e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,4.5835611622453844e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,5.193725235139199e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,5.713558967569824e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,6.271257988793733e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,6.74730988429417e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,7.22425131831414e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,7.701718313467944e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,8.114388851239995e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,8.53312989236859e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,9.001055130731826e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,9.56547374526915e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0010110619735408284
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0010734780833348224
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0011426483953351765
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0012252302656746853
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0013202598825855024
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0014791618165307776
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0017114602484311877
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0019593404695992405
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.00220324272945901
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.773424539913206e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,4.5449372545466004e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.488941718876454e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,6.54492195154641e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,7.434549718425931e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.127681319459359e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,8.659584035343402e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,9.228221663003761e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,9.699661339916156e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.001021611122679843
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0010815203672690041
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0011427975054143797
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0012057022237202408
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0012753858527772952
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0013528905465890963
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0014405324850332874
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0015247965197113995
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0016285621936322453
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0017942780745663915
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0019834931232814513
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.00228253731353187
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.002652572320442011
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003090146026892629
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.3709102072347646e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,4.1286360379394065e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,5.126834235422734e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,6.344622186143483e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,7.220712383769025e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,7.883089263473119e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,8.586348453146592e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,9.236576366062176e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,9.82162536357075e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.00104775561948882
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0011216167230862107
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0011917969687611559
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.001268137406653457
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001358999114695409
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0014566948497402726
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0015734993454373583
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0016941475484086987
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.00181245780019497
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0020315453240721208
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0022926894132639887
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0027419950855595027
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0031799021008278275
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0036394935186827193
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,9.21719772628978e-4
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.001083588877937773
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.001173814625029457
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0012870130017276153
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0013534832215161127
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0014229572410558555
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.001465088454298438
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0015181028774459869
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0015493076713022228
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.001581862591223423
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0016157547427767202
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0016643607936750176
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0017114061567388098
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0017447265295674136
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0018054776071763782
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0018588230361117398
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0019295062179905645
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0020045238216373842
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.002125984176734488
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002334232559062343
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002580171281211845
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0029317446963369144
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0034359436999737273
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.100153329319208e-4
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.336127588012578e-4
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.420440517362589e-4
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0010709524098500094
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0011578967695675
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.001236044524285378
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0012963923237272906
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0013558553546843682
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0014091508556068329
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0014564752865223202
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0015067860871542226
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0015616566657990468
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0016114542323331243
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0016636682807341006
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0017271238539203408
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0017907854757791347
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0018622079079777328
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.001946844703359607
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0020618848661300287
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.002230959590242751
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0024662844288095235
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0027239352375501443
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.003080252697201691
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.898860885101296e-4
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,7.026086745845539e-4
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,8.321390682808764e-4
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.604072422441826e-4
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.001065653516023349
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0011399329087471816
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0012056816777968227
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0012672709332337507
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.001324963733989661
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0013841950992512391
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0014453086917864872
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0015022972644511494
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0015657650230991513
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0016384310640053146
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0017154790060061973
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0017956620317563588
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0018974761969362995
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.002010663490377966
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.002139144575802576
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0023172777991935286
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0026789013287900256
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0029737998940770095
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.003337221862999186
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.277410560582536e-4
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.35354694967113e-4
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,7.509035209882654e-4
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,8.772448020923008e-4
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,9.8531448156051e-4
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.001075125518156785
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.001145336135015621
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.001220734790970858
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0012780754675731482
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0013487410083857579
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0014242908174792652
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.001500046569667799
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0015783346211055709
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0016633647954623228
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.001758902365748469
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.001866018004852165
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0019804808595102327
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0021197473515699814
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0023206491082842858
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0025592284220013733
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0029500463481697253
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.003398042734415996
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003956283147924268
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.6896473302911196e-4
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.554858894213946e-4
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.9285105748775e-4
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,8.393287881143527e-4
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,9.469188612502969e-4
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0010356998288526499
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0011244627263219899
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.001206115720161883
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0012866062210985703
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.001371614914225164
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001468936083370849
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0015551402093628812
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0016520612751562377
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0017654751273707288
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0018852149401015707
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.002024755623351738
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0021774785900639517
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.002339113925029777
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0026139723155683787
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0029413155338444442
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0034951466693380114
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.004043701196662888
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004577719353363089
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,5.120163804299737e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,6.281924255764403e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,6.836900737082734e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,7.553347716147557e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,7.944794772919933e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,8.397490667069132e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,8.634525285767005e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,8.974648420799362e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,9.137565877508964e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,9.313127755798312e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,9.531661899353524e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,9.851325096897215e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0010166791907704363
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0010347380080628571
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0010787741932831555
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0011145535781180208
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0011639820500544305
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0012171013548654141
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0013058916609267873
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0014694785282281999
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.001658867136003361
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0019379248341257352
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.002356301416867528
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,6.517434431753398e-4
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,7.902070430538615e-4
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.106910122300791e-4
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0010562977535953345
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0011850912495261208
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0012993007049337017
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0013976280617790657
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.001493682218758085
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0015834360964634563
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0016645985605990782
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0017535845917149122
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0018434018011827462
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.001934372964466992
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.002025747617140899
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0021339905972917904
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0022521183892086757
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.002361916345930128
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.002506341217728412
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.002686601325042438
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0029098644524478243
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0033066919845812295
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0036864382386060496
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.004240007799334571
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,4.8431150245409967e-4
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.160389069561851e-4
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,7.294310797365451e-4
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.049509365192706e-4
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0010547886536084702
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.001159577968838985
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.001258925636012347
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0013735453049699778
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0015096376234025293
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0016421067489803068
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0017635524776804978
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.001904453453332801
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0020591264492557876
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0022221104452523938
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.002408677654250924
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0026109808013585964
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0028565698056494185
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0031343085645549594
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.003511420456774188
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.004115883830498112
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.005003448201374862
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.005832560237115729
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.006943811670902613
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,6.433737512983955e-4
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,7.768702586341645e-4
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,9.392445327595474e-4
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,0.0011580705374823184
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.0012976540293183024
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0014382196268558217
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0015501452870518623
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0016800142818227627
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0017852400744543038
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0018967621450669487
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.00204711065557869
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0021809290170782
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0023730373069461366
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0025627758450320385
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0027281519326617923
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0029347055101107255
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.003134388044547325
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.003353454797522723
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0037038940850357823
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.004027405366608487
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.004466717574469762
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.005087904371671225
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.005701924496022974
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,6.207762528015212e-4
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,7.237656157990797e-4
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,9.214070591924216e-4
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,0.0011423201570651012
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.0013118698204279016
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.001444573775966648
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0015711623702813191
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0017179187119817196
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001873097453899951
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0020144032871440495
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0021974593509188206
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0023849204034964303
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.002592023293778336
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0028475259670050043
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.003097872660481249
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0033914738855717295
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0036806353077912285
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.00398939854779002
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.004543033027109383
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.004985313848036144
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.005818055168815605
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.006528884699010767
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.00707324250871596
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,6.3248623066199e-4
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,7.546296711503257e-4
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,8.310312607609318e-4
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,9.290726646298998e-4
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,9.894931500880936e-4
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.001050166491238128
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0010859456438311124
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0011306600709031752
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0011600734122235536
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0011921922013811712
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0012223160008665427
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0012651150675824082
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0013060870245356732
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0013362051049026302
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0013921679653988456
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.001440449885059868
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.001506990824281124
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0015803990015342698
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0016983109794323243
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0018866102205055202
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0021251202139156047
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002453147069348442
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0029107534998292174
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,1.014787925909138e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,1.3366134236897473e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,2.3416209572899661e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,2.6929208988836473e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,3.470100477346301e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,3.825169968225956e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,4.00233039294303e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,4.708670891954331e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,4.942359628087885e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,5.137224012706228e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,5.696587440410637e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,6.040670771356963e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,6.324044691729755e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,6.86718618815115e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,7.635859178483081e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,8.234687453246255e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,9.118974537239044e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0010124860274696025
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0011220570232609603
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0012753892379340423
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0015360802188561697
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0017745622004492491
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.002033709333293968
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.550381677968208e-5
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,8.19794701289229e-5
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,1.1317156565873516e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,1.3480477145152376e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,2.2999315181788067e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,2.497362353308085e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,2.593545103017173e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,2.703274330484761e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,3.478493810859473e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,3.647779810498652e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.00038167435821987963
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,4.0777831709498907e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,4.733420247459716e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,4.993678349727265e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,5.389194632206698e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,6.098916394550539e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,6.718576645260007e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,7.744587528773414e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,9.071443355590558e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0010670710335149156
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0013822262986767351
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0017200371393152794
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002173684494237797
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.044840519738659e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.640598626803721e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.264159503303932e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,3.9261203652678255e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,4.548121310457402e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,5.007260942567633e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,5.376740231446826e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,5.749125168361479e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,6.087094729340601e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,6.445521056118232e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,6.79839896132446e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,7.205737229604692e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,7.555576680408295e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,7.91810539286945e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,8.403243964478026e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,8.95703266842031e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,9.545896940086889e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0010336059121918825
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0011473729825735917
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0012934845570831302
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0015563628024895574
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0018381340166017204
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0022292410220158807
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.5167562485716112e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.1445741445667724e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,2.863980159387826e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,3.6381329233449986e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.188893771953612e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,4.6593704671495486e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,5.132831993060816e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,5.529279129545333e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,5.88665349425008e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,6.315905011430754e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,6.75025056356311e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,7.161760238527371e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,7.586842493941513e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,8.123744428118248e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,8.700524122555689e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,9.401085334063019e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0010214775149624492
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0010965263321912322
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0012334664541412527
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.00143534927848626
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0017651629879674334
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.002106957209803139
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.002502379037770075
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,9.865084376871219e-4
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0011625492805736968
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.001290063666292731
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0014481848723495463
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0015508005943266612
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0016396326798643471
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0017127925467271068
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0017876235017862548
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0018423275067632838
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0018975527258581015
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0019448712381891092
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.002007967431338123
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.002067430766214174
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0021284794829944833
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0021893792793751033
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0022594446843012986
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0023374947715225003
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002415514240969213
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0025340654616257817
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002711291309077282
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0029259029061613987
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.003236575412552532
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0036627904642027066
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,0.0010346532721354986
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,0.001146773297910638
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,0.0012301426006907025
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0013405202334396487
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.00139494261882307
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0014371756394868523
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0014701681530223485
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0015009564612984197
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.00153333796330999
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0015599130514321175
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0015874788882947444
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0016145029423835012
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.001641836001294316
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0016708696439373632
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0017039241473027576
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0017376737880707605
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0017725712524455368
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.001807587089997634
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.00187839619793301
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0019690523817179305
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002125020179101525
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002298530316849683
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.002465179509894863
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,6.242123103957483e-4
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,7.270087822433941e-4
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,8.145021281413443e-4
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.24079909307369e-4
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.001007425604431768
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0010789774598833016
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.001142827636154461
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0012066015532766808
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0012558492750366131
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0013150005740575356
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0013719902786147988
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.001427800255971172
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0014913541097209115
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.001555565922076042
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0016213795730576556
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0016995493575448538
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0017901748228073174
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0018874177768792959
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0020198974157867398
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.002170627833653952
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0024625883689323507
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0027553915522834016
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.003167437213042729
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.327177869776247e-4
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.345858334535773e-4
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,7.463784790819224e-4
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,8.83454840748441e-4
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,9.903984467630083e-4
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0010796580894279002
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0011563023513219135
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0012352108609006117
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.00130162425271522
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0013747899285521574
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.001459526626187595
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0015408705692189382
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0016320212424993834
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.001722447056626478
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0018258514926308782
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0019458063470090341
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0020628533231798044
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0022163279319280475
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.002430563954028162
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0026845860259436067
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.003075364010943815
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0035514361307407427
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.004089496906241946
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.591660169815314e-4
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.518886322989113e-4
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.780322093658344e-4
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,8.259356798894469e-4
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,9.367794424026681e-4
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0010246611544370912
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.00111142034036042
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0011995361982326642
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0012820295956036992
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0013711749819369816
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0014716340338842711
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0015655565472167776
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0016731132988865556
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0017912789042563877
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.001919913815771997
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.002079029632687738
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.002245357959521242
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0024147387438242683
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.002710589901303638
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0030449455737973784
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0036103093889169966
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.004136621752190384
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.00466048901221423
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,6.834489090439597e-4
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,8.048079821445693e-4
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,8.797629969706143e-4
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,9.730108612146465e-4
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0010305802001210854
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0010850064109034297
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.001123320202268477
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0011664681821395458
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001196239924721329
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0012255900567841689
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0012542428802160394
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.001291688869825474
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0013282530643847165
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0013599396595375404
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.001402194304383719
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0014446410320276093
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0014967648071361364
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001551657038628429
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0016357675267417964
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0017733030928558998
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0019424935984921272
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0021766997122493704
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.002508971002937218
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,4.514581849621068e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,5.03003718503922e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,5.448265204444484e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.154369940543213e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,6.710376824674469e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.180996077891703e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,7.585122639914751e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,7.969532582228543e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,8.325159202394128e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,8.728646854682929e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,9.105072750953072e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,9.419128058259128e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,9.721000175859176e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0010015250765614656
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0010388577899480477
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0010720333009385035
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0011125580028360387
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0011579189852086685
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.00121810074856706
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0013082235353432921
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.001451126484676509
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0015953332135352407
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.001827029293266438
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.686365137742539e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,3.230105206099501e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,3.8166483509000397e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,4.568431819889705e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,5.192068567303854e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,5.658780278813484e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,6.163925458662468e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,6.602906446232562e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,7.029148462875068e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,7.422652561782284e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,7.815158933612165e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,8.232667336805035e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,8.657642742282657e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,9.182202192190809e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,9.722185546438069e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0010246863768752785
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0010974555853321324
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.001186920174625532
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0013013611198490374
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0014369466358323528
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0017227905204148775
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.002024607301166945
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002452169386146592
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.963746232778462e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,3.72286776631849e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,4.4556910864951434e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,5.352438864500876e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,6.063195335902029e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,6.61333803352419e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,7.100440760371726e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,7.577367314401413e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,7.988262084078488e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,8.46216941558754e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,8.916435140484099e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,9.397770235898662e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,9.918087439328743e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0010491195232782634
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0011159033229741872
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0011855918983733284
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0012591178095128527
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0013556194053505493
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0014962666149217125
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0016623105115630636
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0019286186586417358
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0022456528242358617
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.00264630440056392
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.622758939144614e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.2380395682926144e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.0429499181443324e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,4.998276396434816e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,5.736262994356237e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,6.302307457229615e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,6.858265018207324e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,7.400546164955591e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,7.890595067566526e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,8.406767177519746e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,9.009156321732881e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,9.535274227966831e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0010160682269618163
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0010886444370833332
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0011619052171119662
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0012536736467526058
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0013483531556293434
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0014514594434794684
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0016180256522452291
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.001839773969642267
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0022044549018763564
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0025878995985408226
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0029344768145774976
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,4.838655085246068e-4
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,6.247771239576895e-4
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,7.154340487721838e-4
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,8.305228851939909e-4
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,9.027289439454435e-4
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,9.710114878374579e-4
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0010236971511613107
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0010817553624164157
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0011196715595532267
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0011572991841387863
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0011939415312066427
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0012443519331886274
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0012930208986809768
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0013373519914842854
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0013901444985781638
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0014470649901845187
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.001512576234492199
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001578106873327506
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0016817290667974275
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0018589735530193164
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002065733933319076
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0023792984376740096
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0028447619445030052
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.518705724178569e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.902094044567619e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,3.7328307704454313e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,4.722661134258788e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,5.196411800323646e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,5.928296344439682e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,6.292380521063194e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,6.966855121636374e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,7.255142241124129e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,7.900526638654627e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,8.264068864136051e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,8.883829928831728e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,9.229472909724782e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,9.859976874891565e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0010257142767014817
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0010932571321884106
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0011459690840437179
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0012268716537771535
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0013234661519710594
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0014516001039210167
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0016672807902605824
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0018426437914917763
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.002079117711547363
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.8225314862458587e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.7202345893012186e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,3.1309097769990213e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,4.0681546669924635e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.5106598120594435e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,5.247751579083753e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,5.93040281878084e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,6.276282754435212e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,6.573668044478785e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,7.243763647383221e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,7.595329648695086e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,8.297860088147447e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,8.693522115788564e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,9.419688509689406e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0010107257569435765
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0010915542807450793
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.001166716944786705
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0012602570791710583
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0013846402201990078
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0015958115048268552
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0018906950642707033
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0021568721321247393
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002637519701578892
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.5063280142974464e-4
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,4.372341730514703e-4
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.516991915194887e-4
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,6.862084184485078e-4
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,7.865954790510039e-4
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.771713498642088e-4
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,9.504236029332961e-4
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0010293109254198764
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0010988206821113023
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0011690567867007331
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0012615842553896925
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0013490546229012815
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0014558086305209383
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0015632768811549595
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.00167434977659673
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0018108663033151076
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0019433181574548988
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0021029919018536753
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0023550364007467366
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0026255695940928026
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.00303901014817395
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0035514186869809016
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.004164903832417314
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.106112235750979e-4
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.775330092111799e-4
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.965871123757638e-4
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,6.470302106347681e-4
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,7.604660418446036e-4
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,8.49651955681251e-4
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,9.376448471549144e-4
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0010339288836214728
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0011255418716717776
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0012207856778491104
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0013342645134416114
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.001443671594413241
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.001564774232561929
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0017147463359822143
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.001869060159910753
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0020607318457262725
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0022511114637060346
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0024512554367416743
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0028085388421220676
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0031879765812643165
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0038683189122262294
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.004516522423622063
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.005102496784265337
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0010903272865964888
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.001246872989071985
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0013454262636284965
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0014718803740948572
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0015485258314757878
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0016190892239766835
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.001666148902576042
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0017212386039195135
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0017554576805553573
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0017935645041011214
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001828077289126133
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0018768705606659244
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0019219817818694482
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.001960046132515097
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.002016570018376971
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0020709779039194643
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0021376955895604584
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002207474877270002
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0023203593534567813
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0024964092370929765
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0027093393016406576
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0030088992073811715
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0034262508504128253
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,6.564547292459304e-4
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,7.769224222696459e-4
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,8.992582432795541e-4
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0010363613841406936
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0011322246492512702
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0012165845427896834
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0012938567528816244
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.001361351749899708
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.001434974110824148
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0015007397247551889
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.001567338223710802
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0016352048586431318
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0017057866549867655
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0017783458409681332
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0018538400867639756
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0019379559865578626
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0020270227378816046
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.002131136530968491
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0022588504805146434
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0024349517212148364
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.00270539416512215
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002955943819612904
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0032839812931008475
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,4.6422747485443073e-4
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,5.601830425625761e-4
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,6.887836865109012e-4
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,8.351575223059843e-4
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,9.50827999876375e-4
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0010422437027813257
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0011272241579941516
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0012047799609484792
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0012784342922485452
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0013557128757535261
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0014295458623533432
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.001520797077766806
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.001600396388864278
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0016950447419587665
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0017892853410200363
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0018943159635079543
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0020067178552269
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.002137059058212724
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.002355534082011385
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.002647791854040371
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0031223880473808105
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.003701751492455411
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.004519344534924207
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,7.275165735026907e-4
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,8.686634904934369e-4
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,0.001011061281128648
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,0.0011897128654904743
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.001320015871420574
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0014366119484595808
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0015264181014318324
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0016270774472706595
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0017076966740637721
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0017942961482823728
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0019025919450328486
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.002006908516922882
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0021289052398731807
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0022507101475390838
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0023728918522917305
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.002519590571466005
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.002661790041327681
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.002828364748328609
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.003076408556157597
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0033575002344540155
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.003772370325269059
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.004269053696131965
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.004793596401945834
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,6.677935739805527e-4
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,7.82233112126315e-4
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,9.559279100256988e-4
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,0.0011482937884458248
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.0012864433247811546
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0013968714839966024
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0015031122569949644
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0016135518038093055
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0017244935383308809
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0018331998029843142
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001963840784694728
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.002093853773591543
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.002235007866831378
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.002397665104395324
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0025608316381842172
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0027565727553790233
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0029580933470378557
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0031676452032639293
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0035204770448393997
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0038892479533843127
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.004534917427906073
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.005135766485838392
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0056549441878434945
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,3.1874396237779705e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,4.3015908995656243e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,4.877315076735236e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,5.65876716792289e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,6.09847958265942e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,6.54041228226427e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,6.82640673632787e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,7.194870911366143e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,7.372379600065824e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,7.564047257287217e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,7.796143090576124e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,8.114765374388391e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,8.42340318979672e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,8.655594070691869e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,9.043139634657758e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,9.425298689025103e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,9.873212090599662e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0010331348683931653
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0011103308035672332
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0012556648001750997
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0014233846120032406
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0016816035539407746
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.002095059590788305
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,1.6155008650887634e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,0.00018195621893363188
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,2.1130171823318116e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,2.5275361483646027e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,2.75824609282162e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,2.9727317596579524e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,3.1056529562594387e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,3.2727931570370735e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,3.407415705654486e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,3.504180800541482e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,3.6249790260211727e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,3.792112848100548e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,3.9357259620119683e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,4.069133585600566e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,4.293874831594427e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,4.485415511182178e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,4.7377455109177025e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,4.986496496059327e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,5.369672482636798e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,6.0214484992488e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,7.004204332665831e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,8.089430548669237e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,9.969215527466098e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,6.538619914252647e-5
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,9.608342907456358e-5
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,1.381980085073058e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,1.7012354675962363e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,1.9736786794330476e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,2.150261210961952e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,2.264621872094126e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,2.3807557648200338e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,2.514668029684335e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,2.632724203636129e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,2.798776905807941e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,2.931082306382363e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,3.0681631118989645e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,3.299440433062936e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,3.554595804136155e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,3.7866963819708664e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,4.1624595641305925e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,4.576334873402728e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,5.020180601381007e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,5.635916477458006e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,7.225906014901887e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,8.568839843989733e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0010483348896680505
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.4483077592044127e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,1.9543619645321752e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,2.524288043310337e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,3.1453200970248926e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,3.728870099229893e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,4.130466734541972e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,4.444161686814954e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,4.814180971080961e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,5.092992137089077e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,5.411915883460651e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,5.739902336182211e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,6.103541755825847e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,6.43864942246239e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,6.834762369449784e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,7.328466235291344e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,7.888863232841498e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,8.379562517204053e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,9.094707938661626e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0010228661209359536
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0011646106176761587
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0013984339315652487
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.001688089676202642
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0020746012016270004
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.2826501644925842e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.7680270792872342e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,2.4239367885617492e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,3.1875610101208705e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,3.7487169754193495e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,4.156525101676928e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,4.616010713685267e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,5.013947068227063e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,5.331744645620119e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,5.703168480465884e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,6.151738294905835e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,6.588809737470612e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,7.002745513572563e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,7.542396462166595e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,8.162482245025074e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,8.865502563130917e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,9.657561951001612e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0010335844435349227
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0011724781976903654
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0013658721290175585
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0017171586876165643
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0020901364666703376
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0024165267335161476
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,2.5240079454533817e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,3.4735985466268415e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,4.007622423616733e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,4.7383296999653073e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,5.164120742658311e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,5.58459205591555e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,5.852747692000754e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,6.197059237845454e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,6.371342310833388e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,6.573262208303037e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,6.788799041168217e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,7.098875058229019e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,7.391263910001587e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,7.613994265196196e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,7.998590415396657e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,8.365856894851516e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,8.811688593090684e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,9.275716349124105e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0010068526167569909
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0011464416479639173
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0013117548971172605
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0015643463545785728
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0019565816846894976
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.2441531432356088e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.9018360655461525e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,3.411726445646648e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,4.058285210445753e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,4.499581325260959e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,4.942145921448864e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,5.283008783874871e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,5.653552381143476e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,6.014212584835943e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,6.356066376088333e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,6.704470552244589e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,7.053670370863853e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,7.407708693299166e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,7.85128984492534e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,8.235730190839102e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,8.684425316442402e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,9.174810596245174e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,9.791446357951552e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0010567680499828512
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0011533906411668308
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0013218190616702463
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0014839199840214062
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0016866943670250214
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.4291608212332776e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,1.96992093446525e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.5287043499981447e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.1886811603026475e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,3.705927098210617e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.147383324769217e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,4.531013017594572e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,4.900515791058454e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,5.276647919793362e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,5.628278289527397e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,6.001608571061262e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,6.403882451576585e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,6.839704140316331e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,7.354873002841618e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,7.930040325213677e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,8.53491343649799e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,9.226911608765587e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0010154283918531733
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0011316576489523455
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0013015594113616204
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0016624598744890513
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.002146213837832016
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002757928385776728
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.982208787028379e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.736222329883371e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.5350708952854655e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,4.5008830017882333e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,5.28789960449334e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,5.939999116918008e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,6.449548153295145e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,7.050792991375803e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,7.517076045954574e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,8.047240022096302e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,8.710242732661118e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,9.362955193559235e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0010168366904621416
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0010980438910432766
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0011824328720527384
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0012832483039940767
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.001378893718831509
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0014978193231033614
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0016982566280067384
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.001902130802329507
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0022100153711342406
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0026387727118140996
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003122147416961375
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.752796664605728e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.3379997667710272e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,3.263161664526265e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,4.375196915590062e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,5.21360882837848e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,5.869470302900556e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,6.55070587255823e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,7.264728032238283e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,7.928055375054576e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,8.644309873553299e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,9.522625581221487e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0010364829190501728
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0011301285039268388
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0012455154176375129
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0013647234530982152
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0015100659586213773
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0016623891162143288
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0018090113647919515
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.002101769852993721
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002403910476408552
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0029696572332592462
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003531704650533955
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0040173835113388
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,6.264070482280885e-4
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,7.875355395408742e-4
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,8.787885943738627e-4
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,9.996861123530898e-4
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.001070974623747503
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0011388648024549196
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0011854809837855513
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0012415001457216936
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0012734630039657451
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0013071095132053945
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001343124893794836
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0013913872488815423
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0014378215136695563
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0014764391074123032
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0015325024393149042
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0015896402253421397
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0016565341817758297
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001725470397453327
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0018374878893500266
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002034095686733397
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0022680034772699347
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0026136561052611308
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0031436762731456747
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.7907392102229133e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,3.427109860215166e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,4.0222273414021014e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,4.7022776058521204e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,5.19146625025434e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,5.622440978791414e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,6.013930909853562e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,6.39244926484955e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,6.759395209954693e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,7.085087752242214e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,7.482735485113421e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,7.859590403136618e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,8.192477519383223e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,8.558230750469373e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,8.958053113542891e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,9.298597489514816e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,9.812359947836457e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0010361458248899457
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0011028758245574936
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0011994664179013508
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.001353747936433001
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0015013148625221543
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0017945962840586105
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.4270855541962627e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.1243451125377625e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.7781656920358293e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.315230206738233e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,3.7610229908509524e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.116721507389615e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,4.397991468850348e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,4.714898515658316e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,4.994297304166304e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,5.246177008382962e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,5.551021892865667e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,5.850295816700177e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,6.135899371493983e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,6.55124632135912e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,7.045663100869285e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,7.670141361824627e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,8.418426720191827e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,9.156800042433406e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0010231574252925052
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0011766981829948139
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0014248387199902292
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0017410758203192534
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002215580705083248
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.450255928955632e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,3.1221805055180765e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.8234333510031864e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,4.6010974023161764e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,5.361091143290498e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,5.833814036796681e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,6.2254286022688e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,6.627500896137012e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,6.955122936809961e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,7.352496788074858e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,7.735949249337924e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,8.165038093789201e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,8.559842339896503e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,9.004788284142671e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,9.59372029918467e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0010284656473962437
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.001087016493904247
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0011716011055596222
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0013048926369582593
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.001469536179549387
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0017538813362277595
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.002094921918030293
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0025286709271130766
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.0546278642788457e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.6793558908023236e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,3.4641540963553305e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,4.436940505188438e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,5.112950243355602e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,5.623247807579447e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,6.203707716661382e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,6.691263579626182e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,7.056433696869767e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,7.544111060475119e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,8.068328489113492e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,8.561098589907649e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,9.05733260135187e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,9.681700043406252e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0010322227959967995
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.001112918881537465
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.001200988926999679
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0012828199251832249
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.001449930829796054
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0016884660138391512
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.002099658401035763
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0025045901901094873
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0029387192078286833
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,4.0194533231990127e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,5.02556542475966e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,5.727114543175282e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,6.666413386919759e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,7.246634754853022e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,7.772567474908479e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,8.14396393065366e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,8.579295259381844e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,8.817607861958561e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,9.118022191987979e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,9.363734912995674e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,9.760624620644612e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.001010662222519227
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0010410762799921453
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0010850489924780352
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.001128449698078004
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0011791311547876306
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0012295496178766137
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0013185952988525778
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0014545464465040956
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0016104507289998087
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0018551009441761968
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0022045317080325692
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.846656996122943e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,3.448057920251654e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,4.1304586730715634e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,4.8350725772513024e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,5.426828609252603e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,5.886720743325134e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,6.307907027847381e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,6.706965887028683e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,7.104281822577343e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,7.48181316380314e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,7.866393843175656e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,8.23399549749399e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,8.629155845686527e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,9.072476602348151e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,9.519587568242086e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0010047081253454575
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0010554195487541486
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0011131423418881724
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0011919762837823554
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0012924659402100986
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.001469139478563143
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0015951243932139085
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0017662252674058203
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.834191495039494e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.4310091058707433e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.991120394717252e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.8492880747173963e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.3737949410003346e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.880416998203427e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,5.33187131310588e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,5.74164732007438e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,6.226040201708624e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,6.611578273086987e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,7.01836704393999e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,7.453866400085091e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,7.89959427160741e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,8.430499831644921e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,8.959282575417308e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,9.534537006044117e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0010186316865486967
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0011016766063104023
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0012083329080093425
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0013612965201960326
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0015706875736901699
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.001788104046080062
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0020690753569056705
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.7599640832723333e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,3.48609651683068e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,4.34416855616239e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,5.393284744251801e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,6.233832711249164e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,6.955494278510061e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,7.514398355461327e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,8.171538575652324e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,8.696961981508104e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,9.259051319033136e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,9.943285684209102e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0010612372882870913
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001141604466931565
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0012248830294320102
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0013121962156754888
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0014154543858102622
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0015141013845827288
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0016372161387591465
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0018306138307432834
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002023601780747739
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.002337053489596678
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.00274009255684261
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003182604088272119
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.481890447974772e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.0403348177164406e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.0437880527353226e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,5.217696063327352e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,6.077628736204928e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,6.804678768010594e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,7.559311586254303e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,8.271443230716313e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,8.964739194732641e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,9.731405213066498e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0010635459217847327
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0011491175316782124
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.001243701476909557
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0013650108122393845
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0014840923158514424
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0016256347524436872
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0017713401520892777
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0019168259171776013
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0022049353686553435
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0024953620031929044
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0030126042516575727
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0035099042686914236
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.003946953243513483
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,7.336090760655859e-4
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,8.857680097037938e-4
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,9.635789367853923e-4
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.001065056530281497
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.001121863455280584
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0011791060986837219
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0012159015492735202
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0012624520742870824
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0012856838457962702
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0013103678973930277
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0013390790511737837
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0013791289010944324
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0014176531426384235
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0014462189735008478
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0014939458756242847
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.001539727225648445
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0015942976439202372
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0016497831902097448
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0017421116275472114
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0019111957870282664
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0021022548374638127
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0023894329006640225
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.002828492544356786
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,5.405057049844805e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,6.207579801481441e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,6.982865889397857e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,8.040338765098708e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,8.722274459011185e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,9.216942156475669e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,9.581783639882955e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,9.985634257961265e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0010294021890478052
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0010551547468320504
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0010886884544140964
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.001127309781789501
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0011642191424367082
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0011986943268936004
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.001242408233447068
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0012845893789332308
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0013382768959646699
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.001393983093722828
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001471955728696322
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0016010486742595584
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0017755219347525115
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0019696330546390447
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.002278863476484337
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,3.7891802023610555e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,4.524227304597613e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,5.190043293147506e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,6.268455661671238e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,6.963207497078607e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,7.650146711009207e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,8.095901836630813e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,8.513330379216238e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,9.022921321666774e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,9.470625166784515e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,9.995784513762178e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0010438399587244342
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0010956983512272645
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0011657058082868688
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0012404421355082969
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0013104850967287141
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.001410551045377679
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.001509796429949113
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.001625515160212876
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0018549993474193576
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.002192225985539125
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0024866262060081975
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002968395153478385
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,4.276372285611928e-4
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,5.18399010674373e-4
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,6.18183252328074e-4
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,7.257258605505925e-4
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,8.192244472143833e-4
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.86664202727476e-4
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,9.405451283930963e-4
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0010017496840028426
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0010431212586567342
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0010975377213247467
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0011538311916569999
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0012160618423792404
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001275043264950829
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0013386250189792624
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0014210142066810299
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0015065664106751614
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0015833966601183358
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0016909357782440562
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0018636626147611537
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0020608299981795843
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.002362345867717248
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0027581259220356967
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0032477085809295434
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.903398320569321e-4
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,4.634486915389166e-4
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,5.838009842917479e-4
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,7.127628943766123e-4
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,8.053786522752745e-4
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,8.719708186465348e-4
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,9.461823335811727e-4
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.001016912710436718
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0010763797559484776
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0011432427574890921
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001221748864267493
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0012892031019131277
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0013603010393103126
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0014509289948302874
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0015470751395455398
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.00166664339327651
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.001788432722446905
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0018928202181145595
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0021113425189103145
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0023823852102105216
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.00285722193294075
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.00330607180464021
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0037049258494019836
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0014390402368175503
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0016565500602788207
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0017995420311345096
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.001971564894073853
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.002080230871642103
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0021812797171766943
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0022583031014093186
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.002340324834611966
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.002399141130018693
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0024559287041033494
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0025083958303322184
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0025784451632966704
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0026463127712034124
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.002708725207785712
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0027811400943388766
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.002857234831338908
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.002947934406803634
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0030405092497450747
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0031805459936428433
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0034047437198949297
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.00367243545921596
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.004050842664139485
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.004572600336304593
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.674695616224365e-4
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.594236035470502e-4
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.46700248832016e-4
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.001045844548594787
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0011392186839899589
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0011993082060145668
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.001238133496766746
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0012815065840542463
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0013149839022964498
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0013439812878280192
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.001377791689607272
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0014186095559931434
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0014578040831572645
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0014889677753119658
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0015379648596928791
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0015838395724205472
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0016394936829486795
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0017058147066364908
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0017919358015381103
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0019291118473386843
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0021272567365241877
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0023408391255119758
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0026655863383611275
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,0.00049375055995512355
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,5.83335794969022e-4
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,6.771584511294604e-4
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,7.691100359359111e-4
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,8.408120328472939e-4
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,8.938437194393157e-4
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,9.345607897860075e-4
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,9.723278504381011e-4
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0010134125434149359
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0010535082870371108
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0010956560135608785
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0011434946582450085
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0011869324523549037
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0012375914277393102
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0013007993025417096
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.00136925790520708
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0014511253588346618
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0015525363916721294
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0016654692526109028
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.001810781694349348
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.002141752212758541
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.002405153909210727
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0028093519685628153
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.52808140948119e-4
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.573449858393709e-4
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,7.606850702862346e-4
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,8.795755268787513e-4
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,9.847586179134629e-4
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0010578044540283519
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0011177453516376683
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0011740820016672591
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.001223225758014582
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0012811458608386244
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.001336424114654157
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0014004413612264972
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001460045970879898
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0015189235417146626
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0016007705986249622
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0016915959261781118
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0017789739223559747
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0019000705135676396
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.002079161854595986
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0023011967261824216
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.00269559493762305
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0030966708128771668
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003652393837920295
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.6109404013636786e-4
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.633099372514325e-4
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.771897201171887e-4
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,8.096716025874423e-4
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,9.064913512017777e-4
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,9.792642439407388e-4
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0010567895753634897
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0011257434926053725
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0011850382947315172
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0012558259491091469
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001326261537482752
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0013889236128787207
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0014620934139053842
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0015441675940641752
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0016323707038756626
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0017381508474379093
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0018619049577560135
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0019902237699303883
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.002192823707387693
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0024815421438985153
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0029528454262578753
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0034484858158496928
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.00400168435950714
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,6.060291852853858e-4
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,7.631678813637868e-4
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,8.593701484982826e-4
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,9.806198992704232e-4
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.001054202474756098
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0011273016572546518
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0011800974067456976
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0012411995884425645
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0012767869206890272
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0013137612244848327
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0013500266168225564
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0014043220894613356
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0014556872495517991
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0014980276659321357
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.001557054095363654
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0016156319837779811
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0016854413608632197
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0017543575479826298
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.001868923522311428
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002069188846350939
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0022918085257270016
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0026405426112575147
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.003156762911243045
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.643979387160417e-5
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,1.4604755524038249e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,1.697511575772632e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,2.3226760969369758e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,2.493770645304392e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,2.9810151104534146e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,3.094429183662146e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,3.498624743050568e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,3.6061837170795787e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,3.9112812205156506e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,4.06111764898568e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,4.252125813642331e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,4.610010385355574e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,4.7715364202859784e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,5.20566541612156e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,5.468562563076106e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,5.870330793598391e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,6.386793480732003e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,7.138956103598713e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,8.018342453029674e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,9.697099442366717e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0011580391227226667
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0013971537391301498
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,4.712887149593406e-5
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,7.094882600641883e-5
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,1.0478380441189924e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,1.229025533337585e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,1.7665126748748423e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,1.8833299951592948e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,1.923456841215689e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,2.3057961829459685e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,2.388061343350456e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,2.452137534386924e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,2.8102507954096205e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,2.950792577087988e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,3.031194258062774e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,3.4639691558223807e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,3.704946283780012e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,4.1670941113567826e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,4.5266075223412673e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,5.182537363255629e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,5.808732953291491e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,6.785417162891686e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,9.025359582287721e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0011353881740475322
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0014482949606602342
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.7709192986199262e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.3064343322711097e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,2.890436200030619e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,3.5267395923854685e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,4.1463672105463036e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,4.574476691189971e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,4.904020497321391e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,5.235498339805924e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,5.51095711999656e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,5.861308019732337e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,6.152199780278693e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,6.530435361143698e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,6.818819472781094e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,7.1636637051407e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,7.62207504239632e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,8.143165913604692e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,8.60332388040013e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,9.319975435548233e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.001043223952726777
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0011794978525868703
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0014283231046476725
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0017166875201998018
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.002123992698646326
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.4619940298703937e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.9138131092863426e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,2.638427702419695e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,3.3457776523156357e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,3.9359903986704164e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,4.3354493894294906e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,4.7955640622653333e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,5.206912359007699e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,5.530901637365457e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,5.918080424158649e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,6.345897288827721e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,6.713226707745285e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,7.083958409242339e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,7.518946627108232e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,8.018245792520888e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,8.681385921009016e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,9.40972127099524e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0010095150038639089
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0011389544147413473
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0013326686803302487
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0016638953480659936
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.002010550019783947
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0023769596955861066
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0011374144524458694
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0013233635781411824
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0014453730283238652
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0015968699150760218
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0016916935351568045
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0017815019502593222
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0018439511025598121
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0019144080618269921
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0019627910364216324
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.002012695697312245
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.002058060801924172
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0021209900484581647
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0021809143553486055
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0022323755580210673
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.002303638524353245
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.002372881132011899
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.002459750840562227
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002551021253756716
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0026939905305354717
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002919294391555568
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.003194895149667084
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.003580438883145528
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.004112300779040395
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,6.964493107566622e-4
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,7.994954881854837e-4
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,8.865266687723401e-4
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,9.817500334504748e-4
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0010439853373438255
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0011000122385396386
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0011426798724834331
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.001183535537522862
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0012199686010986952
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0012499208292524558
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0012841324808906271
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.001322967510388331
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0013599862201281428
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0014003783048978263
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0014476919710596347
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.001491384937851446
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.001549574185347869
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0016122587318416588
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0017001706405322201
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0018333399506477274
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0020123140540255205
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0022381232310207553
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0025500683931234565
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,4.3329439228939474e-4
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,5.301190023005363e-4
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,6.254964488910161e-4
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,7.203097752995795e-4
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,7.908955164948543e-4
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,8.473345061719918e-4
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,8.938311266163349e-4
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,9.344584158002508e-4
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,9.813229773030206e-4
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0010196889709688933
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0010664244779395285
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.001116490695365408
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0011597931020829665
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0012171240558829033
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0012814993580866126
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0013432025990319008
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0014318660059580474
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0015375195231924089
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0016430525440582237
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0017989980819509504
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.002156391339680242
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.002461596721782356
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0028711676044526476
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.095659573309747e-4
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.195549919176652e-4
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,7.184673334176845e-4
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,8.419815735679623e-4
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,9.520757179911383e-4
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0010383944712750535
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0011013849268016942
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0011681052757404557
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.001227282637872364
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0012869981143125743
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.001349244499543115
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.001421693055620163
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0014877415401797999
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0015574856609054594
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0016471992261659026
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0017432503476915969
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0018454564146518988
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0019793299251721964
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0021711219805613143
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0024068919418719654
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0028079078467483087
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0032513290465398083
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003799575993309718
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.266931442068433e-4
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.26885618376086e-4
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.431061262782166e-4
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,7.897276255522179e-4
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,8.904376576041248e-4
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,9.744231390996023e-4
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0010547218152579963
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0011343799848014763
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0011994857011807412
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0012768397343290877
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0013528365367583546
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0014320315948073946
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0015111908390576286
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0016097885656868186
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.001706916291616623
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0018361375605149446
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.001969943558081207
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.002101696005623795
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.002337661142711363
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002662966857251128
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.003189596397367738
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0037421624300243757
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0042823705727208046
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,8.354879386871169e-4
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.001009267376695292
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0011248896797704689
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.001273116482401986
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0013657040460472592
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0014483832406603234
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0015120612070149103
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.001581537680515586
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0016262705940386318
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0016737361335370767
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0017164862583933453
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0017760299946519389
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0018314080046246206
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0018840008933537467
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0019454770107930422
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.002012319848736706
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.002087502404335852
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002162504934937323
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0022829422125460984
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002474143938094541
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002699150552759372
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0030351402658079295
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.003518620085246752
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,4.192243116090151e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,4.908456892394778e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,5.525929507239997e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.275225660752292e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,6.711878532199627e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.118573224210807e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,7.372455197873038e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,7.676969229455402e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,7.916172184901015e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,8.124518176039863e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,8.369321712508237e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,8.670669241919838e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,8.937987439668022e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,9.194113944077625e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,9.558686363338604e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,9.88022607322636e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.001027974297445413
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0010748914365987354
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0011404423101778517
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0012464956563257691
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0013980381764774922
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0015639326242356177
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0018288976361264583
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.3771197877602257e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.9539533999843647e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,3.7027471517642185e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,4.3077875660006866e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.810587613441652e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,5.191666586516661e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,5.440499386277279e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,5.684919969812018e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,5.969700684131345e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,6.215018842754526e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,6.525825425680962e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,6.831395322118847e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,7.141700730655453e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,7.550876714917909e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,7.991278822761152e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,8.440057169992924e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,9.035646449370416e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,9.726121917418029e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0010537432076857464
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0011611686871983626
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0014125572059453004
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.001629550748039446
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0019412637365355922
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.4858738048090256e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,4.1992479866597717e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.034895946826201e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,5.930688023219956e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,6.737737462663249e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,7.333468897728834e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,7.773757682406221e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,8.303424649999415e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,8.703548439611896e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,9.148646371666409e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,9.603021423010866e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.001013579902960652
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0010564912629746567
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0011109636783568561
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0011788612770028115
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0012537915274589155
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0013233153117393579
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0014309285536096368
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.001588426840290668
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0017789287251220565
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.00209291830409045
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0024587703646641867
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.002930659211062373
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.739644096322544e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.6084232556997766e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.5054362534285354e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,5.556387431219669e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,6.317855030747333e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,6.91399247534112e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,7.574842613152192e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,8.137854733606582e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,8.617355791088412e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,9.196417869478865e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,9.799556657246928e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.001036822291192772
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0010980307007179568
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001168601489573996
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0012503170288936548
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0013464138571448818
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.001447719927067523
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0015505518167331822
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0017376846032417042
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0020025311504721505
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.002454647571854105
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0029168745493867642
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.003395708293958204
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,2.85629309623083e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,3.736468663938558e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,4.2075641581387204e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,4.846184020581173e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,5.20073988463137e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,5.582767929348193e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,5.794457816308668e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,6.095908694426934e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,6.21154248407002e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,6.374370290434586e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,6.541881118941679e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,6.830160581082098e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,7.090258382418356e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,7.24830419704573e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,7.62766116204722e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,7.941023268865087e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,8.351545947929774e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,8.773580992430473e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,9.549377077784176e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0010906167823730635
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0012405901637556828
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0014810880600772767
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0018436426025978806
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.4781001818416934e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.8400066382194643e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,3.294961789968487e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,3.9034188105645706e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,4.2358786309761243e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,4.5801426326287317e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,4.840683436315437e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,5.100922242490681e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,5.28956206933344e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,5.474482359921988e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,5.671233550133291e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,5.919254188524709e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,6.142185237228633e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,6.378186936980377e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,6.681671830108147e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,6.959322139144543e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,7.291672310796394e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,7.61319023438985e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,8.10250767806907e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,8.93826346856512e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0010021769832066413
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0011526263109304766
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0013792092008302471
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.3746491633757386e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,1.8315288070042633e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.4210495669349443e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,2.98014115656128e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,3.422334427164131e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,3.7873096940449616e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,4.043417617068158e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,4.3319026711047487e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,4.5961009111180966e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,4.852833773333902e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,5.158330797115605e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,5.457210436589378e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,5.781863894135182e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,6.213335404471622e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,6.682702014604609e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,7.115601647241982e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,7.741507975542637e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,8.439991068041326e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,9.199371588117541e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0010339129509461303
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0012673409453604705
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0014541214481508947
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0017463392333040048
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.97499403074631e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.5727946438706706e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.3119428029857064e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,4.113535955060646e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,4.8182233838126964e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,5.368443047105953e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,5.788350664407615e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,6.28844267570389e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,6.619964005748213e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,7.051606113916287e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,7.536156145900369e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,8.048514895011453e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,8.597825443925134e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,9.1676600015255e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,9.785999186205283e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0010555394619274317
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.001124155532526138
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0012170320826836519
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.001372395660563199
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0015292869040518563
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0017839004601438676
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0021466723326004334
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0025246292124634453
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.7693958785706143e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.3074903857117724e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,3.137652910968211e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,4.092813811170286e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.8175002383713417e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,5.406767817901846e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,5.991183364277019e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,6.579442711546685e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,7.062400424687702e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,7.61045471079659e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,8.279063464459052e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,8.885563114523864e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,9.5510368439934e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0010407661930512306
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0011270287556284255
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.001234230369178454
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0013427381719387918
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.001445320372619202
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.001663225387507523
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.001903414145659668
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0023356009499324094
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.002758080762107128
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.003132231179271994
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0013216152688726088
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0015505197993270054
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0016928949134203486
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0018693349393422984
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0019775492260214887
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0020762197414322635
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0021537074645184076
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0022370577350004964
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.002290921851319358
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.002344159774379813
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0023954641137257085
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0024646344153755055
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.002530703213268567
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0025924864995279717
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.002661480816522361
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.002737901762265165
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0028226642780118725
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0029058491081325175
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0030358744426732696
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0032541165731796696
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0035027104609784638
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0038745886665023203
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.004414739051814364
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,6.143846888954039e-4
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,7.174665896723406e-4
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,7.970997481510752e-4
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,8.888159038569279e-4
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,9.464515984450082e-4
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,9.978259902524832e-4
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0010335827216551908
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0010691806218630624
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0011030724704680119
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0011309396522402061
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0011621267571296123
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0012093981704383847
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0012501582577137931
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0012922954150419892
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0013411127069804032
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0013983442905344205
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0014575192281635213
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0015241141135630774
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0015994066117823835
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0017067157167234043
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0018927798598431167
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0021084792030258894
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.00244924577042155
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,3.7987462706217203e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,4.611908371120471e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,5.579756470216507e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,6.326800058791719e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,6.987873039088586e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,7.495124229956833e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,7.872519881746451e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,8.187636541285479e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,8.574810172593677e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,8.938968728096856e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,9.357530631500875e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,9.756310764761532e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0010093761740816742
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0010617457931315869
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0011260353991899797
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.001187062282143808
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0012755863287479611
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.001376815918085165
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0014726575247215367
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0016666600068107505
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0020322196820462034
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0023687620198764785
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0028178854936114273
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,4.939879661871864e-4
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,5.944207848880125e-4
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,6.900205660227607e-4
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,7.883925821406839e-4
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,8.876292611138359e-4
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,9.485438262955411e-4
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,9.998066495296822e-4
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0010529675580316859
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0010947072204138494
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.001141769701013133
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0011872524102991145
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0012419510145034824
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0012855031622724577
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0013378478311037289
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0014087827298683879
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0014830836253962585
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.001552427169634739
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001662568619380351
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0018239939804864521
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0020300172865403295
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0023622239188936618
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0027420673385619575
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0032888278292548395
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.269210441145936e-4
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.233568502642434e-4
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.253305630685288e-4
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,7.451615199908534e-4
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,8.324073028881688e-4
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,8.983702393666548e-4
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,9.740380916725594e-4
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0010357329653681916
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0010810987267728257
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.001140034180392675
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001205269356035602
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0012599962146176225
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0013190081350573832
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0013875949884151948
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0014688589801576143
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0015690706468251378
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0016731370745658078
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.001770822363991352
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0019524745743883464
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002219575424581602
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.002669703364224715
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003119353597579355
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.003633660249996903
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,8.519350381481217e-4
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.001000325812405873
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0010843338123333417
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0011943172101623206
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.001258912608390175
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0013209351924705916
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0013596534995439732
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0014077425186873366
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001435827245185537
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0014666204113533896
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001497950703098867
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0015406524837306614
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0015812876850868794
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0016128451270264197
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0016656950443949276
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0017151762156102615
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0017770864670774175
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0018430339786044653
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0019497616965760134
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002126837946837766
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0023422571336143764
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0026450026647288085
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0030848271372155315
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,4.4409123337591373e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,5.169861827305606e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,5.936866842671655e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.87737476803311e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,7.551970679216353e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,8.095268310387509e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,8.515417842135165e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,8.875369160327372e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,9.159040611858235e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,9.453883434957281e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,9.738927378892907e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0010104187061991483
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0010453912022161255
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0010784745370127184
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0011210083572673784
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0011607342350069456
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0012081699004085917
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.001260450253859369
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001339726822113091
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0014551955372713121
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0016242911297037316
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0018114396588652937
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0020807851923978667
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.940411085293109e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,3.704593223700553e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,4.3280546599455146e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,5.144513489652269e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,5.820488604371312e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,6.292417240245212e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,6.65567188193972e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,7.008216363654894e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,7.377539665518469e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,7.729135177226643e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,8.158596521271683e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,8.557658078857198e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,8.952060147929983e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,9.469976932690756e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,9.994955519624818e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0010529162172235465
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0011275418923494438
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0012208143854884486
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0013127782938329073
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0014436236567632954
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0017423546823566163
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0019634130393506536
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0021952405028247916
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,4.0749088973407455e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,5.001518534818701e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.992444634440492e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,7.038442545000926e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,7.916200166635601e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.57202816981164e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,9.119251876194515e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,9.69531376800718e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0010151334582663598
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0010687017469045625
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0011279158482253523
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.001190282774785304
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001250146447770925
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0013156539491790704
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0013924351907760894
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0014808638395216276
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0015646230548165474
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001677202457700192
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.001845935738606196
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002051835264531875
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0023879763451418326
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0027778797617963305
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0032529884339710883
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.552889162216535e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,4.34953555369277e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,5.350857123494889e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,6.580165802281973e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,7.489396367166272e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,8.173658928486876e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,8.899925409104356e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,9.567433959776029e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0010174851266850202
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0010851632433875242
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0011573572315735328
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0012243298586575241
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0012987111428767024
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001386738495123628
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0014773852290654314
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0015928368364310623
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0017158421229722344
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0018397619291650636
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0020497878164693526
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002321399389631375
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.002769169028480147
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003258158319332786
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0037115536642861923
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.2222797991621558e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.6148132318039183e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,3.059777025148118e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,3.5525914909807457e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,3.886820530411288e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,4.184298273075617e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,4.489330984686513e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,4.738083584533272e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,5.003769271415862e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,5.250562214061978e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,5.488740500224262e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,5.750859360689256e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,5.994306852660781e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,6.252976648661091e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,6.561207338599571e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,6.89152342655559e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,7.21134578895911e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,7.633103295251165e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,8.044548387520383e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,8.555303255993836e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,9.59467397870131e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0010523018209357621
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0011576288036126382
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,4.771425100152659e-5
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,8.086523090517205e-5
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,1.0506299019131992e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,1.4322877629571894e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,1.79285052431355e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,2.0329207959796666e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,2.271831928194735e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,2.6012827480132014e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,2.891063293342024e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,3.1676266976103716e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,3.418092546617264e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,3.701608306549549e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,3.988180651187146e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,4.2945578318824866e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,4.674717048078743e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,5.02762079307598e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,5.503080811643443e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,6.111975306560384e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,6.732007205387264e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,7.67490725342182e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,9.231858933843489e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.001122312584164556
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.001330795132066537
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,1.1165354795802109e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,1.6094516933470537e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,1.779965551568861e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,2.05006532318781e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,2.172122106925352e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,2.3287042932938914e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,2.3703537233172228e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,2.479830100062637e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,2.487837729363801e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,2.52920524116673e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,2.602325576104489e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,2.7151783748994256e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,2.823690934865506e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,2.846857634695001e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,3.058573306037862e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,3.2021895552231735e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,3.418509704463985e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,3.668035906072405e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,4.1291999747034155e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,4.980482444175684e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,5.96964825620553e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,7.504031761475148e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,9.900959061913256e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,4.080937956033427e-5
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,6.492010113800808e-5
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,8.438225945338309e-5
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,1.6831556719819782e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,1.8503104456334628e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,2.0151468733170018e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,2.1520404869057168e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,2.810633802637796e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,2.8959262203808654e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,2.981959891634685e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,3.5939404613887806e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,3.739807786830462e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,3.855071056265716e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,4.445056726066883e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,4.612693341361716e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,4.772135032769324e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,5.419816154829874e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,5.591731001038764e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,6.364495684931878e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,7.417442404474761e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,8.88272388524042e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.001038270664136732
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0012386630076200872
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.6966201133777316e-5
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,4.923654406998265e-5
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,8.272588531791268e-5
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,1.1041306900262467e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,1.3284051424444822e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,2.0626547560712705e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,2.1957861017380108e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,2.301576505671084e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,2.4197730367106035e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,3.0273215521538905e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,3.2034251086832653e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,3.336185669420465e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,3.5029384140441153e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,4.236878819139703e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,4.4835896007484064e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,5.150203173681564e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,5.53518768613022e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,6.35966371128144e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,7.184947171515281e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,8.233845556521924e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0010923629168100293
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0012712642322368186
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0014506832941983956
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.0179319371718802e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,1.5183579410973154e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,2.0562549688472333e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,2.638341584277025e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,3.135986554285056e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,3.5893556541481263e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,3.8982663810730047e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,4.2926935192971223e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,4.547263945871733e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,4.872533418612662e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,5.259750515170434e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,5.662233842591124e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,6.124833416525251e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,6.610623193560026e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,7.097475251317596e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,7.719362060833885e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,8.277353419492828e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,9.003929689721816e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0010151631872167555
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0011451482948523738
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0013277483029766586
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0016062675051973798
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0018853989222721028
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,9.364153588724348e-5
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.3234842665263072e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,1.9871148230685327e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,2.738405001131278e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,3.316531631820521e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,3.75500695846359e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,4.2323086947701916e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,4.6481791234315585e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,5.049694499093438e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,5.560174219342042e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,6.122422469898053e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,6.687086924799493e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,7.251106518869771e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,7.933743116364147e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,8.635538406146176e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,9.506992441836453e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0010416568397993544
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0011127237982592394
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0012823858135062706
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0014779137214804051
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0018476400266560903
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0021921481673078357
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0024760018221839106
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,3.6546094956311587e-4
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,4.948343063851245e-4
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,5.931410231316507e-4
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,7.187123500377887e-4
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,8.028575668857439e-4
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,8.760246430194457e-4
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,9.432651315875472e-4
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0010103103883405684
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0010576072982555291
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0011051097357522761
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0011460942703504784
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0012033176919377818
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0012571841845515435
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0013149549327088569
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0013653953097076043
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0014289450082771618
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0014944217903339594
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0015552724220567271
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0016502823495311936
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0018004233399057901
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0019655761842868715
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0022396448799763403
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.002634507314641465
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,5.016178950650806e-5
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,7.685028946333486e-5
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,1.2987635597972583e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,1.5594998621606864e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,1.9995756834218366e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,2.1771451611233525e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,2.519531671721431e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,2.667024009502645e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,2.773704055779424e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,3.0627393347953437e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,3.189689626485543e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,3.3858915757220087e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,3.700910841843258e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,3.84325077277786e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,4.188834668422241e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,4.418819209742361e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,4.7930683839051086e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,5.171416013928286e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,5.759000963458002e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,6.64937605956474e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,7.990959020034176e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,9.30225409576924e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0011728889474905
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.066655393261622e-5
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,4.0503857510732454e-5
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,6.742347622652965e-5
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,8.593714795424148e-5
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,1.3405657746131693e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,1.4704749139845212e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,1.5469471832027162e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,1.8949881871553202e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,2.0041567273067538e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,2.0996743359208067e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,2.4238941855217163e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,2.585663707196299e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,2.7340159011094616e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,3.1042734506341664e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,3.383674378667965e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,3.7660629687187087e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,4.203751241143175e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,4.730764188087673e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,5.331073771870651e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,6.292062089645327e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,8.506884656022543e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0010512609024755384
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0013887250929727043
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,8.914421080806585e-5
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,1.291715986559134e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,1.7253927844913003e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,2.2375792283304137e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,2.710526056384241e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,3.036947251363536e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,3.3304031850395037e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,3.62694335114326e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,3.884787920189595e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,4.1684652160450927e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,4.4316716275563846e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,4.752179775411805e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,5.025005250073934e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,5.31728912693231e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,5.750310005102628e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,6.221988083062518e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,6.653764699589611e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,7.310978030917668e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,8.282494792032572e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,9.541197928795854e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.001174520257434797
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.001431521639898213
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0017965239926654893
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,7.824674597486158e-5
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.0321544822561765e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,1.5040411134264998e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,2.041309814033876e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,2.502785815571881e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,2.8619987189484864e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,3.250571642348467e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,3.5751363300632813e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,3.871409177573606e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,4.226214088543127e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,4.588934855076182e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,4.925882700001704e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,5.275215655904225e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,5.68595653035883e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,6.173791946805525e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,6.791033116092297e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,7.434088215753259e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,8.060635442712754e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,9.268804399972686e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0010970925821559441
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0014044133880443017
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0017280377885780483
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0020556390368611376
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,3.145985572874662e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,3.972942969654279e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,4.4859493892423114e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,5.155425158235973e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,5.56384206213069e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,5.947385359840584e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,6.212538730656258e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,6.523120518116786e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,6.713567817592931e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,6.919400370431299e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,7.116719789735767e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,7.39163919318293e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,7.650905095254853e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,7.872184707657921e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,8.188565993783175e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,8.504112807034658e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,8.883860662354341e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,9.277909693600886e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,9.91787771665583e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0010968907411115494
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.001223779800721265
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0014087381152251613
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0016794046106723074
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,3.1190050443199015e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,3.6329552564154225e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,4.2278007056194896e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,4.929930310521977e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,5.419958473153168e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,5.868961139572773e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,6.20201085162704e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,6.59876640832418e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,6.902941753126688e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,7.214419480844325e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,7.512782603839503e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,7.829702981977738e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,8.139030828386368e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,8.490268743767814e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,8.779816162737552e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,9.179627387892671e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,9.64134189945479e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0010067886301595858
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0010722729295357025
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0011512481607607705
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0012879903132225776
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0014173197939701325
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0015789314581868244
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.845827306827349e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.305464264414653e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.8458681677510987e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.7034987043142796e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.202255068402002e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.702616093291872e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,5.099997846199787e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,5.543474567748544e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,5.987736563415097e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,6.44032752445159e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,6.857350310812481e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,7.325456378986598e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,7.766679799135513e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,8.2152104829091e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,8.779809121848778e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,9.47285813920164e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0010172600636063891
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.001097245383223026
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0012169381668079618
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0013662145364553898
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0016540579507616
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0019424199731582668
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0023070360913178163
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.0332243012864546e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.6633173999301193e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.3847304099864447e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,4.363654253417373e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,5.079869825558493e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,5.725942902680809e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,6.23868886590251e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,6.823303376864843e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,7.268780484006962e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,7.775215929787221e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,8.446716814288399e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,9.054421340726516e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,9.864544211348697e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0010669916310602893
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.001145207107408207
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0012386104780136124
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.001332177606520189
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001442414026133763
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0016091505515373312
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0017860580860501814
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.002067498365308433
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0024039216437979766
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0027966289302304996
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.8424420070082252e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.3375360033623624e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,3.2137544452593466e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,4.215346267468097e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.988275217611538e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,5.606852628346384e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,6.224988950844785e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,6.853278923115531e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,7.487763648167944e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,8.139399341549668e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,8.924564743323959e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,9.699886539425424e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0010570039864461057
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0011638869214801815
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0012726509292894515
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0014003668476868269
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0015336336208779007
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0016710709973319754
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.001920624026453739
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0021673428421698495
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0026127591533941594
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003032448603837557
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0034007379032441566
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,7.205734779205728e-4
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,8.812959776567126e-4
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,9.582197360585175e-4
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0010577839790351189
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0011134869021721327
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0011722633059779728
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0012076413295311862
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0012535944805829131
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0012802935222654998
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.001304619616461322
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001337305081756438
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0013767138698684161
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0014178430012156743
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0014469763097333152
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0014981815255434546
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.001546555487283447
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0016077492858337017
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001674037932990079
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0017763715536538549
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.001970650231719947
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0022072932738049634
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002538184004161908
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0030531965401109588
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,3.0342819687225944e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,3.547043981889329e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,4.003631889556659e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,5.495393393097086e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,5.969751698213794e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,6.362766966145608e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,7.412535426460238e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,7.773889980814471e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,8.104303623936367e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,9.071282589304412e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,9.381911529889856e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,9.741870192670301e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0010720388438789678
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0011168485981089527
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0011625202922872584
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0012557566864419294
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.00130955267976985
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0014167930112038243
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0015117790296404101
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0016776421574355364
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0019174953503202342
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002162475624650253
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0024292280191430824
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.6197643188140317e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,3.157419235133851e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,3.671423286359054e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,4.360442243972703e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.8342898730366135e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,5.959260622500351e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,6.339924370992339e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,6.722371946791153e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,7.024033044078182e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,7.99283249519851e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,8.346495050028714e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,8.695195158823923e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,9.518207537847622e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0010037886188132706
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0010468474533742837
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0011491929742375275
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0012122085730659669
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0013361642720845393
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0014723840511892123
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0016765370572482691
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.001986927412932937
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0023475096687904265
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.00284365149339471
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.241972476393202e-4
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.344932228758246e-4
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,7.665230145391014e-4
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,9.160606497572565e-4
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.0010320563575598083
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0011258765277211626
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0012034129835281006
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.001287658688076552
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0013588018348939996
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0014320223835083655
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0015205822578653954
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.00161408931420793
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0017199342289381742
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0018252985817140165
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0019409670754982323
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.002074155195185106
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.002201140337947468
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.002365615395491437
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0026234703580994894
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002899349574423552
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0033301577899409736
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0038468039535443713
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.004493535125571776
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.841896786574026e-4
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.765182678014033e-4
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,7.121286593967733e-4
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,8.823544853769996e-4
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.0010064273160495189
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0010967189736753574
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0011928646355245864
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0012921775074427881
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001382385850592781
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0014744291880590644
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001585621848673193
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0016917683447928433
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0018081038439167062
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001953229017032718
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0021101614995140054
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0022954259549314055
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.002478306800412706
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0026744889710323223
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0030165030274694415
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.003385013629903193
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.004043073896983354
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.004667812373580807
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.005253883635663833
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.001296749847491962
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.001496886198455851
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0016263571311809601
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0017837265639715654
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0018824177420482388
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0019758746215469904
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.002043491047648749
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0021177567050543983
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0021702287971796363
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.002221806247312684
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.002269864224543828
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0023346381180691907
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0023973368376500243
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.002452491744274903
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.002523090340251921
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0025939428256591774
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.002681247733831705
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002772036431121663
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0029109900995136773
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0031337066489309034
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0034033221101483577
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0037797827380088517
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.004299580828305445
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,9.213752826011477e-4
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,0.001039900516048067
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,0.0011417323209670957
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.001237889303720266
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.001305134803056314
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.001367378615442832
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0014258695617001505
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.001484486012742193
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0015222006438206678
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0015556432004528193
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0015944776507024981
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0016371206291729329
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0016781779178641036
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0017159941014934271
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0017682043199538549
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0018143146058350774
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.001869029145249538
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.001932603078888449
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0020161615481582543
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0021525060511666007
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002350325149132129
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0025789090871861423
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0028910448425987184
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,6.493814188997026e-4
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,7.637109249642892e-4
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,8.762711288621326e-4
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.775504105664487e-4
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0010674847188773596
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.001131721398511003
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0011862977914482997
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.001233944326319918
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0012925749180686622
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0013414413408859196
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0013955989861954054
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0014509086619731823
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.001506332718686892
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.001572284975311635
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0016453988489461306
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0017249178489413216
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0018306627207357825
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0019483348869668983
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.002084331168789729
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0022755301093881734
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.002640182710897164
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.002990716249613409
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.003401408227232328
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.858776762775293e-4
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,7.026460208746726e-4
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,8.225348889592607e-4
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,9.535865319826889e-4
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.0010637101733862783
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0011454084538670302
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.001212395453368488
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0012792577617555805
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0013407380684803025
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0014021749497215635
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.001469897140198973
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0015420606574560228
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001612062327421613
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0016859992302712748
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0017791129747166887
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.00188056994383399
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0019787798660096567
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.002114886840601119
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0023139778926396268
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0025669775921099026
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0029796756269860076
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.003423766323140799
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003993181760234413
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.951236490199219e-4
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,6.050176182135929e-4
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,7.261828055663418e-4
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,8.753068861866284e-4
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,9.817087418192054e-4
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0010637357537472737
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0011531663875434962
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0012361867596410604
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001305740166303915
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.001384936229606186
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001466757308040616
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.001543646377141193
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0016270535936680278
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0017296121987391247
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.001837913743923544
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0019659452336231735
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.002103614564413275
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.002244622442611896
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0024847729875433215
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0028134303591932745
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0033439500119924782
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003906894992216091
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004447804376051436
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,5.796888084808928e-4
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,7.577373158764038e-4
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,8.816368280255099e-4
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.001040849861994482
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0011426167963443498
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0012332338282504613
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0013124907812318892
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0013949449921216897
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001445890627970624
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0014989565602570576
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0015462683199329033
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0016162699371886685
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0016807786515143216
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.001745665755498372
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0018090457159286092
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0018852173816643674
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0019629951720298144
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0020330987552619815
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0021498906321986222
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002346055286921879
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0025496852464278147
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.00290147977941491
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.003427689397083592
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,1.5832853624064293e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,0.00022660731153035949
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,2.837916595708795e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,3.476669940586286e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,3.961491718889946e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,4.406601836898121e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,4.8598615962539807e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,5.061560107802256e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,5.543687522503424e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,5.779798262672073e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,6.233898731404304e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,6.627772219643781e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,6.947654359570056e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,7.430416162792663e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,7.877230005706031e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,8.296776521628934e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,8.870744546094814e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,9.49180910950344e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0010230166257387575
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0011232177260463378
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0012907304028219211
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0014647851675896736
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0017796333918557142
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,6.388104665132571e-5
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,1.2267037700862228e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,1.9232111462103244e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,2.4692251972647296e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,2.942681366744508e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,3.1665982624308454e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,3.473683943674831e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,3.671650613524328e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,3.9757511923558045e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,4.3058247210527826e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,4.6269611185533594e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,4.955054392387074e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,5.419345648246564e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,5.97497173509592e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,6.524982107959528e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,7.266774931392544e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,8.06046413850358e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,9.032077638993269e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0010216540651729117
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0012000791388219224
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0015366388310326027
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0017769101601921803
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002209268051223794
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.8382475362420392e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.3754433319497827e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.024429559486912e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,3.692733889139951e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,4.3485986768812036e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,4.8193045111006737e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,5.176791381713181e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,5.541926125810677e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,5.835166087242625e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,6.198973384576876e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,6.537396837773793e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,6.957711609796827e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,7.303114968438932e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,7.704846489369845e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,8.205725793966891e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,8.789334211144243e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,9.329811897811505e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0010143375021444234
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0011400284000845564
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0012951227575896287
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0015526924948714306
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.001897037574641902
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0022947353652065326
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.5531194167867082e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.0506679727843894e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,2.7461086185436793e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,3.5731317069918574e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.1966913552462506e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,4.637073156944627e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,5.146484818588772e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,5.597525597862902e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,5.933259072857268e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,6.368085626874282e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,6.848697135452634e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,7.257791176639569e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,7.709570135623834e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,8.24130298305158e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,8.866687878458419e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,9.655655083805405e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.001050133716182782
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0011205256925817648
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0012692243667630707
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0014815729196972424
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0018817080862421514
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.002314716471220675
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.002730428383871838
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,8.727492928893882e-4
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0010131880741945409
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.001090832308834043
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0011896384522406766
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0012477682693966773
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0013059048910635642
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0013413920313141872
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.001385508730999232
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0014127535402055434
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0014407637445845592
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0014703220710182026
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0015098102279598692
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0015484242113848203
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0015771691645128769
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0016268397161169575
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0016720108311225306
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0017306835820029562
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0017939192306411062
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.001893762218954288
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0020623051897702112
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0022679642514232194
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002551317989310652
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.002958478349481402
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.883823069759539e-4
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.78034298486924e-4
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.482222027449697e-4
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0010124828702496617
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.001055422995753568
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0010926836842834356
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0011358836051721581
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.001179588982785939
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0012224352979110333
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.001262427507587701
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0012988827309525623
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0013362312763824176
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0013684209830952892
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.001400564049748627
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0014376401078150304
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.001474149966729273
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0015153256224294176
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0015635245019370678
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0016277380860103769
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0017310741699554052
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0018644995638881356
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002033527215488944
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.002242908778630875
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.025729616752017e-4
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,5.760472694297484e-4
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,6.529303929007773e-4
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,7.510740172074902e-4
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,8.229452183218463e-4
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,8.832662571132113e-4
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,9.406872956310925e-4
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,9.92874204264828e-4
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.001043500546112585
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0010898883039177818
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0011408330108459758
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0011916554211227675
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0012442905341280772
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0013004121375060878
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0013619701130220558
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0014204483231462074
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0014960069106482626
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0015781547071526112
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0016877246108335958
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0018281628540718152
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.002029138019302003
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0022665504215899773
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0025295730213927034
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,4.781701198261692e-4
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,5.854304705102723e-4
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,6.896375529185692e-4
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,8.154275535810238e-4
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,9.149545909719532e-4
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,9.95811233852248e-4
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0010575194194703745
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.001121537554391234
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0011791156112577889
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0012383959554117655
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.001303373059460588
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0013736776677552678
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0014488675019335795
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0015225624238757284
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0016106238691665502
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0017073098767769583
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0018028409366032782
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001926248484292978
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0021066455189427714
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002319688156484265
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.002664349456228005
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0030738810790875135
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003556013498458184
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.280349275299736e-4
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.189698426390468e-4
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.34922066768636e-4
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,7.733744394992436e-4
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,8.720739979930421e-4
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,9.492528112331298e-4
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0010284735473462831
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0011054417404888339
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0011748772028842098
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0012449899250498173
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.00133099882088991
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0014102632331289408
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0014998280999244315
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0015982614883141826
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0017068811372312953
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.001840053545695078
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.001975644965666939
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.00210552446003997
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0023362057619736726
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0026160072487185953
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0031013747842181896
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003574912420197008
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004011989168094351
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0013872775140348359
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0016102942810776286
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0017371713776009664
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0018942170052248341
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0019886365416217633
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0020826598413034737
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0021444012352343288
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.002217183579963806
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.002265833937359954
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.002312508100454982
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.002361813317333052
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0024256253324360195
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.002489268131783315
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0025396839271120005
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0026158807588034295
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.00268841796704903
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0027809890447628815
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002879889405861431
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0030314302843356938
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.00328990698194442
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0036058574956634513
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.004039637369528512
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.00466260335253037
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,0.001383657480061409
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,0.0015306360330131392
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,0.0016462183527080712
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.001807284400377235
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0018988411330656738
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.001959008987956262
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0020167299131037524
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0020682653167949723
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0021160349002701086
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0021638685293362842
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0022106651300514593
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0022547466552691802
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0023031210947781523
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.002364510787938759
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0024372887551613737
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0025162637283945104
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0025942090916451577
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0026891092751241217
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0028088005498000264
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0029516592459798915
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0031915134492257287
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.003436593708006387
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0036654795897022455
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,9.314157295250479e-4
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,0.0010657135060285804
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,0.0012153901645646456
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,0.001359493362938675
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0014770082424634952
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0015852434846358515
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0016738776563426437
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0017578303372502587
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0018402944415053762
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0019145365862638175
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0019960897713297314
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.002075554025929573
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0021623437587581736
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0022587792475780317
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.002361581478941002
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.002489946908665547
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.002625337418132168
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0028023948523309096
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0029897202053271524
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.003286095234821911
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.003747921630768182
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.004298531357158893
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.005005062356527406
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,8.464925501952265e-4
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,9.988829779369172e-4
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,0.0011497042610574132
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,0.0013440084663088531
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.001494902849266272
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0016125570894189316
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.001712393415933985
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0018121682834592494
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0018971706433546934
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0019896710470270517
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.002094614275605905
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0021973620116655787
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0023186550640603492
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.002446781193715654
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.002580538197482077
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.002734798839997064
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.002886362064125076
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0030723179783246086
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0033517788825986015
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0036897761532236903
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.00419971229291102
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.004815599643492728
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0055615371505163685
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,7.597336991182083e-4
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,8.843786598082407e-4
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,0.0010607140897106616
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,0.0012682797044145776
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.0014205865091115144
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0015373184649818635
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0016549209801792137
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.001772196820998748
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001882597472159614
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.001993803575066915
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0021200126919294704
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.002244686190243825
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.002375537192402021
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.002531653303105257
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0026997602853361816
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0029057394626914356
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0031214789397405462
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.003345845787718455
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.003716711272475486
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.004154394958228869
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.004904885381608534
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.005630677796502256
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.006345593027205719
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,5.589591593818966e-4
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,6.842336728356084e-4
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,7.555877656986851e-4
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,8.549797308350137e-4
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,9.13238210694005e-4
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,9.705023257609662e-4
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0010005174554929995
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0010424996513600513
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0010649063565712404
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0010935820966681384
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0011218617645225412
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0011624155480072776
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0012002118409349613
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0012255416987411263
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0012833380704976233
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0013319967632107635
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0013982123432701367
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0014722870821282854
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.001597219770562202
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.001799147385714151
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0020557927365746327
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0024164978671009866
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0029423742288089043
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.678715500530985e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,3.259580548081296e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,4.5170168310341096e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,5.865319480974926e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,6.315795780204922e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.399610519254892e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,7.753266800418577e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,8.704132639627753e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,9.018708046364309e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,9.736283102177208e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0010640894877211476
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0011090974364551059
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0011951698504965298
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0012517983010125648
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0013433103095073016
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0014046159153323172
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0015098405988958664
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0016186930367886403
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001762906677952002
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0019332647603908712
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0022220034294422077
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002485407326199846
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.00297441663381126
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.2119876813241133e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,1.6678255417888082e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,3.098416530901044e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.6815888933788604e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.910052802795833e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,5.356855183796283e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,6.319114776526626e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,6.682099274010227e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,7.660241418087916e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,8.450749451312476e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,9.04548938910431e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,9.887949431889287e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0010753639609874487
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.001180150422471765
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0012582615830962584
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0013690455788651495
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0014814383192666087
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0016141427471685487
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0018162111506371385
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0021111026789226457
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0027137960567600984
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0032956362709035767
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.004049621052443828
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.729509362579287e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,3.422615899463558e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,4.260086379188781e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,5.260356318342336e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,6.116200589936441e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,6.779793133029309e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,7.32567264536478e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,7.912801580990197e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,8.380660955234936e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,8.942948474727206e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,9.544392005596274e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0010168179814819167
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0010821659462453826
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0011506351394774818
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0012317146402026041
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0013286266825188239
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0014187470404920066
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0015366704314846691
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.001720599571427852
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0019415539033045565
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0023076340763994044
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0027848726890617155
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.00333906801160294
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.2494690810644693e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.9154059776517245e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,3.8571333681188577e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,4.994314446230328e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,5.843601034994673e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,6.463171223710578e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,7.161927124369029e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,7.810706711224994e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,8.430223651821446e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,9.104689204628058e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,9.891251343790333e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0010656244311842455
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0011445892212660798
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0012427654143006821
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0013452270159255222
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0014743273821843442
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0016136846416824717
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0017437700379543074
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.002003758598536454
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002322564462113384
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.002873358587676289
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0034468664114302573
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.003966441654341485
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,1.6745797542956075e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,2.4482645703036474e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,2.825049347383566e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,3.3256145627989764e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,3.5998106024819694e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,3.9065066845747403e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,4.088258353616235e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,4.3377408459073453e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,4.452004793254729e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,4.5697727336913436e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,4.727553907984014e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,4.95153079104534e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,5.174666501261955e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,5.319347353812039e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,5.608344007585332e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,5.870125684171962e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,6.200430756929262e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,6.542897376465668e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,7.122235045130036e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,8.26529685646662e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,9.566867570359872e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0011598777863127152
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0014866202464320127
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.1766964295996655e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.6820955525618797e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,3.0314040779482615e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,3.6403997063068247e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,4.08054077504836e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,4.480846612744601e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,4.754145996687416e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,5.081892960502196e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,5.288880194104686e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,5.489023241300933e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,5.70562623004912e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,6.004688230407926e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,6.253808763911871e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,6.520429615831973e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,6.838295177538503e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,7.175449480560991e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,7.544788386517887e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,7.888273861977403e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,8.465678184706309e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,9.549625354814009e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0010879574552012216
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0012870453017207561
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.001602840942422134
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.2384788789984925e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,1.7822667049658336e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.659990953008529e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.386085106116706e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,3.9922443963954406e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.394367541551106e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,4.730409125135154e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,5.037912640941091e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,5.346710991669827e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,5.612471238358104e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,6.020714335238877e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,6.328092944324195e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,6.682191752985327e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,7.234798237491443e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,7.81517282921273e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,8.331813922318414e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,9.11744670167945e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,9.873014293054867e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0010704110693088003
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0011627233051839762
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0014573961089514617
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.001687855420912216
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.00188086709300139
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.5041035711513991e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.031673161851176e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,2.641536448434255e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,3.379178420227462e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,3.996074523242968e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,4.486120462002547e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,4.887100447265396e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,5.33055727369419e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,5.6704995994246e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,6.091898706882066e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,6.563510189708741e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,7.05001005421388e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,7.606013242770879e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,8.161063657727856e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,8.783147232684624e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,9.517518812735317e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0010186094611423222
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0011068800690891304
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0012558870832223715
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0014154770181380523
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0016599567008815264
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0019967428544449715
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.002396577550206408
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.370520023783942e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.8063756740085515e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,2.5705166519202945e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,3.4274044391178647e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.0798755539895616e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,4.551062164579476e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,5.08539074079051e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,5.608735422106333e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,6.082052151515181e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,6.63069987375739e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,7.273191548662866e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,7.871569469952456e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,8.539011563644251e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,9.366362139467119e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0010259957603202287
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0011339646406218872
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0012424371206366644
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0013443157705981404
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0015555152245168647
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0017875398971188019
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.00221859417632916
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.002647717758847301
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.003005703503700285
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,4.4523733283346524e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,5.561889739214162e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,6.175751682070044e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,6.947288676156848e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,7.391844782438631e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,7.879332414114256e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,8.179872403124046e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,8.566704653365198e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,8.761459895829701e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,8.975842705277646e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,9.199797586092065e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,9.560364343451596e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,9.901077215661248e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0010129739868992068
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0010568126644703922
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0010945987538361875
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0011440251039714284
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001194170088269427
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0012805079534458936
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.001435175766051913
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0016053009094842802
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0018709127559325125
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0022626589662762555
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,6.297098944142619e-5
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,1.2571791431163486e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,1.460808237492823e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,2.0225504026738796e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,2.169381223021929e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,2.620574731536296e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,2.7120162193904437e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,3.0983437265576523e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,3.193153500609179e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,3.2663914061899316e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,3.606829056938015e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,3.748842739677901e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,3.895125871294345e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,4.2525538398220224e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,4.4310593887224184e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,4.932715055203502e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,5.165148344554401e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,5.720169892335601e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,6.185518852235585e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,6.887381650455017e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,8.080310319392004e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,9.644584870608703e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0012187508692862248
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,3.8629272710454735e-5
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.0007818873593164e-5
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,8.991985451571873e-5
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,1.4214729365370928e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,1.585378775224276e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,1.7004466448742483e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,2.0650992008231148e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,2.118324750539968e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,2.1993360318556165e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,2.5498026500890114e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,2.65649233960429e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,2.7629083276674955e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,3.1063619663553634e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,3.2871776327169906e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,3.7125853716923614e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,3.9093876161606293e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,4.4136797679020776e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,4.8039492700904167e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,5.383120699358273e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,6.286356781882074e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,8.122385571910897e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,9.987553474566817e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0013034119943900538
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.4529380832873932e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,1.952116699424437e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,2.478605680974824e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,3.0757167826993623e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,3.607200443480212e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,3.9809844981763637e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,4.2888702101173627e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,4.602119557712168e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,4.8747930794051323e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,5.174012046958772e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,5.442582262392512e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,5.788656305434146e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,6.098674003396109e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,6.438762260120045e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,6.888386465911158e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,7.373582667613197e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,7.801990411189769e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,8.427383847636673e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,9.491712740699253e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0010774418083946637
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0012850859761254054
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.001554825636942072
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0018781892445502739
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.329940829237734e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.7295903298329124e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,2.2723458579068423e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,2.935968414472869e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,3.433970029880021e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,3.81197173083826e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,4.2821538914286216e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,4.6388157535712704e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,4.942822160040453e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,5.369917118204408e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,5.748798241526554e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,6.09938159889374e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,6.440083190185781e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,6.874831250417163e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,7.35435385781898e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,7.948565849744189e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,8.581411814867408e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,9.184116910001755e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.001041441940255865
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0012118122638104945
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0015119693126212945
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0018069285232286928
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.00215372109004253
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,3.1261123744422305e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,4.0693452510076405e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,4.690216958415918e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,5.461828265334536e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,5.944768377489656e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,6.429358723372114e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,6.781996489012747e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,7.18411201886681e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,7.431731548332714e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,7.690077756671546e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,7.927444677814817e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,8.295072512290952e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,8.641245854913833e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,8.92838216788262e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,9.327261586159105e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,9.714654838077093e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.001019119663946117
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0010664343059085491
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0011449877102983675
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0012778677989327759
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.001426589076899713
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0016598415231812746
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0019956765639448496
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.871136283586755e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,3.6348109190277437e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,4.165632993835776e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,4.758595907340795e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,5.212171472084748e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,5.522811505586898e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,5.790587031745827e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,6.098366139916764e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,6.351555698143801e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,6.60608605353172e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,6.924384356209885e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,7.184333009093822e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,7.465657726264357e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,7.727199510772114e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,8.034263257034157e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,8.43138825359175e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,8.914398611701842e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,9.394682903872372e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0010008672516363195
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0010762818675168393
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0012065943083253814
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0013261409928789678
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.001499955565109385
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.9299984773707622e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.560299579362844e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,3.065773040139664e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.807139759697169e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.3556269075956865e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.784850269179458e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,5.176124965539354e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,5.527573473125349e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,5.853507767842039e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,6.175653210028554e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,6.479505051794391e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,6.767839053864939e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,7.100868373779781e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,7.446644682218492e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,7.839016272698325e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,8.272277921186258e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,8.793002832802166e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,9.362371240845687e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0010245858960141823
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.001148232734455632
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0013427647193352443
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0015282157528361054
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0018003913566656913
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.584085353822427e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.16954805664765e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,2.83936101209167e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,3.658923642233075e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,4.3157993181693e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,4.886093636867546e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,5.327940221717225e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,5.857943550696099e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,6.26779432141805e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,6.747278158777956e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,7.332549079282029e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,7.892598106127247e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,8.536402786790782e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,9.207529912436999e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,9.944969714228333e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0010818642959514227
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0011635970538429647
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0012697586330121188
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0014347042888763414
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0016121323120559805
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0019008940088807288
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.00226889249512754
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0027269304666327878
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.3155236589906113e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.819998024253046e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,2.550246280679918e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,3.480404924193596e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.162517820330334e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,4.7166459918057864e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,5.305221768398068e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,5.883460645961816e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,6.429444062503254e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,7.049736967470767e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,7.760607764528641e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,8.470141380685853e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,9.226931657052224e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001017126715061687
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0011138094191791093
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.00123645346854593
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0013596558015259008
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.001487533656827359
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.001727808172911007
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.001993252049437716
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0024556959080208017
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.00293374963861638
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0033801002698444892
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,4.961617128591153e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,5.994857098371038e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,6.556724427348072e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,7.297748748329882e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,7.720382099336107e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,8.155438595137147e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,8.405684671255721e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,8.739953766638697e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,8.905871115434573e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,9.10429893091808e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,9.308979421990927e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,9.619067909113056e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,9.908305781179325e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0010103507922868996
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0010504391584106765
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.001085001648789623
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0011300907476129165
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0011776811409526054
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0012588312083484268
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0013970421444971673
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0015580350045590796
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0017957407826676003
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0021432562831643753
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,4.922078040858118e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,5.664111644492877e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,6.249602042249923e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.753514151223053e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,7.255965569562483e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.702456682055592e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,8.124090702488859e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,8.485258947466506e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,8.857173444694442e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,9.252861410506394e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,9.586660836219459e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,9.936073787912636e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.001030968159566538
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0010660864332753262
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0011015034442703705
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0011390292660380013
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0011808797770078237
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0012259326951046898
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0012867537453670576
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.001382030535027503
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0015117964829450138
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0016728608363935293
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.001843251147792328
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,3.240268678438008e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,3.8991238372740637e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,4.5624556352341335e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,5.383384320612922e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,5.978142440687691e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,6.503440966913706e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,7.017730176313956e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,7.548615542724297e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,8.038093582162642e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,8.523810266247635e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,9.005677129742188e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,9.500448131443098e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0010034822298735516
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0010586653279078511
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0011173217140078302
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0011840313609823103
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0012629133586045482
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0013593610374336206
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0014819722754407564
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0016496193297907398
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.001992053460290625
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0023158187553821053
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002735920156392971
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.302524550134998e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,4.007515155622951e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,4.891744165805385e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,5.931614159159329e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,6.735237845175881e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,7.402311972855952e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,7.939869922506102e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,8.568616422197973e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,9.051718621609316e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,9.582163352525848e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0010188782293805232
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0010837701210080612
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001157767712007049
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0012325704277365347
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0013105905930389694
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0014046073798191622
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.001493869452248821
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001610569779819703
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0017853143082056135
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0019732163660003063
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0022604521844139577
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0026299506379175498
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.00306456561032932
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.796824760475981e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.504652055513927e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.5145749192814996e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,5.697058490834175e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,6.564643365347591e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,7.26550403988293e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,7.973006566797251e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,8.665497042651416e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,9.318052743287821e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,9.991534084490576e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0010837231728232492
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0011615691939145223
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0012447746984090512
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0013465497733615066
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0014509992373982123
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0015763189603231185
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0017055921425634991
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.001833088698779892
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.002074403748304014
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0023398493042183642
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.002801701131579829
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003234864148153379
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.003640486411172014
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,6.129911120718631e-4
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,7.454285011109492e-4
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,8.357182144213892e-4
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,9.533879795827507e-4
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0010274149247121536
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0010931519844036765
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.001141676037077057
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0011956358460824127
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001231095628311047
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0012698254657998243
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001303930234718351
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0013511922578938013
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0013949377740193171
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0014360496896985533
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0014873844303265387
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0015414286975197371
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0016042809649834072
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0016689418138739261
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0017727684010029187
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.001932487420110111
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002128535725130837
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0024120735863473993
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0028153464094106033
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,9.190092134726069e-5
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,1.1760962770196936e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,1.7965268799566606e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,2.0279637022051322e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,2.65039792146339e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,2.77949340144622e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,3.2419986231590304e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,3.789510600317434e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,3.963916633209295e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,4.5502715513317903e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,4.887705478298183e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,5.102923194993947e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,5.794214292908788e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,6.104442868759988e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,6.599914320353118e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,7.177304578096771e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,7.765381328484907e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,8.634245071853152e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,9.489541206502598e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0010777487881029532
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0012892606317259584
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.001468685562516784
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0017066553184372389
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.788861745034044e-5
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,3.380342131385299e-5
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,5.398277433550898e-5
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,1.1539160956333661e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,1.2628953788103645e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,1.7762623581841483e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,1.833495276355248e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,1.884173722077552e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,2.5903939023194325e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,2.7474284827753884e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,2.896728009814125e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,3.6394159162309926e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,3.8849126544951266e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,4.293843988842172e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,4.928660923150913e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,5.481969741178428e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,6.196978657913076e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,7.102643228720381e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,8.070131007325729e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,9.73110767261178e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0012556896536988177
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0016107814137558641
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0019493768403311081
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.1874828196896452e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,1.623767552189006e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,2.0333502131086683e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,2.470789398087702e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,2.9424741726024554e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,3.237595854471435e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,3.493361535838953e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,3.755883035835672e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,3.994308056676706e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,4.2735821369044346e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,4.4863962829461834e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,4.7291460834157325e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,4.949862397070017e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,5.195812739395212e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,5.513894591692033e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,5.885921436795149e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,6.243293859194485e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,6.771542183494681e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,7.479413075351013e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,8.497783231369864e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.00103934748426177
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.00123567368176541
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0015209863061699017
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.1608675548252054e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.4573693146095775e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,1.8437972265296913e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,2.376734508985569e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,2.7826266849072235e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,3.094147765521567e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,3.457637837320925e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,3.7422534663616124e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,3.958639287722312e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,4.2456719692268805e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,4.551175607922991e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,4.8134998828369674e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,5.071428647879969e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,5.377131625571353e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,5.739175927535331e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,6.148645961041871e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,6.633519858498763e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,7.105660245628648e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,7.880424643283382e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,9.159404704776607e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0011210763224007937
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.001361916578835271
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.001668792698891966
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.001148610674793605
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0013415431902199279
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0014548717654511466
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0015915457445054315
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0016748565393113466
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0017592899049981082
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.001816824770549016
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0018830525616269165
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0019278791078916337
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.001970142600801349
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0020136497151779452
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0020720273352489373
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.002130088787858389
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0021764670593906643
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0022435040420008164
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.002307425577742614
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.002389127463065665
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002474847653478634
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0026064042421983812
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0028320648175044227
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0031011608070154436
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.003478894798936518
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0040152768430537725
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.834235536498544e-4
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.801368836805142e-4
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.927950307147483e-4
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.001127551555555944
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0012187919395247751
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.001296461530638772
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0013570891883980208
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0014216912620537963
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.001470929451395121
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0015118381419010874
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0015559849432425156
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.001611941064482439
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.001658322193974516
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0017028508382404804
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.001761563019822596
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0018218466831979182
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0018912918216444545
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0019694194274634453
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0020829382842732103
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.002243746900322654
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0024865412041547045
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0027643585538179513
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0031179673129812574
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.379373624815561e-4
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.39488962829327e-4
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,7.355871929666114e-4
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,8.610009927684141e-4
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,9.6488075399613e-4
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0010463843735379872
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.001114802142395629
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.001176734638039887
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0012454080398779522
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0013117934313141974
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0013801289596082063
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0014479199724575817
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0015141870145980443
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.001604482822420956
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0017032506991908197
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0018109253634936617
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0019517097996687822
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0021112218174314575
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0022732327128083376
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.00252573788150746
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0030598412184263913
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0035802829233566183
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.004293311345085074
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.851809720626359e-4
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.94450128292803e-4
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,8.181799947196532e-4
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,9.612171269249675e-4
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.0010677467581494523
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0011522820271234547
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.001222791278695666
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0012935318109252236
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0013538026028081652
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0014219794889389374
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.001495671367405865
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0015746851296472718
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0016500619911084988
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0017325237296710314
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0018312229940028962
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0019392972515410605
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.002045525097538586
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0021960904952362664
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.002405416755121976
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.00266918585979324
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.003088179936260101
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.003575942837295621
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.004191300169779694
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.957311216191045e-4
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,6.036471218373006e-4
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,7.329092141138513e-4
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,8.901871954887079e-4
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.0010002177328325439
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0010923220233135956
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0011853181012697288
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0012715682252336569
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0013465422139223992
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0014238993250377148
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0015140643628019073
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0016012087000210214
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.001693854944905677
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0017999569724714967
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0019166400153920495
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0020659511901188893
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0022260875283409043
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.002385353215650799
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.002643598317936724
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0029751645043681954
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0035378696303798515
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.004125267327105935
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004701743556885537
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0016274695080013698
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.001884542448672377
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.002107234477482942
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.002383808580909211
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.00256900003383318
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0027202152126876624
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0028565652329462054
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.002989193500144015
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.003083898145459517
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0031875476883778497
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0032629955625068075
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.003375368325938238
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0034742747049700882
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.003585787732756854
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0036814787563242985
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0037989095029777324
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.003920020666510778
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.004032222919798593
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.004212335953590576
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.004446662682739145
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.004707707719521125
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0051342613668085004
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.00567904835860802
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,5.264075826750617e-4
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,5.991930716847812e-4
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,7.428270054150908e-4
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,8.98670226448618e-4
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.001029017512386557
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.001138403195963202
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0011833778137591618
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0012717064211524272
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.001307823433659941
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.001384195769425444
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0014338061401504302
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.001516838562605385
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0016041907509196803
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0016501654958370326
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0017539262411946587
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.001825002041044044
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0019015390236354636
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0019885477112278564
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.002109099183945299
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.002313619258998514
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0026187312510807907
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002948936115172807
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0034370524011734646
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,3.801988177203122e-4
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,4.4841129852545036e-4
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,5.973861054708061e-4
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,7.317890746245249e-4
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,8.462967841093457e-4
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,8.992625545104363e-4
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,9.881183124029979e-4
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.001077145641465918
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0011224183546313664
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0012065604449585693
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0012939569532292676
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0013738453465065661
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0014440158746539923
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0015507110629859196
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0016368027116192385
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0017158247640709679
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.001859315716286003
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0020470566717263597
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.002243503781077059
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0026349986276044362
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.003198221730138104
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0037723630046260846
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.004937600889240204
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.290900433093024e-4
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.357830822188893e-4
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,7.428285746531888e-4
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,8.536144896294187e-4
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,9.675635472375619e-4
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0010462855909716224
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0011044088203116553
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0011686804854904496
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0012160264885853899
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0012742448760393447
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0013280271435268287
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0013911427253695638
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0014422640635503917
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0014979814916650878
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0015739140217534222
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.001664604809782099
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0017528787957871643
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0018761003319002372
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0020562950984359014
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002278917568013793
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0026745045835886274
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.003138267706841637
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0037367355388147126
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.139625756856707e-4
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.24412587694426e-4
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.44853087462214e-4
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,7.878736390912312e-4
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,8.834449884941413e-4
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,9.638310395375883e-4
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0010462216785555865
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0011085158060940804
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001166513488385007
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0012393810759874372
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0013182658311069976
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.001384360485189712
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0014555278854374277
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0015425374897689533
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0016290847397967176
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0017410342534310474
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0018644216907716584
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0019853755445966527
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0022012660097180843
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002502927054454856
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.003004649354137426
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0035388450705642165
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004096682591909222
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0011025151111144311
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0012869585097520576
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0014054845933434582
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.001560514792744516
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0016555004719500752
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0017376676027912657
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0017979247401348874
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0018652184029096944
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0019081167878131436
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0019550265579939734
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0019977146956560903
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0020546761562142907
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.002107380608488488
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0021573746213431224
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.002218934696396792
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.002285125673207695
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0023598542603874397
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002436533951295866
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0025588570345296334
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002748284023739684
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0029804706042955795
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0033107073378602697
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0037852730236225124
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,0.0010212358489062807
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,0.0011386262099522934
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,0.0012318454436644566
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.001365582235225495
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.001448184242447363
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.001510970453937977
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.001565857506293365
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0016192122461805845
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.001664743175559712
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0017095605817435719
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0017541929264718007
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.001802108555633707
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0018433745872079603
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0019009818464450982
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0019549098689881084
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0020092404790288234
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0020727893018060613
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0021454562762281467
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0022437159290179176
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0023569816492502883
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0025496905010407734
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002775677718507453
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.003011977418402639
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.888526958191262e-4
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,7.062375031103397e-4
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,8.141206861558006e-4
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.606278929917233e-4
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.001082602886433048
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0011778181932277346
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.001284129465642899
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0013777507071199534
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0014694627787278035
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0015644978288334053
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0016515369537547973
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0017394681719383402
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0018397706751779382
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0019403244190865712
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0020455846041533424
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.002152208777705975
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0022918813694235134
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0024593572355904245
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0026566317975162783
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0029278201779062664
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.003452361599594931
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0040006955608364965
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.004897972032725867
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,6.145702452112212e-4
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,7.297117872017349e-4
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,8.491837635616259e-4
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,9.918085255256875e-4
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.0011058720980590367
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.001195212024186008
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0012664007021389815
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0013443181940828311
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0014040010090205848
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.001475645017397858
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.001550677321306862
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0016303054471138887
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0017175882594956879
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0018065663898600244
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0019073776219669812
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0020237627892462327
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0021445513078054506
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0022848131602418195
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0024986726391011726
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0027355975735159
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.003127858338917465
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.003564337857945563
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0041183002990875005
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,5.544490449520131e-4
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,6.549530333288557e-4
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,7.915952785822482e-4
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,9.451972805077965e-4
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.001060189995719812
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0011492498669278285
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0012457529032204526
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.001330199699677818
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0014110194999514053
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0014964232307027475
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001596800618900573
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0016886953488369028
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0017869489910140683
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0019098813657136985
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0020365514623766224
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.002187252277735316
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0023494546448206304
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0025011452498607755
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0027840742326640487
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0031248504316682846
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0036892016033560028
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.004246665136997204
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004757097206926087
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,9.091132998270511e-4
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0010667316254088358
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0011700156440376567
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.001298244003343842
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0013784003272445428
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0014515432724495109
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0015070034008099358
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0015670661655393242
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0016077524932276881
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.001648962849906481
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0016866883927731619
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0017380551252223723
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0017868207936741832
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0018320240811507075
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0018855176410366506
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.001942248155119712
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.002008236355194976
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.00207505305393412
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.002179162805457924
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0023452163789667185
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002542324522659645
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0028271024202533445
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.003227706835849682
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.221613484240712e-4
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.434486860167543e-4
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.318881326524894e-4
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0010450622143418336
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0011117979075288456
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0011728578160406678
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0012133996218868443
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0012598752596760154
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0012926467555080506
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.001322797567305948
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0013558775032588525
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0013982684613852714
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0014362816759694486
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.001472345030941678
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0015213045901851798
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0015668976665637801
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0016220434435595293
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0016689727484160604
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001730014195508417
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0018534771254315528
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002062832378762675
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002293120408057998
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0025029226979066893
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.622722893216202e-4
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.694754218425378e-4
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,7.975081914184681e-4
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.067219948885393e-4
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,9.91313437361042e-4
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.001053663495779845
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0011024601351050144
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0011478394846255102
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0011952182053340873
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0012352898606900922
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.001287629747995531
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0013351285548916095
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0013849450074391676
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0014511811948060898
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0015241456000325481
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.001594200307682323
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0016916952265550295
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0018030786139678818
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0019164059077646821
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.002082540261723506
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0023632769066672553
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.00267543588925494
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002990596874904003
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,4.3317562485477204e-4
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,5.1778101228556e-4
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,6.104489538464421e-4
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,7.213666745373999e-4
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,8.143894574230519e-4
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.906181919166035e-4
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,9.519797351886433e-4
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0010123568146328122
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0010632006478262887
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.001119644188314714
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0011798478631723966
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0012438465318589562
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001309312892133329
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0013817429746518922
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.00146040851710598
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0015562070237150002
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0016478400972503582
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0017659785825372507
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0019386082230965697
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0021467618836005535
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.002468742466142639
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0028539022078787482
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0033090524076926546
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.62476853332108e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,4.371071687399762e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,5.468216833400644e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,6.751385497690905e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,7.731836488658886e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,8.452327188177628e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,9.210275880130302e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,9.930851633388855e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0010549855324189247
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0011242263604214894
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0012022127657038337
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0012770412167249358
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0013539914141495284
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0014473001096156864
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0015460322380491391
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0016653479292856503
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0017907726877226956
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0019141907748691494
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0021342962777251458
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0024188789201832054
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.002900001226580758
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003358820086478472
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0038511583830729227
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,6.127669391436317e-4
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,7.734871478580544e-4
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,8.919624824498799e-4
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0010420347713450107
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0011405612561845519
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0012254581161573685
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.001300571315449522
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0013762620839780735
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001429241127599841
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0014830286906165654
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0015293172928503062
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0015930525676406345
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.001652672487863444
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0017159713865912665
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0017735619418847498
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0018443853146337796
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.001918370328216937
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001988512931293272
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0020978088848680183
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0022671271404007495
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0024590894122310607
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002763816817087515
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0031983446719773974
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,3.7293573896876044e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,4.6608638948822704e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,5.447538949458983e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.381211062519319e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,6.960437021625097e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.51584217659784e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,7.907789879837324e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,8.322059433305913e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,8.749430848705752e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,9.220087713840688e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,9.650036267854786e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.001011687429401987
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0010588012048139846
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0011131882615744012
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0011642114066144386
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0012214896686782196
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.001287264555335733
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.001357901735876625
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0014394174357474183
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.001545767248992347
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0017085686462455871
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0019120996960074036
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0022372314955816483
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.555733044913137e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,3.3050102518932163e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,4.173185550287214e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,5.119934759323288e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,5.880107394197656e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,6.516098293143926e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,7.084761114492003e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,7.658367084946585e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,8.17488336235157e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,8.726924202606133e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,9.28751265942046e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,9.8482327207124e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.001052292047445992
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0011137212901649303
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0011847750007832679
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0012649048842605236
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.00134587664870465
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0014543500471383521
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0015826655014250166
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0017667792959990816
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0021813428303569518
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0025748807091293294
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.00312704557953822
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.1204061428486964e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.8343415734845056e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.63557516950416e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,4.4953161952223915e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,5.223651989464443e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,5.769255672332782e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,6.212899994381756e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,6.694310696954756e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,7.095221713010504e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,7.525644951601354e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,7.97536550580192e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.00084850047053583455
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,8.985271076764772e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,9.498939293475612e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0010146959651888233
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0010896173924109364
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0011604959511622094
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001258946480858753
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0014078165591166918
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0015855155872973464
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0019029519855897912
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.002271516758941787
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0027101167114613267
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.8277974456422169e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.4035935192251085e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,3.1862404219638776e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,4.158497873859747e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.878633478294282e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,5.437456781234824e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,6.038363547321748e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,6.546179360415411e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,7.007881938891441e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,7.561191371190281e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,8.145781325551067e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,8.69157029046896e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,9.318545653363052e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001003513198777472
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0010813339925547583
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0011782458026737379
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0012836880727435116
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0013851509117683149
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.001576264338577845
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.001823051026597257
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0022553354531049024
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0027077331572142715
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0031743115327502397
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.00047168109872671485
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,5.974394475780028e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,6.630289283214405e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,7.448984226435719e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,7.917843353131118e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,8.437839785248069e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,8.763049458445093e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,9.17755875828576e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,9.404879024314821e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,9.624755544374959e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,9.885929240353469e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.001026030592942858
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0010633335373955895
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0010889612582625431
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0011347575987588306
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0011759651989066647
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.001229314487916143
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0012844512201472505
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.001374448170691356
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.001544237062189337
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0017370997635979201
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002028354501866855
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0024704419792873846
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.1682989388905916e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.567988288365732e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,3.8567078922665545e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,4.4489180229560473e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,5.680440509622563e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,6.090542069643361e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,6.476831080743399e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,7.527911667943427e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,7.889524743865497e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,8.239515546590047e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,9.234424607955558e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,9.582560813453546e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,9.988737832020388e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0010937108080779575
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0011400739998295103
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0012339457960162774
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0013014120071727728
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0014153587767327057
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0015569419111421783
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0017235846435971394
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.001985882119535864
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0021941673866054164
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0025312556320182854
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.8821775391055648e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.2247799729871548e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.719116984883512e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.2677802854684144e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.5843794724838413e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.908562045542778e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,5.226742643540117e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,6.293492972519846e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,6.673639473584478e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,6.99301310666869e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,7.33303968019074e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,8.367184924979367e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,8.738638563724974e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,9.202584578258361e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.001028293878505098
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0010884038040506203
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0011940445808870416
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0013163547236798257
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0014603677999406972
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0016398890589509742
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.002028847136025083
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0023812738265574203
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.003140706137786232
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.154689320454808e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,3.946701933956901e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,4.94802739954471e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,6.127423144999661e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,7.059486899154016e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,7.818226697317366e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,8.442061291545507e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,9.092035281392523e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,9.687113227421338e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0010312643095232803
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0011032018236292649
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0011808226169906265
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0012660570571914015
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0013535915574396664
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0014571512602229906
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0015611707706375609
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0016666977711863274
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0018044390911644607
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.002044084351694339
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002278460495793456
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0026649564024328314
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0031169558672886864
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0036329707088051857
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.939046759005e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.610954692945868e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.7011315998458946e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,5.94337916013418e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,6.881709736720025e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,7.646992577239292e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,8.418789475558321e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,9.28339574688589e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001001286465023
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.001072532938882932
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.00116157010072178
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.001242731505416975
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0013425299524354225
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001457781818451887
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0015814569237701686
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.001726924045158884
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0018767464525846422
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.002044282201294562
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0023326237437358427
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002637943739545735
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0032096150658166905
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003752580686153373
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004268436627997209
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.001056858976859767
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0012356801845042628
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0013303563140011484
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0014453786990109684
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0015126637055051712
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.001588374833393474
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0016315808171525443
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0016874295348839148
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001722277692144831
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0017557233391430538
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0017932486792532015
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.001845529645255026
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0018982123082984027
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.001932339303679308
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.002000797330772381
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0020577727045545118
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0021380693762072926
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0022252660233307094
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0023626685606211216
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0026054514953292728
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002895783436376574
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.003300753287670086
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0038789501223250333
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,0.0010179422586236774
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,0.0011318387404198045
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,0.001237324204909664
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0013689209580228174
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0014419496784007174
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0014999033493261428
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0015678032312157965
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0016256157815183229
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0016893671022868578
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0017447912742115036
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0018008973524212073
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0018527202342080544
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0019012691422805776
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0019542583718246864
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.002013983359166727
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.002075095652746501
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0021428083097594463
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0022246998263014883
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0023263497876993833
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.002482590728683903
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002711219258440219
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0029538113604433793
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0032071223828807533
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,6.726325916744233e-4
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,7.89373473879042e-4
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,9.154824950792721e-4
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,0.0010633351660550533
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0011799194407766766
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0012761426771564423
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0013629147572095405
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0014433073089175344
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0015233733813303095
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.001597526421278155
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0016774549197875795
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0017610055128586559
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0018414672786357528
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0019340042132023451
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.002032926761555829
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0021423738061598025
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0022821492913923285
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0024471395276549623
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0026616611745693187
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.002964199363971004
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.003595334229346524
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.004139854065359522
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.004813183562770874
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,6.441412422821792e-4
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,7.615088965929352e-4
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,9.088740770028065e-4
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,0.0010815487552688998
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.0012107129878018844
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0013153108254262563
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0013984855813893898
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0014854677181939955
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0015620676935811121
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0016441332450307699
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0017365835712928688
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0018377782024542539
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0019380374192156092
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.002040053175342241
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0021576536723951754
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0022956195752658727
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0024285928363494743
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.002599216452993436
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0028580663468341684
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0031575306122077805
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.003642157672524048
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.004192753984746611
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0048672815108987
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,5.573921165093529e-4
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,6.805965822197716e-4
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,8.394717980985893e-4
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,0.001015836554660999
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.0011477655653787647
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0012548945609197203
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0013602047714900709
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0014615452139228762
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001557614236611036
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0016558102626449732
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0017669187838082483
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0018796580431890632
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0020010555382413754
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0021420412618428555
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.002290733515351951
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.002470683224794913
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0026611005320826154
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.002865689320259545
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.003197350610475885
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0035908970093703604
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.004267005552993704
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0049606046995592824
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.005574104194444697
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,4.886519462401743e-4
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,6.117386386595024e-4
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,6.961734756345744e-4
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,8.059553075928135e-4
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,8.75201826869623e-4
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,9.372462645219468e-4
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,9.848115994357271e-4
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0010371271930542994
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001070437698821438
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0011067606606887845
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0011387063174983084
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0011844141863062284
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0012264994397175983
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0012664090416917334
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0013141643344036407
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0013655585435342205
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0014238277802604761
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0014819771490137826
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0015769870739839376
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0017261930490494433
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0019021179189318697
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0021685341777533435
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0025523813626130427
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,5.088673660493548e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,5.706941506208926e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,6.199332087825044e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.901746213480075e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,7.411837501010413e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.817987633933537e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,8.146027072974798e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,8.434128823488871e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,8.702375729852385e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,9.001470164529699e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,9.361739268194659e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,9.754404532515999e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0010139795601685174
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0010530168186581304
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0010948048683944189
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.001144750106624694
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0011950256270045717
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0012546121067942384
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0013293887823530694
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0014259366370178007
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0015817505868936598
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0017308681595735293
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.001877784194477404
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.930750159680965e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,0.00034692054600987947
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,4.0565659643352535e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,4.930970414326666e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,5.531175439890546e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,6.051425083352538e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,6.519523761859558e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,6.991483802531152e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,7.432526660345703e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,7.877248391595343e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,8.327469209015543e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,8.827880893278018e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,9.323765490587582e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,9.830360160896067e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0010424294242270219
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0011076995443472168
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.00117498599478739
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0012593154077131814
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.001373411326330761
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0015183941407661391
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0017715519972081304
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0020118784842333985
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0023578382135148275
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.127780081936583e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,3.9280407447086666e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,4.85097929053398e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,6.066944096807443e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,6.963516524455214e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.00077577455241514175
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,8.390547092075807e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,9.071782881012499e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,9.597832140943602e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0010214737046371108
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0010970206193828681
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0011676424775462217
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0012545668714714375
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0013429468202734137
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0014347154982951946
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0015431213085140005
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0016513643196985712
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0017796119926459454
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0019855811996176455
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.00219521241094975
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0025522203756140217
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0029737281361613436
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003440306457065132
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.823917127639365e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.5285746079457533e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.570239068168154e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,5.742482556743433e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,6.695799105051675e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,7.482353940424055e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,8.240193916175431e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,9.024705887370138e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,9.793441733730558e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0010581387372870115
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0011518812954437142
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0012419485716949766
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0013443402701577645
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001463925002240954
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0015883696730806455
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0017395211231608235
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0018963645673199347
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0020499447066233936
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0023360126147192193
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0026551956973773147
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0032263905210943907
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0037511463392394294
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0041886196008361345
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,5.786295089572857e-4
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,7.206371849971017e-4
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,7.890981616794432e-4
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,8.81571398295452e-4
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,9.324147487719921e-4
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,9.870647416150632e-4
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0010162892032377707
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.001057960247896953
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001078001864359651
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0011003840969277523
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001128264794412673
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0011664235934697171
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0012040112677931731
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0012273917304566461
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0012805483469234922
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0013262345464846613
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0013866665733685607
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0014524519680414259
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0015618431372368844
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.001760774395360637
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0019995685299850114
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002346247450574469
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0028777163309776977
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,3.5345268519366144e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,4.495164709395384e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,5.319466088325372e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.374432181606921e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,7.037195846123609e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.6715638181915e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,8.162693022053529e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,8.651978605423374e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,9.006617292796884e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,9.404465623368344e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,9.825724594422344e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0010261278433918294
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.001073184133569176
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.001122622754252707
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0011718708853390384
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0012308040332618295
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0012941424453130155
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0013640591085666391
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0014758329628390473
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.001606051670220967
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0018432093433186007
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0020713056443332823
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0025023860875103623
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.0222688168557824e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.742731929221336e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,3.6531595209616857e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,4.618231368918557e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,5.392561512514024e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,5.963650814172662e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,6.47854598944747e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,6.976449223535862e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,7.492464983126235e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,7.985689540670011e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,8.583059160441595e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,9.168103511639754e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,9.80844030899609e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0010625366678124993
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0011521414746377802
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0012457730381779672
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0013655149063681047
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0015104625412112054
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0016936954619607239
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0019203011355194933
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.002378482875406527
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0031243318115417415
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.003878282275488733
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.457600628955714e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,4.2743412191560383e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.27786244011343e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,6.349818207817586e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,7.3045989139902e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.020892312578609e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,8.559853762330862e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,9.180246651686914e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,9.661550579758644e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0010212962461610931
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0010827860719688593
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0011465664181579838
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001212643133540314
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.001284105373415229
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0013685230413629894
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0014605993477189213
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0015502439386935844
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001672680396742566
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0018672948861495346
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0020832412502451766
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.00243239848096667
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.002910495088873883
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0034577898134407446
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.088398320672062e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.8439449599725925e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.929350235691948e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,6.183660540691762e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,7.081407923455988e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,7.763183608504355e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,8.521789063570288e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,9.23551580309941e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,9.88117532024762e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0010568595128648956
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0011393340044373213
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0012172037386769992
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0012980092130438028
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0013955408718701167
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0014988206690897147
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.001633820569048509
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0017709680762075983
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0018977989401488728
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0021508641941045607
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0024683692092705776
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0030430991056596647
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003603882551266064
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004167854514523281
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,4.531620128934996e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,5.737718571143092e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,6.4348280392359e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,7.364912648800631e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,7.90638021735656e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,8.430749283818246e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,8.781191152940752e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,9.215409263749585e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,9.428942975282517e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,9.682928308175687e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,9.93533775737522e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0010321307099802222
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.001067404281131965
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0010951614776000256
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0011399109508601463
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0011831424534999488
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0012339919815592757
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001284789318497117
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.00137345057077241
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0015260440242998875
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0016973316751713048
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.001966044174571309
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0023720242027836253
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.3327303460413373e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.9397548001307977e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,3.412885704625847e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,3.981404580935586e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,4.3287537158429306e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,4.659377789771485e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,4.8810005889707666e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,5.119196565010094e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,5.293911177989114e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,5.460069541758175e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,5.681648472774959e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,5.926571976550487e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,6.150890210470191e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,6.351308577008943e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,6.650373414597017e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,6.893164028713571e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,7.199306953750926e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,7.538455394230431e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,8.076413186834448e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,8.894179649494845e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.001011845813419898
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.001159274774517736
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0013960069011478078
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.2886757494944356e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,1.734730475021957e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.3428211641073293e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,2.836292512188053e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,3.2453940557577163e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,3.541710855143757e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,3.759231317601754e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,3.9447386725572633e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,4.1715043216590823e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,4.372189530003939e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,4.6280173878025305e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,4.8741399830491943e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,5.122435318382307e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,5.461684996940512e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,5.840419258391668e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,6.213153297914964e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,6.737935536009231e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,7.364779725167034e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,7.978083888465567e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,8.844254214227857e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0010889558377033003
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0012915590857175037
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.001525264389798709
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.0089141250000152e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.6407264612807104e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.288346175909366e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,4.007224654985935e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,4.679606430514206e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,5.154614115043244e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,5.549678614892279e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,5.944170157859051e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,6.214790041095067e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,6.569881200679736e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,6.934612658915979e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,7.356088293556644e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,7.771715969003162e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,8.179016282751877e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,8.685656637388937e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,9.340673761781573e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,9.88633750426667e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001067127962337125
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0011930120378215768
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.001349853942155386
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0015934559416447354
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.001918626393768688
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0022953022476334033
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.706009540025081e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.242618718159859e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,3.0481225029048724e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,3.877103192114892e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.5456424642059256e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,5.028384096245233e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,5.564340275689846e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,6.036474606855517e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,6.448619175563338e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,6.921169230382706e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,7.446053608193819e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,7.941720990630881e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,8.471022800498534e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,9.093521441736768e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,9.774689291659634e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0010630304297203131
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.001151481420050843
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0012289538610404421
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0013922048514128245
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0016056654646815862
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0019886115259756297
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0023655844728851716
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0027561698186402937
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,8.166326605998933e-4
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,9.622768425067045e-4
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0010474311822040632
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.00115586017596162
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0012203914633222134
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0012814899793007536
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0013239571026615574
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0013734002125102437
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0014030063695577217
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0014339328859694187
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0014648482817128242
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0015073862111484972
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.001547820464493157
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0015817705513505242
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0016295131015743175
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0016773488680303988
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0017340054446192924
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001791906234000518
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0018850232276072878
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002041900239879728
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0022253427537515633
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002492192862643852
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0028811991598419124
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.904893618769612e-4
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.627119176535011e-4
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.14251790947239e-4
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,9.782560458835266e-4
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0010176762939242332
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.001052960415547966
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0010768344750488761
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0011033269863605028
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0011220274389339203
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0011391088611047507
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.00116250817014572
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0011870832383288055
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.00120930717796142
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0012310642463844693
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0012582468673792383
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0012846121581742457
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0013150990200779247
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0013471925538181002
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0013961813600991471
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0014763086745357339
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0015841216240781103
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0017214830862544812
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0019300329411595458
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.308498552209276e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.03684835769891e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,6.634881756769999e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,7.25234569632304e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,7.857881766028729e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,8.368317531828118e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,8.858085030244566e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,9.323965126172894e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,9.729548004975328e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0010102162031776548
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.001049088726897459
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.001082638329308216
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0011180046873014106
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0011643818859751317
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0012128526733918583
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.00126244854478663
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0013280217644611246
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0014005022890184052
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0014785438023217183
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0015903900289323154
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0018163865172838142
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0020141586489217083
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0022682339983517716
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,4.192072895584614e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,5.039068398652465e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.966592247034247e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,7.048318514879442e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,7.947414693417085e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.634332672917994e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,9.179580401207527e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,9.724113870257845e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0010210566998545604
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0010735931101406226
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0011320014934089978
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0011949151227041448
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0012532913968982787
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0013119988823063246
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0013847009254813372
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0014669909294640275
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0015488856701228184
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0016585640319312183
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0018178426517976498
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002003545369225406
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0022944757278077054
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.00265503491519842
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0030647145745806145
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.656321929535498e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,4.448825288650784e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,5.531538486256622e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,6.741232432322442e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,7.666139557073123e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,8.344442484524314e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,9.06901193627186e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,9.724131993223573e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0010308857064478339
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.001094597634884611
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0011667038276401706
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.001235127798015343
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.001304668279683916
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0013938565175260044
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0014882017005768528
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0015973176655972193
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0017164783518884852
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0018272879596921037
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0020342479582388328
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0022819896131992413
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0027132668510685574
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0031644041670821793
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0035562751094977826


### PR DESCRIPTION
This PR is a manually generated ensemble addition (since GHA hasn't been cooperating). Generated with `hubhelpr::generate_hub_ensemble(".", "2026-05-09", "covid")`.