### PR TITLE
Add Ensemble Forecast For Reference Date 2026-05-09

### DIFF
--- a/auxiliary-data/weekly-model-submissions/2026-05-09-models-submitted-to-hub.csv
+++ b/auxiliary-data/weekly-model-submissions/2026-05-09-models-submitted-to-hub.csv
@@ -1,0 +1,19 @@
+model_id,target,designated
+CADPH-CovidCAT_Ensemble,wk inc covid hosp,TRUE
+CEPH-Rtrend_covid,wk inc covid hosp,TRUE
+CFA_Pyrenew-Pyrenew_H_COVID,wk inc covid hosp,FALSE
+CFA_Pyrenew-Pyrenew_HE_COVID,wk inc covid hosp,TRUE
+CFA-EpiAutoGP,wk inc covid hosp,TRUE
+CMU-TimeSeries,wk inc covid hosp,TRUE
+CovidHub-baseline,wk inc covid hosp,FALSE
+Google_SAI-Ensemble,wk inc covid hosp,TRUE
+OHT_JHU-nbxd,wk inc covid hosp,TRUE
+UGA_flucast-INFLAenza,wk inc covid hosp,TRUE
+UM-DeepOutbreak,wk inc covid hosp,TRUE
+UMass-ar6_pooled,wk inc covid hosp,TRUE
+UMass-gbqr,wk inc covid hosp,TRUE
+CFA_Pyrenew-Pyrenew_E_COVID,wk inc covid prop ed visits,TRUE
+CFA_Pyrenew-Pyrenew_HE_COVID,wk inc covid prop ed visits,FALSE
+CMU-TimeSeries,wk inc covid prop ed visits,TRUE
+CovidHub-baseline,wk inc covid prop ed visits,FALSE
+UGA_flucast-INFLAenza,wk inc covid prop ed visits,TRUE

--- a/model-output/CovidHub-ensemble/2026-05-09-CovidHub-ensemble.csv
+++ b/model-output/CovidHub-ensemble/2026-05-09-CovidHub-ensemble.csv
@@ -1,0 +1,11892 @@
+reference_date,location,horizon,target,target_end_date,output_type,output_type_id,value
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.01,30.874174
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.025,34.033418
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.05,36.655942
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.1,39.22895
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.15,41.443611
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.2,43.21004
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.25,44.578842
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.3,46.008517
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.35,47.274125
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.4,48.487728
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.45,49.957241
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.5,51.072509
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.55,52.275427
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.6,53.411433
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.65,54.752498
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.7,56.005823
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.75,57.563275
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.8,59.402838
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.85,61.778983
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.9,64.767001
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.95,69.77637
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.975,73.246445
+2026-05-09,01,-1,wk inc covid hosp,2026-05-02,quantile,0.99,80.365481
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.01,18.52415931936207
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.025,21.65960728954519
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.05,25.11924209609884
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.1,29.511559587614364
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.15,32.765223649961406
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.2,34.7827966660104
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.25,36.31607380669366
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.3,37.98822115222934
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.35,39.417440549960276
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.4,40.87680655424222
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.45,43.48969725210341
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.5,45.880262818047754
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.55,47.20947402794506
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.6,50.49555981682724
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.65,51.85620225467326
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.7,53.3611558390913
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.75,55.14399006600938
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.8,57.58331336503707
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.85,59.7031888828144
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.9,63.46670479587009
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.95,68.2673845718912
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.975,74.3054412111687
+2026-05-09,01,0,wk inc covid hosp,2026-05-09,quantile,0.99,86.86128508216278
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.01,12.066237474740657
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.025,15.182831836726578
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.05,19.40816699086818
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.1,24.568200116173415
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.15,28.126109664501442
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.2,31.415438
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.25,33.484210000000004
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.3,36.036962
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.35,37.763200999999995
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.4,40
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.45,42
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.5,43
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.55,44.5
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.6,46
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.65,48
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.7,49.5
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.75,51.5
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.8,54
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.85,64.41528871635077
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.9,66.51694629364805
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.95,73.44123137814816
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.975,82.76146582237901
+2026-05-09,01,1,wk inc covid hosp,2026-05-16,quantile,0.99,95.9952468052796
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.01,6.888888888888889
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.025,10.72457969402808
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.05,14.79634110290994
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.1,22.15240393258088
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.15,26.479585886858445
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.2,28
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.25,31.604399
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.3,33
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.35,35
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.4,36
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.45,38
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.5,40
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.55,41
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.6,43
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.65,45.00678823641893
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.7,47
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.75,58.20173036035574
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.8,65.4774848658413
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.85,70.99
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.9,75.33
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.95,82.18
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.975,88.53
+2026-05-09,01,2,wk inc covid hosp,2026-05-23,quantile,0.99,101.90896483124409
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.01,4.888888888888889
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.025,7.704133877213147
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.05,13.265756399547113
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.1,18
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.15,20.033799
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.2,25.00979
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.25,29
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.3,31
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.35,33
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.4,35.58060051371816
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.45,41.81481090952372
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.5,43.31541551855469
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.55,44.40015709047629
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.6,50.63436748628185
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.65,53.356710390491166
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.7,59.99752464279375
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.75,63.14
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.8,66.14
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.85,69.8
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.9,74.63
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.95,82.3
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.975,89.47
+2026-05-09,01,3,wk inc covid hosp,2026-05-30,quantile,0.99,109.72829210523483
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0.53988778
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0.78331282
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.05,1.0387321
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.1,1.3147504
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.15,1.5365487
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.2,1.8078536
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.25,2.0214294
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.3,2.2227421
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.35,2.416894
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.4,2.53
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.45,2.57
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.5,2.61
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.55,2.65
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.6,2.7
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.65,2.74
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.7,2.79
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.75,2.8768002117734244
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.8,3.432715400941879
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.85,3.846454784611372
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.9,4.412994647922531
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.95,5.547352617625406
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.975,6.570813256303538
+2026-05-09,02,-1,wk inc covid hosp,2026-05-02,quantile,0.99,7.057140788226954
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.0628790216434068
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.2558533940415436
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.05,0.47749160355287695
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.1,0.9064061364162058
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.15,1
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.2,1.0924053417513584
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.25,1.3134642962853822
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.3,1.5064286945647751
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.35,1.8888888888888888
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.4,2
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.45,2
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.5,2.017018610109034
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.55,2.3822193625356034
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.6,2.564755190733921
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.65,3.0055515998442504
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.7,3.3956727976138392
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.75,3.8036064390674618
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.8,4.131022472890054
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.85,4.7286470849163535
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.9,5.224003261954088
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.95,6.474650261865598
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.975,7.23463376388742
+2026-05-09,02,0,wk inc covid hosp,2026-05-09,quantile,0.99,8
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.01,0
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.025,0.0439801648624482
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.4247287660527965
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.1,0.6337381337568625
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.15,1
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.2,1
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.25,1.0047464135554187
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.3,1.0994719387792498
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.35,1.161795536846989
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.4,2
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.45,2
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.5,2.1
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.55,2.1727392217596764
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.6,2.675
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.65,3
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.7,3
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.75,3.778562163211708
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.8,4
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.85,4.609154360122759
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.9,5.4204601658248635
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.95,7.3225764394171335
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.975,7.958802211148747
+2026-05-09,02,1,wk inc covid hosp,2026-05-16,quantile,0.99,9.004999999999995
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.09353262061427256
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.05,0.2083452345604399
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.1,0.39545085687625503
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.15,1
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.2,1
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.25,1
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.3,1
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.35,1
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.4,1.2930696028923805
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.45,1.99
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.5,2.07
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.55,2.15
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.6,2.24
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.65,3
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.7,3.480613324096076
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.75,3.796332321415501
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.8,5.242335427342531
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.85,6.222222222222222
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.9,7.0157794801426805
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.95,7.771680879133913
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.975,8.326455313954561
+2026-05-09,02,2,wk inc covid hosp,2026-05-23,quantile,0.99,10
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.059703559146676
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.1418822000782216
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.1,0.26067317226267495
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.15,0.3451133791503533
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.2,1
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.25,1
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.3,1
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.35,1
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.4,1.6030825785332332
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.45,2
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.5,2.7830800249830667
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.55,3.1902063016253734
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.6,3.430016606780036
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.65,4.161805378847429
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.7,4.542840582105597
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.75,5.09437218498284
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.8,5.6773218830356145
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.85,7
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.9,7.5733212685784554
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.95,7.857675719797015
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.975,10
+2026-05-09,02,3,wk inc covid hosp,2026-05-30,quantile,0.99,12
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.01,15.62
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.025,16.82
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.05,17.91
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.1,19.24
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.15,20.18
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.2,22.55562761237853
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.25,24.345361647611725
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.3,26.0052315932779
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.35,27.558228289804735
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.4,28.300419320624666
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.45,28.991382218687324
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.5,29.468421052631584
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.55,30.564728892423794
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.6,31.668206
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.65,32.201668
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.7,32.821406
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.75,33.455107
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.8,34.276442
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.85,35.224013
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.9,36.191398
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.95,37.888721
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.975,39.23843
+2026-05-09,04,-1,wk inc covid hosp,2026-05-02,quantile,0.99,41.257501
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.01,11.61111111111111
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.025,13.885
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.05,15.559999999999999
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.1,17.950000000000017
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.15,19.5
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.2,21.160018124939434
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.25,22.697851348288438
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.3,24.573104096077415
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.35,25.61111111111111
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.4,26.944444444444443
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.45,27.833333333333336
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.5,28.666666666666664
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.55,29.5
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.6,30.244444444444444
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.65,31.11111111111111
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.7,32.55555555555556
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.75,34.000168271934186
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.8,35.96097465975522
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.85,38.8669844966674
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.9,45.37498015809179
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.95,50.46334198133334
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.975,61.25138888888888
+2026-05-09,04,0,wk inc covid hosp,2026-05-09,quantile,0.99,66.13293577380952
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.01,8.787672700078893
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.025,12
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.05,13.75
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.1,15.71
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.15,17.721894703702382
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.2,20.31537440626801
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.25,22.055555555555557
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.3,23.22222222222222
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.35,24.72222222222222
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.4,26.72222222222222
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.45,28.72222222222222
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.5,30.22222222222222
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.55,31.833333333333336
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.6,33.333333333333336
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.65,34.388888888888886
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.7,35.888888888888886
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.75,38.16666666666667
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.8,41.59489999065721
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.85,44.72222222222222
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.9,51.31376513088368
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.95,60.204727909036265
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.975,75.73992972222223
+2026-05-09,04,1,wk inc covid hosp,2026-05-16,quantile,0.99,95.66701896355866
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.01,6.252847969805129
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.025,11
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.05,12.84
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.1,14.91
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.15,17
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.2,19
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.25,20
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.3,21
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.35,22
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.4,26
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.45,27.88888888888889
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.5,29.444444444444443
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.55,30.555555555555557
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.6,31.599999999999998
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.65,32.888888888888886
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.7,34.55555555555556
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.75,37.111111111111114
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.8,39.96823830023968
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.85,54.701370652320136
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.9,61.58112137940118
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.95,76.4583930599573
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.975,104.60786990402939
+2026-05-09,04,2,wk inc covid hosp,2026-05-23,quantile,0.99,124.51665466666668
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.01,5.823711737436516
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.025,9.62374008311063
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.05,12.994444444444445
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.1,15
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.15,17.140983088790524
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.2,19.11
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.25,20.48
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.3,21.78
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.35,23.04
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.4,24.29
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.45,26
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.5,30.11111111111111
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.55,35
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.6,40
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.65,47
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.7,48.871197634825165
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.75,49.17667071206684
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.8,60.66103033714136
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.85,78.73805643574697
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.9,89.79817940401855
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.95,95.28969311183468
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.975,112.41728864562806
+2026-05-09,04,3,wk inc covid hosp,2026-05-30,quantile,0.99,161.89238393252623
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.01,5.3518742
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.025,5.763366
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.05,6.2402019
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.1,6.7606702
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.15,7.1578999
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.2,7.455745
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.25,7.7673089
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.3,8.0340168
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.35,8.2851253
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.4,8.5868372
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.45,8.7976596
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.5,8.9989427
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.55,9.250842
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.6,9.6015804
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.65,9.9229034
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.7,10.228106899871008
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.75,11.465735971409764
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.8,13.01003804184715
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.85,14.55933775841887
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.9,15.31
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.95,16.28
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.975,17.16
+2026-05-09,05,-1,wk inc covid hosp,2026-05-02,quantile,0.99,18.24
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.01,2.3283333333333345
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.025,2.7777777777777777
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.05,3.678787871205193
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.1,4.720087696603848
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.15,6.006849955523723
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.2,6.2524680121697624
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.25,6.8885023499999996
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.3,7.147216748061727
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.35,7.7141500999999995
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.4,7.8570209
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.45,8.511656
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.5,8.777777777777779
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.55,9.45349907424761
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.6,10
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.65,10.591087302261704
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.7,11.315391288353496
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.75,12.083148008912467
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.8,13.045163389307666
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.85,14.047615429260901
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.9,15.587222222222223
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.95,18.503185763360804
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.975,21.66834104975212
+2026-05-09,05,0,wk inc covid hosp,2026-05-09,quantile,0.99,25.389092087624224
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.01,1.6111111111111112
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.025,2.666666666666667
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.05,3.1817234348934704
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.1,4.2297116
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.15,4.711328618653061
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.2,5.1662592499999995
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.25,5.435481055555556
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.3,6.123332749999999
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.35,7.049296701428569
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.4,7.5368580000000005
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.45,8.229531699999999
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.5,8.751964402694412
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.55,9.869023039482006
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.6,10.415864683037519
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.65,11.388268629757938
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.7,11.430636160302422
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.75,12.277970192647775
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.8,13.403017444231118
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.85,14.774250192594998
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.9,16.650555555555556
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.95,20.742914495332705
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.975,24.235984047813396
+2026-05-09,05,1,wk inc covid hosp,2026-05-16,quantile,0.99,29.4223316392139
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.01,1
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.025,1
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.05,2.5555555555555554
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.1,3.3333333333333335
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.15,4.111111111111111
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.2,4.555555555555555
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.25,5
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.3,5.5312141
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.35,6.0233827
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.4,7.130562781176464
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.45,8.741496811439104
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.5,9
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.55,10
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.6,10
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.65,11
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.7,11.11111111111111
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.75,12.444444444444445
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.8,13.911111111111117
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.85,15.57
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.9,17.08
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.95,21
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.975,25
+2026-05-09,05,2,wk inc covid hosp,2026-05-23,quantile,0.99,31.40341077843476
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.01,1
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.025,1
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.05,2.4444444444444446
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.1,3.2974579
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.15,3.9016278
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.2,4.3421167
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.25,4.8301693
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.3,5.269563
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.35,6.222222222222222
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.4,8
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.45,8
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.5,9
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.55,9
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.6,10
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.65,11
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.7,11.444444444444445
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.75,13.11111111111111
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.8,14.444444444444445
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.85,15.89
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.9,18
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.95,24
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.975,30
+2026-05-09,05,3,wk inc covid hosp,2026-05-30,quantile,0.99,37
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.01,94.5
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.025,100.75
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.05,106.4
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.1,113.24
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.15,118.06
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.2,124.18014718390287
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.25,134.14307970710476
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.3,141.99736937471715
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.35,149.76542113626383
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.4,153.43607843137255
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.45,156.77158900070606
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.5,159.0947368421053
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.55,164.60785544373846
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.6,171.75058823529415
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.65,178.2657
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.7,180.39444
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.75,182.54262
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.8,185.37467
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.85,188.3537
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.9,192.19891
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.95,198.87856
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.975,204.977
+2026-05-09,06,-1,wk inc covid hosp,2026-05-02,quantile,0.99,211.56681
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.01,83.38
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.025,93
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.05,101.74012339309424
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.1,115
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.15,120.55555555555556
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.2,126
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.25,131
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.3,136
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.35,141
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.4,145
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.45,150
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.5,154
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.55,159
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.6,163
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.65,168
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.7,174.16272122026453
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.75,183.23622217761542
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.8,187.5629152851582
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.85,201.134387050737
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.9,210
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.95,234.46851315265957
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.975,265.44503
+2026-05-09,06,0,wk inc covid hosp,2026-05-09,quantile,0.99,281.27986
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.01,67.22222222222223
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.025,80
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.05,94.49
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.1,104.8
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.15,112.28
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.2,118.53
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.25,124.13
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.3,129.34
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.35,134.33
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.4,139.22
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.45,144.08
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.5,160.2514952857142
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.55,160.7292516645361
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.6,169.11111111111111
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.65,174.44444444444446
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.7,183
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.75,194
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.8,208
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.85,223
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.9,239.5097731753359
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.95,280
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.975,339.82020912312777
+2026-05-09,06,1,wk inc covid hosp,2026-05-16,quantile,0.99,353.0793702857143
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.01,56.09337913847219
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.025,76.77777777777777
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.05,93.58111111111111
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.1,110.15166666666667
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.15,119.79166666666666
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.2,126.90166666666667
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.25,134.03055555555557
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.3,140.71555555555557
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.35,146.20277777777778
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.4,152.42944444444444
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.45,157.79166666666669
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.5,166.51357982539682
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.55,172.04627852175787
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.6,177.36226712302383
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.65,193.1054129302357
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.7,209.87399148894838
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.75,221.432609839085
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.8,235.503612450431
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.85,253.2435624265795
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.9,278.0245256276965
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.95,318.2664375233675
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.975,377.20694444444445
+2026-05-09,06,2,wk inc covid hosp,2026-05-23,quantile,0.99,443.8002513766917
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.01,47.49891437703295
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.025,73.67794093441577
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.05,92.64444444444445
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.1,109.45388888888888
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.15,119.88222222222223
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.2,128.98388888888888
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.25,136.75111111111113
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.3,143.78666666666666
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.35,149.90222222222224
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.4,156.2288888888889
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.45,161.94944444444445
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.5,170.77034898412708
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.55,186.87339425083707
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.6,190.56311222772504
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.65,215.2640344804085
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.7,227.63342051555082
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.75,238.5265635535006
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.8,251.47262422584146
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.85,272.36137594884553
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.9,306.23811190087247
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.95,358.95804777775754
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.975,412.1222222222222
+2026-05-09,06,3,wk inc covid hosp,2026-05-30,quantile,0.99,528.867255025632
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.01,10.641055
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.025,11.538737
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.05,12.323345
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.1,13.274603
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.15,13.87442
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.2,14.390382
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.25,14.955961
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.3,15.45067
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.35,15.899211
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.4,16.410886
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.45,16.83686
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.5,17.259234
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.55,17.625965
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.6,18.052456
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.65,18.952418826305642
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.7,20.56
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.75,21.12
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.8,21.75
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.85,22.5
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.9,23.48
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.95,25
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.975,26.38
+2026-05-09,08,-1,wk inc covid hosp,2026-05-02,quantile,0.99,28.06
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.01,3.5
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.025,6
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.05,7.111111111111111
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.1,10.642372120224767
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.15,12.224108055555554
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.2,13.230514055555556
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.25,14.721905704988215
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.3,15.56835233688929
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.35,16.685915472109862
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.4,17.767303637355873
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.45,18.331377820496222
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.5,18.89
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.55,19.705
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.6,20.535
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.65,20.884999999999998
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.7,21.765
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.75,22.185000000000002
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.8,23.44777777777778
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.85,25.371111111111112
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.9,27.918888888888887
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.95,31.837145371125672
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.975,37.577730122991724
+2026-05-09,08,0,wk inc covid hosp,2026-05-09,quantile,0.99,46.67666119863446
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.01,3.0128204814628585
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.025,5.611111111111111
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.05,7
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.1,9.00573892659924
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.15,10.976887737626676
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.2,12.550228474318715
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.25,14.274233011752791
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.3,15.877777777777776
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.35,16.72222222222222
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.4,17.75915150584221
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.45,20.28
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.5,21.68
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.55,22.595
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.6,23.53
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.65,24.494999999999997
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.7,26
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.75,27.064999999999998
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.8,28.77777777777778
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.85,31.5
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.9,35.56111111111112
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.95,42.83611111111111
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.975,51.391666666666666
+2026-05-09,08,1,wk inc covid hosp,2026-05-16,quantile,0.99,63.11026597349857
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.01,3
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.025,5.444444444444445
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.05,6.777777777777778
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.1,9.555555555555555
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.15,11
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.2,13.940081691787
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.25,16.59
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.3,17.57
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.35,18.51
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.4,21.06778296080013
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.45,24.867642
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.5,26.903269
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.55,28
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.6,30
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.65,33
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.7,35
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.75,37.6845086987842
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.8,42
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.85,46
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.9,49.81813427051764
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.95,57.97422171581979
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.975,71
+2026-05-09,08,2,wk inc covid hosp,2026-05-23,quantile,0.99,83.44444444444444
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.01,2.3532597
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.025,4.596262480775214
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.05,6.444444444444445
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.1,8.666666666666666
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.15,12.361401854096716
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.2,15.518918
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.25,18.42
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.3,20.212504
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.35,22.39623
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.4,24.918547
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.45,27
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.5,30
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.55,33
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.6,36
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.65,38.666574453037875
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.7,40.01325962791355
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.75,41.194658755320525
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.8,49.710673334475075
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.85,52.00694307471375
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.9,57.35215935296919
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.95,67.03496128818342
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.975,84.24598030487405
+2026-05-09,08,3,wk inc covid hosp,2026-05-30,quantile,0.99,106.5612432541492
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.01,9.6665335
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.025,10.133072
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.05,10.561266
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.1,11.201895
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.15,11.618203
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.2,11.942141
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.25,12.284701
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.3,12.573617
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.35,12.837554
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.4,13.081891
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.45,13.34977
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.5,13.575698
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.55,13.843909
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.6,14.360108285603335
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.65,15.273830961808265
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.7,16.51656335140148
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.75,17.814405090845856
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.8,19.504292908462666
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.85,20.22
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.9,21.15
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.95,22.59
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.975,23.9
+2026-05-09,09,-1,wk inc covid hosp,2026-05-02,quantile,0.99,25.51
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.01,2.6447510219894053
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.025,5.355868584617309
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.05,6.555555555555555
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.1,7.611111111111111
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.15,8.5
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.2,8.833333333333332
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.25,9.71089985976326
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.3,10.177314227569711
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.35,10.96608669022362
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.4,11.474237438969457
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.45,11.98244165289032
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.5,12.779612566969773
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.55,13.402191547103708
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.6,13.865029475952099
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.65,15.22031933884983
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.7,16.59445000047786
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.75,17.465225766064133
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.8,19.141492506106516
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.85,20.848491716539304
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.9,22.577746233892938
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.95,25.48
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.975,29.725234043058535
+2026-05-09,09,0,wk inc covid hosp,2026-05-09,quantile,0.99,34.80484140616434
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.01,2.2068931665051505
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.025,4.166666666666666
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.05,4.666666666666666
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.1,5.777777777777778
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.15,6.611111111111111
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.2,7.467362896983959
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.25,8.317266430048507
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.3,9.125700123528993
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.35,9.905755265371496
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.4,10.542945553027852
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.45,11.234064559801435
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.5,13.097931149788465
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.55,13.834363454422542
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.6,14.844614715296306
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.65,15.807970122136588
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.7,16.80008030970075
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.75,18.084172564878344
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.8,19.205595962776428
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.85,21.11111111111111
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.9,23
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.95,29.4
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.975,33.49281460251457
+2026-05-09,09,1,wk inc covid hosp,2026-05-16,quantile,0.99,40.19589660532508
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.01,1
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.025,3.6666666666666665
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.05,4.8973029
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.1,5.8766486
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.15,6.5277237
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.2,7.1726738
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.25,7.7610456
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.3,8.590292764141426
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.35,9.444444444444445
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.4,10.222222222222221
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.45,11.11111111111111
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.5,14
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.55,15
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.6,16
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.65,17
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.7,18
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.75,19
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.8,20
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.85,22
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.9,24.77777777777778
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.95,30.444444444444443
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.975,36.41
+2026-05-09,09,2,wk inc covid hosp,2026-05-23,quantile,0.99,47.81852083766628
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.01,1
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.025,3.3642286
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.05,4.1134094
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.1,4.9666345
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.15,5.7771684
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.2,6.423625
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.25,6.9847971012736
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.3,9.11111111111111
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.35,9.777777777777779
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.4,10.444444444444445
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.45,11.555555555555555
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.5,14
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.55,15
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.6,16
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.65,17
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.7,18
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.75,20
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.8,21
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.85,23
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.9,26.555555555555557
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.95,33.33888888888888
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.975,38.76
+2026-05-09,09,3,wk inc covid hosp,2026-05-30,quantile,0.99,54.212648765680534
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.01,2.8160789897635023
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.025,3.324002421382235
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.05,4.2061912
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.1,4.7998533
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.15,5.1626843
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.2,5.5149544
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.25,5.8835531
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.3,6.232125
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.35,6.5020369
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.4,6.8340649000000004
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.45,6.993683750736036
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.5,7.057894736842105
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.55,7.195760693708408
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.6,7.372412444058924
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.65,7.584684400333049
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.7,7.913160493281842
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.75,8.236813005551815
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.8,8.730202054311812
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.85,9.288381300002959
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.9,10.173039466253861
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.95,12.351996996882079
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.975,13.944418631249341
+2026-05-09,10,-1,wk inc covid hosp,2026-05-02,quantile,0.99,14.646964488497364
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.01,1.1666666666666665
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.025,1.657707917908337
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.05,2.280290338158683
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.1,3.0168662583210124
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.15,3.6746762427742583
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.2,4.089672496826261
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.25,4.374968604785893
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.3,4.703494370240351
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.35,5.106064735385624
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.4,5.470471486257607
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.45,5.611111111111111
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.5,6
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.55,6
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.6,6.5
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.65,7
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.7,7.392062995921152
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.75,7.597161297022227
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.8,8.745502174377677
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.85,9.126714232631706
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.9,10
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.95,11.613888888888887
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.975,13.11111111111111
+2026-05-09,10,0,wk inc covid hosp,2026-05-09,quantile,0.99,16.451111111111103
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.8888888888888888
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.025,1.2222222222222223
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.05,2.0555555555555554
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.1,2.4572222222222226
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.15,3.107769493774849
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.2,3.5858077440464107
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.25,4.053077674390793
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.3,4.350834866285902
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.35,4.681076341651666
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.4,5.151658581925476
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.45,5.343630806598668
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.5,5.967550000641207
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.55,6
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.6,6.747724892492961
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.65,6.908727971538439
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.7,7.096945367653012
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.75,7.812228230731724
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.8,8.56475134575316
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.85,10.166666666666668
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.9,12.166666666666668
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.95,15.030487600462404
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.975,17.42229787600774
+2026-05-09,10,1,wk inc covid hosp,2026-05-16,quantile,0.99,21.90679145687632
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.6666666666666666
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.025,1.2222222222222223
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.05,1.7777777777777777
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.1,2.32
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.15,2.9591000393003317
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.2,3.5744710164431033
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.25,4
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.3,4.4839233480985925
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.35,5
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.4,5
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.45,5
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.5,6
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.55,6
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.6,7
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.65,7.106421749023423
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.7,7.421412853336863
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.75,8
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.8,8.333333333333334
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.85,9.555555555555555
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.9,11.555555555555555
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.95,14.777777777777779
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.975,18.11111111111111
+2026-05-09,10,2,wk inc covid hosp,2026-05-23,quantile,0.99,23.6456868696396
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.6666666666666666
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.025,1
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.05,1.7777777777777777
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.1,2.111111111111111
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.15,2.585117783972477
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.2,3
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.25,3.6258184995903746
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.3,4
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.35,4.415100890098783
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.4,5
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.45,5.377221693326093
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.5,5.725197235007457
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.55,6.053698466594885
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.6,6.514723389678616
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.65,7.081503431382181
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.7,7.619660207882389
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.75,8.177001722488937
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.8,8.558393956079666
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.85,9.777777777777779
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.9,12.222222222222221
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.95,16.11111111111111
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.975,20.22222222222222
+2026-05-09,10,3,wk inc covid hosp,2026-05-30,quantile,0.99,25.384706627382705
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0.75795599
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0.92
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.05,1
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.1,1.11
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.15,1.19003906303762
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.2,1.3930159348814615
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.25,1.5793361994414081
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.3,1.7204275901626451
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.35,1.861021887966363
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.4,1.9366318482606095
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.45,2.0035139985078647
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.5,2.0526315789473686
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.55,2.1548193348254694
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.6,2.2868975635040965
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.65,2.4608531120336377
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.7,2.719572409837354
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.75,2.962330467225258
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.8,3.3085225266569998
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.85,3.70996093696238
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.9,4.2317341999481215
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.95,5.487375444822146
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.975,6.383684210526314
+2026-05-09,11,-1,wk inc covid hosp,2026-05-02,quantile,0.99,6.853496619259124
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.01,0
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.10086597718991785
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.05,0.2836150550755104
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.1,0.6066204998178049
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.15,0.940234285650305
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.2,1.0180313132232834
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.25,1.065
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.3,1.1
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.35,1.13
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.4,1.3314944470655918
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.45,1.4396112636253542
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.5,1.8104168034704675
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.55,2
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.6,2.1152159749257384
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.65,2.2591114175735356
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.7,2.437011791637875
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.75,3.1385836719769076
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.8,3.3676646069572804
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.85,4.182343660544436
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.9,4.566621959293707
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.95,5.779880406659377
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.975,7.01812317079057
+2026-05-09,11,0,wk inc covid hosp,2026-05-09,quantile,0.99,9.23849453301689
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.01,0
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.025,0
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.06735957273560038
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.1,0.23972666455035152
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.15,0.3188744030690616
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.2,0.8680586801649621
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.25,1
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.3,1.065
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.35,1.1
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.4,1.235583599690273
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.45,1.4955192016485372
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.5,1.766837902729174
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.55,2.1898881529758922
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.6,2.408603621973177
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.65,2.651259202141305
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.7,2.9025669682383173
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.75,3.3009036014074153
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.8,3.9340837
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.85,4.2775391
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.9,5.5233835
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.95,7.232332417719221
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.975,8.134146042503158
+2026-05-09,11,1,wk inc covid hosp,2026-05-16,quantile,0.99,9.904128903102016
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.025,0
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.05,0.08538278073181267
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.1,0.21815489562058746
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.15,0.45377788530452967
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.2,0.5702927800153801
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.25,1
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.3,1
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.35,1
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.4,1.37
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.45,1.754218905150407
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.5,2.298740600528313
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.55,2.6858289
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.6,3.0135795
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.65,3.3832531
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.7,3.8341528
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.75,4.4069108
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.8,5.1156923
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.85,6.1694243
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.9,7.98237
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.95,9.624509771013006
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.975,11.552968077159575
+2026-05-09,11,2,wk inc covid hosp,2026-05-23,quantile,0.99,14.161291632630597
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.025,0
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.12384426208524257
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.1,0.2364385588984936
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.15,0.3197113319495327
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.2,0.4019242107915906
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.25,1
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.3,1
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.35,1
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.4,1.4293037136743276
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.45,1.9734404291680898
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.5,2.5048069858859914
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.55,2.9147324
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.6,3.2880603
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.65,3.6444268
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.7,4.1363172
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.75,4.685841
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.8,5.4807927
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.85,6.5207817
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.9,8.4414667
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.95,10.068021376798352
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.975,12
+2026-05-09,11,3,wk inc covid hosp,2026-05-30,quantile,0.99,16.123796994821507
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.01,83.71
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.025,87.82
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.05,91.49
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.1,95.88
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.15,98.94
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.2,101.43
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.25,108.63823068228128
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.3,113.67328826290782
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.35,118.00114107988877
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.4,119.93861572055472
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.45,121.8067370469067
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.5,123.12631578947368
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.55,126.11326295309333
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.6,129.96961957356294
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.65,134.43948392011123
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.7,142.60167
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.75,144.53372
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.8,147.2456
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.85,150.32372
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.9,155.47277
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.95,162.51205
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.975,168.92469
+2026-05-09,12,-1,wk inc covid hosp,2026-05-02,quantile,0.99,175.5876
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.01,57.161773154238766
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.025,69.86500000000001
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.05,75.25
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.1,85.5
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.15,91
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.2,95.32222222222222
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.25,99.77777777777777
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.3,103.27777777777777
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.35,108.77271595488774
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.4,115.48514324515665
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.45,121.99074448433052
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.5,126.5
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.55,129.5
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.6,133.5
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.65,136.67500000000007
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.7,140.5
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.75,144.21348500425557
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.8,149.5
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.85,158.4613158551428
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.9,169.04981268682627
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.95,181.63212207433884
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.975,212.3384861111111
+2026-05-09,12,0,wk inc covid hosp,2026-05-09,quantile,0.99,247.52592555555555
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.01,44.07762945957933
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.025,57.16666666666667
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.05,64.78999999999999
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.1,72.16
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.15,78.095
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.2,83.5
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.25,89
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.3,95.1042848165755
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.35,101.11111111111111
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.4,106.55555555555556
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.45,112.5
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.5,118
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.55,123
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.6,129.19999999999993
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.65,136
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.7,143.5
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.75,151.5
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.8,158.4335878955435
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.85,170.81536280477317
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.9,182.71992619429506
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.95,214.47910312621894
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.975,249.37595663897216
+2026-05-09,12,1,wk inc covid hosp,2026-05-16,quantile,0.99,312.6901114236091
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.01,37.111111111111114
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.025,50.333333333333336
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.05,58.94
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.1,66.35
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.15,71.78
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.2,76.36
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.25,84.96783668529629
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.3,90.70000000000005
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.35,95
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.4,100
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.45,112.55555555555556
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.5,116.11111111111111
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.55,120
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.6,129
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.65,141
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.7,152
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.75,166
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.8,182
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.85,204
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.9,218.04172106265992
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.95,243.42997829577502
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.975,274.3666666666666
+2026-05-09,12,2,wk inc covid hosp,2026-05-23,quantile,0.99,357.7270351176363
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.01,35.888888888888886
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.025,47
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.05,53
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.1,62.41
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.15,68.09
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.2,72.9
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.25,81
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.3,86
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.35,91
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.4,96
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.45,101
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.5,120
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.55,124.38333333333334
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.6,129.88888888888889
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.65,136.44444444444446
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.7,151
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.75,167
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.8,187
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.85,215
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.9,255
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.95,282.4480242793253
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.975,323.21486181919835
+2026-05-09,12,3,wk inc covid hosp,2026-05-30,quantile,0.99,411.57344543219125
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.01,30.500199
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.025,32.354729
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.05,33.988277
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.1,35.921045
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.15,37.449472
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.2,38.488744
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.25,39.47664
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.3,40.489873
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.35,41.431063
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.4,42.209345
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.45,43.083638
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.5,43.828669
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.55,44.683449
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.6,45.645506
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.65,46.448825
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.7,47.427712
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.75,48.77398103241293
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.8,53.4375815627393
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.85,58.35016880471681
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.9,64.17453900256594
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.95,72.02
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.975,74.57
+2026-05-09,13,-1,wk inc covid hosp,2026-05-02,quantile,0.99,77.63
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.01,13
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.025,17.666666666666664
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.05,20.93494762432779
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.1,25.344751634081764
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.15,28.833333333333336
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.2,30.166666666666664
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.25,32.111111111111114
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.3,33.611111111111114
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.35,35.993938075067575
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.4,37.786266
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.45,38.843821
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.5,39.898069
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.55,41.0560165
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.6,42.674292
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.65,44.10680721837918
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.7,46.34611566361143
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.75,47.466809462560526
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.8,49.2239
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.85,52.11730289150783
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.9,55.611111111111114
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.95,64.8692734668983
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.975,73.8907354635942
+2026-05-09,13,0,wk inc covid hosp,2026-05-09,quantile,0.99,83.54373055079111
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.01,8.5
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.025,13.18532900037746
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.05,18.333333333333332
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.1,21.944444444444443
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.15,25.050335166666667
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.2,26.832326555555554
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.25,28.68095
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.3,31.131258850385507
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.35,33.11711599775755
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.4,35.335812110099894
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.45,36.715112000000005
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.5,39.5
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.55,41.145059084731415
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.6,43
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.65,45
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.7,47
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.75,49
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.8,51.5
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.85,55.77777777777778
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.9,61.025471588302636
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.95,71.9764843999335
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.975,78.92028159615901
+2026-05-09,13,1,wk inc covid hosp,2026-05-16,quantile,0.99,100.94761420222017
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.01,8.555555555555555
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.025,12
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.05,15.222222222222221
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.1,18.655555555555555
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.15,21.76111111111111
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.2,24.11111111111111
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.25,26.961195
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.3,29.036958
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.35,31.160105
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.4,32.950767
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.45,38
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.5,40
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.55,42
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.6,43
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.65,45
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.7,47
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.75,50
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.8,53.167796
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.85,59.888888888888886
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.9,67.11
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.95,76.46818
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.975,92.2472268965865
+2026-05-09,13,2,wk inc covid hosp,2026-05-23,quantile,0.99,136.7666061629258
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.01,6
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.025,8.433221152621583
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.05,14.516615
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.1,17.744959
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.15,20.665132
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.2,23.11111111111111
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.25,25.206098
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.3,27.555555555555557
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.35,29.342319
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.4,31.885731
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.45,34.048896
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.5,40
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.55,41
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.6,43
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.65,46
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.7,49.083469
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.75,53.539055
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.8,58.458217
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.85,63.111111111111114
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.9,75.46704
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.95,89.582577
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.975,103.6500756997547
+2026-05-09,13,3,wk inc covid hosp,2026-05-30,quantile,0.99,153.23666666666665
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.05,0.13729967
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.1,0.44486984
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.15,0.73039792
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.2,0.93750414
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.25,1.181699520350167
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.3,1.469962740161626
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.35,1.753125
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.4,1.9021489577538069
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.45,2.0270115200152956
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.5,2.1561675
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.55,2.40031
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.6,2.8139294736187423
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.65,3.3031249999999996
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.7,3.59
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.75,3.65
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.8,3.8219619
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.85,4.3021701
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.9,4.8644668
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.95,6.0720664
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.975,7.1097892
+2026-05-09,15,-1,wk inc covid hosp,2026-05-02,quantile,0.99,7.9773496
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.01,0
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.025,0
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.05,0.17613144825324425
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.1,0.6168553669626815
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.15,0.9956447912313394
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.2,1.3005651209468918
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.25,1.6182617665259826
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.3,1.8246013131249088
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.35,1.9973618733617329
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.4,2.182326977695936
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.45,2.4759172344970004
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.5,3.0294420163278852
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.55,3.1863656644444083
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.6,3.3484850277777776
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.65,3.5966174
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.7,3.8437238000000002
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.75,4.0927707
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.8,4.38535435
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.85,4.670330978741086
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.9,5.520103743257497
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.95,6.902465160846178
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.975,8.130538985838012
+2026-05-09,15,0,wk inc covid hosp,2026-05-09,quantile,0.99,9.934609001350822
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.01,0
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.025,0
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.11431604918075434
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.1,0.31285451228944505
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.15,0.5815885254109721
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.2,0.9600488265191394
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.25,1.2296113486762168
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.3,1.6491517128966495
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.35,1.82621345
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.4,1.9793265
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.45,2.177516988194476
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.5,2.4928295589285723
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.55,3.0506845499999997
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.6,3.3461741554590403
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.65,3.915463815714352
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.7,4.2562144
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.75,4.567857894861589
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.8,4.664502048662586
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.85,5.030805646998667
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.9,6.48652465
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.95,8.580077816293983
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.975,9.902832666381022
+2026-05-09,15,1,wk inc covid hosp,2026-05-16,quantile,0.99,12.380315388368015
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.025,0
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.05,0
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.1,0.41890708371848717
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.15,0.6822533260221022
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.2,0.9458181181536718
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.25,1.1082853491213436
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.3,1.3883406
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.35,1.7401163
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.4,2.1677702
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.45,2.5220894
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.5,2.947193
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.55,3.4398042
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.6,3.9757724
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.65,4.561969
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.7,5.12927
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.75,5.8908147
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.8,6.7777431
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.85,7.366684899232586
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.9,9.2649132
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.95,12.016483
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.975,14.338392326161271
+2026-05-09,15,2,wk inc covid hosp,2026-05-23,quantile,0.99,15.396944870952378
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.025,0
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.05,0
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.1,0
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.15,0.23218758
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.2,0.8698724563202376
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.25,1.0078965
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.3,1.4210381
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.35,1.8992592
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.4,2.2750491
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.45,2.7383753
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.5,3.2724114
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.55,3.84
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.6,4.2847431
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.65,4.8912193
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.7,5.66567
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.75,6.5723235
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.8,7.6085654
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.85,9.1388333
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.9,11.06363
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.95,14.469954
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.975,17.819831
+2026-05-09,15,3,wk inc covid hosp,2026-05-30,quantile,0.99,21.285323000000002
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.01,1.5
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.025,1.66
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.05,2.8797406118460245
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.1,5.0130452875516145
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.15,5.645147628941056
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.2,6.326951951387956
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.25,6.85877415648653
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.3,7.234581867822097
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.35,7.628529082765106
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.4,7.822259521305064
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.45,8.004253871032326
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.5,8.115789473684211
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.55,8.353523906745455
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.6,8.648328713989056
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.65,8.996470917234895
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.7,9.54808479884457
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.75,10.19122584351347
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.8,11.211509587073584
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.85,12.217352371058945
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.9,13.48998501547869
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.95,16.970259388153973
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.975,19.847179730592615
+2026-05-09,16,-1,wk inc covid hosp,2026-05-02,quantile,0.99,21.08772911828655
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.01,1.08
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.025,1.5638888888888889
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.05,2.0981891746382475
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.1,2.888888888888889
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.15,3.7200394048703966
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.2,4.069983690060186
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.25,4.270623828675277
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.3,4.912453006590415
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.35,5.044362139478494
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.4,5.722222222222222
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.45,6
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.5,6.232429473809519
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.55,6.87039112871455
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.6,7
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.65,8
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.7,8
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.75,8.555555555555555
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.8,9
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.85,9.833333333333332
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.9,10.944444444444445
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.95,13.05673906048075
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.975,15.795885646746267
+2026-05-09,16,0,wk inc covid hosp,2026-05-09,quantile,0.99,20.141379510868195
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.6018240289700026
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.025,1.08
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.05,1.3657814483718864
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.1,2.417797786579276
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.15,3
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.2,3.4786727249222533
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.25,4.056532423751312
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.3,4.567791957124201
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.35,5.006008830938528
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.4,5.699681669388588
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.45,6.236512666749931
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.5,6.722222222222222
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.55,6.888888888888889
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.6,7.611111111111111
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.65,7.944444444444445
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.7,8.777777777777779
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.75,9.555555555555555
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.8,10.055555555555555
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.85,11.222222222222221
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.9,13.166666666666668
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.95,15.777777777777779
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.975,19.34787539857787
+2026-05-09,16,1,wk inc covid hosp,2026-05-16,quantile,0.99,23.702899969854315
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.85
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.025,1.07
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.05,1.29
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.1,2.311948120574255
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.15,2.9833333333333325
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.2,3.4444444444444446
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.25,3.888888888888889
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.3,4.222222222222222
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.35,5
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.4,6
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.45,6
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.5,7
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.55,7
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.6,8
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.65,9
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.7,10
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.75,11
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.8,12
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.85,13
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.9,15
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.95,18.333333333333332
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.975,23.77777777777778
+2026-05-09,16,2,wk inc covid hosp,2026-05-23,quantile,0.99,30.980961448718396
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.93
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.025,1
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.05,1
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.1,2
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.15,2.02
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.2,3.2222222222222223
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.25,3.7777777777777777
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.3,4.111111111111111
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.35,4.555555555555555
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.4,5.222222222222222
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.45,6
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.5,6.222222222222222
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.55,7
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.6,8
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.65,9
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.7,10
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.75,11
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.8,12
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.85,14
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.9,17
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.95,20.555555555555557
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.975,26.666666666666668
+2026-05-09,16,3,wk inc covid hosp,2026-05-30,quantile,0.99,34.49597314966315
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.01,27.050038
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.025,28.543149
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.05,30.06756
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.1,31.731522
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.15,33.122597
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.2,34.17111
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.25,35.122008
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.3,35.875768
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.35,36.67894
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.4,37.336404
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.45,38.177932
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.5,38.824752
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.55,39.606355
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.6,40.388502
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.65,41.219697
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.7,43.407999999999994
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.75,49.546791167396094
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.8,57.269253336239125
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.85,63.48121290465151
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.9,77.51930951783758
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.95,96.85
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.975,103.09
+2026-05-09,17,-1,wk inc covid hosp,2026-05-02,quantile,0.99,110.77
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.01,9.055555555555555
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.025,13.673498385030117
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.05,18.426283784593515
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.1,23.18575722222222
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.15,24.87341872222222
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.2,26.466865333333335
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.25,27.884978277777776
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.3,29.262466166666666
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.35,30.40718588888889
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.4,32.204908555733354
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.45,34.19113893325709
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.5,37.41625765318824
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.55,39.683933125418434
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.6,41.874413469740674
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.65,43.683454180004546
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.7,46
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.75,48
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.8,50.5
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.85,52.80047388467125
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.9,57.27777777777778
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.95,65.2449574576233
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.975,76.13705422122753
+2026-05-09,17,0,wk inc covid hosp,2026-05-09,quantile,0.99,93.78007558809516
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.01,6.5
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.025,10.305832908683726
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.05,15.052777777777777
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.1,18.3287435
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.15,19.9911445
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.2,22.12967
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.25,23.634542500000002
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.3,25.729321243705538
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.35,28.307624062730913
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.4,30.055555555555557
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.45,32.44444444444444
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.5,37.11602290565583
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.55,39.5
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.6,41.5
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.65,44
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.7,46.5
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.75,49.5
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.8,53
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.85,57.44444444444444
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.9,65.5
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.95,75.60161240805351
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.975,97.16666666666666
+2026-05-09,17,1,wk inc covid hosp,2026-05-16,quantile,0.99,122.15864188816366
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.01,5
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.025,7.8307492475147775
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.05,13.102526
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.1,15.530722
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.15,16.943484
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.2,18.63381857170168
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.25,22.994880057160735
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.3,27
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.35,28.22222222222222
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.4,37
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.45,39
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.5,41
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.55,42
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.6,44
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.65,46
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.7,48
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.75,50
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.8,57
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.85,65
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.9,77
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.95,87.10494772465644
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.975,117
+2026-05-09,17,2,wk inc covid hosp,2026-05-23,quantile,0.99,144.88888888888889
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.01,2
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.025,7.655596151125463
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.05,9.8919121
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.1,12.052082
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.15,14.627212123817186
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.2,20.660896594017693
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.25,26.194444444444443
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.3,28.22222222222222
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.35,29.77777777777778
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.4,31.77777777777778
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.45,39
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.5,41
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.55,43
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.6,44
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.65,46
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.7,49
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.75,52
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.8,58
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.85,70
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.9,86
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.95,106.84135843686691
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.975,146
+2026-05-09,17,3,wk inc covid hosp,2026-05-30,quantile,0.99,178
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.01,10.84
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.025,12.17
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.05,13.42
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.1,15.039404471174198
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.15,17.623596491216748
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.2,19.294658859949543
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.25,21.22111305501748
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.3,22.72947886614769
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.35,24.353942660425755
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.4,24.976902
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.45,25.468578
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.5,26.059935
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.55,26.67257
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.6,27.370978
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.65,28.028081
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.7,28.626501
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.75,29.311862
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.8,30.194681
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.85,31.002546
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.9,32.349524
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.95,34.319417
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.975,37.19
+2026-05-09,18,-1,wk inc covid hosp,2026-05-02,quantile,0.99,40.87
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.01,6.9388460019867
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.025,10.192222222222222
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.05,11.722222222222221
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.1,13.719999999999999
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.15,15.465
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.2,16.61
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.25,17.755515648378612
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.3,19.166666666666664
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.35,20.11111111111111
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.4,21
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.45,21.944444444444443
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.5,22.95
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.55,24.035
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.6,25.540856499999997
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.65,26.698098
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.7,28.045899
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.75,29.395
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.8,30.5
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.85,33.26113060665071
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.9,36.023691307413266
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.95,42.37555555555556
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.975,50.81861111111111
+2026-05-09,18,0,wk inc covid hosp,2026-05-09,quantile,0.99,59.45151535787654
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.01,4.582175144705461
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.025,7.35
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.05,8.690000000000001
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.1,10.897683491073249
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.15,13.074788968271744
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.2,15.092371636773379
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.25,16.92177277777778
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.3,17.87263877777778
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.35,18.895724333333334
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.4,19.88454738888889
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.45,20.850123944444444
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.5,21.837726444444442
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.55,22.85942
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.6,24.080942333333333
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.65,26.18611111111111
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.7,28.5
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.75,30
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.8,33
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.85,36.33333333333333
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.9,41
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.95,48.942865961815954
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.975,59.918055555555554
+2026-05-09,18,1,wk inc covid hosp,2026-05-16,quantile,0.99,74.89111111111112
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.01,4.69585777706781
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.025,7.43
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.05,9.15
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.1,11.535711
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.15,12.789446
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.2,14.666666666666666
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.25,15.555555555555555
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.3,16.444444444444443
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.35,17.666666666666668
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.4,18.77777777777778
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.45,20
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.5,21.22222222222222
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.55,25
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.6,27
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.65,28
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.7,29
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.75,31
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.8,36
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.85,42
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.9,48.41
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.95,57.82
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.975,67.15
+2026-05-09,18,2,wk inc covid hosp,2026-05-23,quantile,0.99,97.38596500109034
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.01,4.372361284714007
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.025,6.4475376
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.05,8.0035686
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.1,9.8976261
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.15,11.347381
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.2,14.666666666666666
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.25,15.555555555555555
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.3,16.88888888888889
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.35,18
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.4,19.11111111111111
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.45,20.394444444444446
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.5,24
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.55,26
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.6,27
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.65,28
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.7,30
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.75,32
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.8,38
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.85,46
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.9,56.43
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.95,67.7
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.975,78.92
+2026-05-09,18,3,wk inc covid hosp,2026-05-30,quantile,0.99,116.80741098395985
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.01,4.6805719
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.025,5.2629591
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.05,6.1111214
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.1,6.901302
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.15,7.4947257
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.2,8.0350629
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.25,8.4849077
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.3,8.8872292
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.35,9.3594022
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.4,9.6619017
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.45,10.050977
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.5,10.416481
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.55,10.785682
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.6,11.237924
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.65,11.690771
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.7,12.150785
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.75,12.747259
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.8,13.493576811320397
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.85,15.195870988021653
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.9,18.551571940858235
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.95,19.88
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.975,21.08
+2026-05-09,19,-1,wk inc covid hosp,2026-05-02,quantile,0.99,22.55
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.01,1.2222222222222223
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.025,2.457850518521444
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.05,3.649541051461211
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.1,4.772222222222222
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.15,5.333333333333334
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.2,6
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.25,6.263888888888889
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.3,7.111111111111111
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.35,7.374773692998646
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.4,8.055555555555555
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.45,8.705491919346311
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.5,9.785615343341119
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.55,10.720634745726558
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.6,11.244715038307525
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.65,11.677808500000001
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.7,12.5133645
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.75,13.006797055555555
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.8,14.00301961111111
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.85,14.956236555555556
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.9,16.605917055555558
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.95,20.048819166666664
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.975,23.767307666666667
+2026-05-09,19,0,wk inc covid hosp,2026-05-09,quantile,0.99,26.80935812193325
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.7588331400246522
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.025,2.180841431787495
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.05,3.6008564361789857
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.1,4.5
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.15,4.777777777777778
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.2,5.655555555555557
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.25,5.833333333333334
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.3,6.555555555555555
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.35,6.916365325440033
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.4,8.327022408393479
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.45,9.471998713351358
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.5,9.997844976310432
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.55,10.604938956018582
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.6,11.643032999999999
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.65,12.0086585
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.7,13.003853
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.75,14.051921499999999
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.8,15.047863388888889
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.85,16.641555722222222
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.9,19.056761055555555
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.95,23.7052905
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.975,29.33158538888889
+2026-05-09,19,1,wk inc covid hosp,2026-05-16,quantile,0.99,33.67548106213411
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.01,1.1111111111111112
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.025,2
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.05,3
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.1,4
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.15,5
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.2,6
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.25,6
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.3,7
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.35,7.622589778215354
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.4,8
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.45,9
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.5,10.896269
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.55,11.719565
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.6,12.778575
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.65,13.809244
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.7,14.989359
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.75,16.216363
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.8,17.94066
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.85,20.283573
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.9,23.652056
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.95,29.649762
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.975,35.26597782436508
+2026-05-09,19,2,wk inc covid hosp,2026-05-23,quantile,0.99,40.47
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.01,1.1111111111111112
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.025,1.8888888888888888
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.05,2.8371688
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.1,3.4444444444444446
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.15,4.333333333333333
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.2,5
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.25,5.644096337742507
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.3,7
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.35,7
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.4,8
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.45,8
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.5,10.582042
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.55,11.583819
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.6,12.660759
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.65,13.874246
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.7,15.244593
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.75,16.639499
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.8,18.803056
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.85,22.049779
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.9,26.899408
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.95,35.42
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.975,39.59
+2026-05-09,19,3,wk inc covid hosp,2026-05-30,quantile,0.99,45.42395137422363
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0.06052631578947366
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0.06413043478260867
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.05,0.121
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.1,0.49090909090909096
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.15,0.565
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.2,0.6769230769230767
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.25,1.1930070868406046
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.3,1.803986038033939
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.35,2.32957
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.4,2.4584515
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.45,2.6083994
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.5,2.7408836
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.55,2.8924303
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.6,3.0679922
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.65,3.2237691
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.7,3.4099681
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.75,3.6453839
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.8,3.9280105
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.85,4.2739245
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.9,4.7178587
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.95,5.5088403
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.975,6.0335074
+2026-05-09,20,-1,wk inc covid hosp,2026-05-02,quantile,0.99,6.8535151
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.014891736618074365
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.056311980777911386
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.05,0.29490958455174976
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.1,0.7257822958083754
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.15,1.0064625998352696
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.2,1.2663476130160871
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.25,1.4651017971688716
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.3,1.6962474900210842
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.35,1.8995389301435446
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.4,2.0927016914900705
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.45,2.8114854613238194
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.5,3.199868588888889
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.55,3.617164131169419
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.6,4.302130888922087
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.65,4.889286064784242
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.7,5.51972056952063
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.75,6.343975824546358
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.8,7.2653021378659854
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.85,8.30764884707258
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.9,9.170087478591736
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.95,11.478631797959434
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.975,13
+2026-05-09,20,0,wk inc covid hosp,2026-05-09,quantile,0.99,15.175866498723042
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.005
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.025,0.01
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.1430799923894027
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.1,0.5363341918920065
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.15,0.7476452025027002
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.2,0.9979665079483668
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.25,1.265945183384241
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.3,1.546886697892716
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.35,1.7690172232744046
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.4,2.37242287512106
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.45,2.462966486429732
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.5,3.465541342950614
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.55,3.8682567386426943
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.6,4.811157506806586
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.65,5.306788094000009
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.7,6.392236086247783
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.75,7.054209348440084
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.8,8
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.85,9
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.9,10
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.95,12
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.975,14.0305675
+2026-05-09,20,1,wk inc covid hosp,2026-05-16,quantile,0.99,20.272345633516487
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.01
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.03
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.05,0.14019747
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.1,0.31987768
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.15,0.47608134
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.2,0.69690831
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.25,0.93266795
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.3,1.1506064
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.35,1.3991389
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.4,1.9058042818124061
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.45,2.610303999905301
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.5,3.640738661064022
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.55,4.939575303520121
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.6,6
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.65,7
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.7,7.777777777777778
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.75,8.666666666666666
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.8,10
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.85,11
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.9,12
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.95,14.937727
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.975,20.668677
+2026-05-09,20,2,wk inc covid hosp,2026-05-23,quantile,0.99,29.591788
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.0022942903
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.02232827
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.069458434
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.1,0.19377165
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.15,0.36602817
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.2,0.54624405
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.25,0.7492336
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.3,0.98880463
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.35,1.5895610838787508
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.4,2.2793542036992194
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.45,3.4728811273257043
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.5,5.185974972317094
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.55,5.888888888888889
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.6,6.555555555555555
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.65,7.666666666666667
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.7,8
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.75,9
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.8,10
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.85,11
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.9,13.114923
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.95,19.432157
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.975,27.204231
+2026-05-09,20,3,wk inc covid hosp,2026-05-30,quantile,0.99,41.617074
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.01,15.020223
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.025,16.737106
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.05,18.187575
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.1,20.236039
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.15,21.58
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.2,22.39
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.25,23.1
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.3,23.76
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.35,24.39
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.4,24.99
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.45,25.59
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.5,26.19
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.55,26.8
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.6,27.44
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.65,28.11
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.7,28.82
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.75,29.62
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.8,30.52
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.85,32.38935739724663
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.9,36.33047323823435
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.95,39.781877
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.975,42.243631
+2026-05-09,21,-1,wk inc covid hosp,2026-05-02,quantile,0.99,46.442804
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.01,7.012326270468136
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.025,9.444444444444445
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.05,10.944444444444445
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.1,13.11111111111111
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.15,14.222222222222221
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.2,15.72155722651894
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.25,17.042636501377515
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.3,18
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.35,19
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.4,20
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.45,21
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.5,21.069299353571427
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.55,22.48637085869523
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.6,24.898201361216316
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.65,25.498932716722464
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.7,26.915
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.75,27.994999999999997
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.8,29.66
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.85,30.334377012786447
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.9,33.035
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.95,37.16274902259018
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.975,41.51260579462959
+2026-05-09,21,0,wk inc covid hosp,2026-05-09,quantile,0.99,55.267281971495066
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.01,5
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.025,6.277777777777778
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.05,7.611111111111111
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.1,9.722222222222221
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.15,12.00504138102906
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.2,13.724586101136898
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.25,15.329682100466055
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.3,16.666666666666668
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.35,17.27777777777778
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.4,18.166666666666664
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.45,19
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.5,22.57105127142857
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.55,23.71
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.6,24.765
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.65,25.86
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.7,27.509999999999998
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.75,29.244999999999997
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.8,31.095
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.85,34.135000000000005
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.9,37.525
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.95,40.9252279824018
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.975,49.747690393473434
+2026-05-09,21,1,wk inc covid hosp,2026-05-16,quantile,0.99,65.38561479529992
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.01,4.666666666666667
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.025,6.111111111111111
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.05,7.438888888888889
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.1,9
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.15,11.044245419558369
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.2,14.027834906130312
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.25,16
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.3,17
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.35,18
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.4,19
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.45,20
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.5,24.6
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.55,25.83
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.6,27.12
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.65,28.51
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.7,30.04
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.75,31.77
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.8,33.8
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.85,38
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.9,44
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.95,50.37469330062316
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.975,58.02366279229276
+2026-05-09,21,2,wk inc covid hosp,2026-05-23,quantile,0.99,76.37373737357595
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.01,4.111111111111111
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.025,5.444444444444445
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.05,6.555555555555555
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.1,8.444444444444445
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.15,10.339547185975714
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.2,13.7199789456242
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.25,16
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.3,17
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.35,18
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.4,22.31263524583759
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.45,24.05
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.5,25.36
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.55,26.74
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.6,28.2
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.65,29.77
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.7,31.52
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.75,33.49
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.8,35.81
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.85,40
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.9,50
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.95,62.95450962034659
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.975,64.57471768574926
+2026-05-09,21,3,wk inc covid hosp,2026-05-30,quantile,0.99,86.38064553397288
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.01,15.14816
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.025,16.974051
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.05,18.748259
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.1,21.004988
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.15,22.356683
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.2,23.770117
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.25,24.864032
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.3,25.818179
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.35,26.868599
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.4,27.808078
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.45,28.731748
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.5,29.731555
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.55,30.7601
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.6,31.598441
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.65,32.56418
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.7,33.511643
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.75,34.667518
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.8,35.861853
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.85,37.37
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.9,38.44
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.95,43.55502041282789
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.975,47.659629
+2026-05-09,22,-1,wk inc covid hosp,2026-05-02,quantile,0.99,51.075039
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.01,7.722222222222222
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.025,9.735736723429309
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.05,12.19635877706269
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.1,14.692451350926719
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.15,16.376699446148265
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.2,18.14015499326435
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.25,21.961308419299673
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.3,23.851486637705055
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.35,24.711054043833187
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.4,26.561947060675717
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.45,27.43277985198722
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.5,28.73400730353001
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.55,29.646323136965854
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.6,30.450605745036402
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.65,32.284236157046934
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.7,33.1823057675999
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.75,34.44771634595847
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.8,36.93
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.85,38.055
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.9,39.875
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.95,42.135000000000005
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.975,46.44135167083873
+2026-05-09,22,0,wk inc covid hosp,2026-05-09,quantile,0.99,58.629715006649036
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.01,6.111111111111111
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.025,8.581944444444444
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.05,10.333333333333332
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.1,13.31911618759371
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.15,15.671334640003845
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.2,18.02952004727515
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.25,19.481142356840543
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.3,21.072070962997202
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.35,23.83438857874082
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.4,24.895702891391238
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.45,27.222882614294868
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.5,28.54144088214285
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.55,29.26055033080317
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.6,31.154115444188555
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.65,31.8106262004384
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.7,35.95432515349252
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.75,37.292822398143414
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.8,38.920101615790465
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.85,40.12472966375873
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.9,44.874151849353815
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.95,50.1717122913622
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.975,58.664690162174196
+2026-05-09,22,1,wk inc covid hosp,2026-05-16,quantile,0.99,69.61333333333333
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.01,6
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.025,7.111111111111111
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.05,9.444444444444445
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.1,12.666666666666666
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.15,15.373591733975086
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.2,18.153663072886474
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.25,20.973815770183656
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.3,24.053956068930848
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.35,25.63
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.4,26.61
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.45,27.58
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.5,31.74796985714288
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.55,34
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.6,36
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.65,38
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.7,41
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.75,44
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.8,47
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.85,51
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.9,57
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.95,65.0732213241096
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.975,71.3544556435554
+2026-05-09,22,2,wk inc covid hosp,2026-05-23,quantile,0.99,83.22999999999999
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.01,5
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.025,7
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.05,8.444444444444445
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.1,11.437343544008167
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.15,15.4561998433889
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.2,18
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.25,20
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.3,22
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.35,24
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.4,26
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.45,27.94
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.5,30
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.55,33
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.6,35
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.65,38
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.7,41
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.75,44
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.8,49
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.85,54
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.9,61
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.95,72
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.975,82
+2026-05-09,22,3,wk inc covid hosp,2026-05-30,quantile,0.99,98.64421593778248
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0.066604721
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0.18573207
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.05,0.33063323
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.1,0.53607149
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.15,0.64106128
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.2,0.76162569
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.25,0.87091874
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.3,0.97542031
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.35,1.0640259
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.4,1.1506073000000001
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.45,1.2430513
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.5,1.3545492
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.55,1.4562377
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.6,1.5767925
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.65,1.7251840810380341
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.7,2.16
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.75,2.25
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.8,2.35
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.85,2.47
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.9,2.6728313
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.95,3.2891816
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.975,3.8819098
+2026-05-09,23,-1,wk inc covid hosp,2026-05-02,quantile,0.99,4.655792
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.01,0
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.025,0
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.05,0
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.1,0.013967898
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.15,0.37469950728976276
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.2,0.48724939138582624
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.25,0.6419802217807427
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.3,1
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.35,1
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.4,1.0779971281546952
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.45,1.193661641161512
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.5,1.4941576333333333
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.55,1.7523428393536338
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.6,2.0555555555555554
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.65,2.331666666666667
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.7,2.613864031925751
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.75,2.82790675
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.8,3.4085434343006966
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.85,3.8389125
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.9,4.7910955
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.95,6.000098449999999
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.975,7.2329217
+2026-05-09,23,0,wk inc covid hosp,2026-05-09,quantile,0.99,9.003501317807686
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.01,0
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.025,0
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.05,0
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.1,0
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.15,0.32723329718347816
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.2,0.7914047369501934
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.25,1
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.3,1
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.35,1
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.4,1.2222222222222223
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.45,1.5297292930378261
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.5,1.9444444444444444
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.55,2.0555555555555554
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.6,2.5072222222222225
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.65,2.855
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.7,2.935
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.75,3.08676645
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.8,3.8526917000000003
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.85,4.2091141
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.9,5.44835605
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.95,7.146530908426604
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.975,8.679948770039758
+2026-05-09,23,1,wk inc covid hosp,2026-05-16,quantile,0.99,10.218393076626814
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.025,0
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.05,0
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.1,0
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.15,0.6666666666666666
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.2,0.8888888888888888
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.25,1
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.3,1
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.35,1
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.4,2
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.45,2
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.5,2.111111111111111
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.55,2.3333333333333335
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.6,3
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.65,3
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.7,3.13
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.75,4
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.8,4.2684926
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.85,5.4723018
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.9,7.555727
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.95,10.49812752181218
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.975,15.273869409654935
+2026-05-09,23,2,wk inc covid hosp,2026-05-23,quantile,0.99,15.98054707639981
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.025,0
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.05,0
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.1,0.11431863055750702
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.15,0.6666666666666666
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.2,0.8888888888888888
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.25,1
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.3,1
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.35,1
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.4,1.9172778391302205
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.45,2.111111111111111
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.5,2.2222222222222223
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.55,2.5555555555555554
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.6,3.111111111111111
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.65,3.51
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.7,3.75
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.75,4.02
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.8,4.8640571
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.85,6.5035463
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.9,8.8424085
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.95,11.65625993687761
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.975,16.70333744132982
+2026-05-09,23,3,wk inc covid hosp,2026-05-30,quantile,0.99,19.392224104610086
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.01,12.49
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.025,13.33
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.05,14.1
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.1,15.02
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.15,15.67
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.2,16.2
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.25,16.67
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.3,17.1
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.35,17.522834270962598
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.4,18.29102755384705
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.45,18.91959109172124
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.5,19.321052631578947
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.55,20.057631130500987
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.6,21.00309009321177
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.65,21.977227
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.7,22.450194
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.75,23.022164
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.8,23.668894
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.85,24.377478
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.9,25.475156
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.95,26.981459
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.975,28.131502
+2026-05-09,24,-1,wk inc covid hosp,2026-05-02,quantile,0.99,30.419434
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.01,4.658819617850361
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.025,8.3905624
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.05,9.61111111111111
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.1,11.666666666666668
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.15,12.665
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.2,13.672202309728622
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.25,14.76774138553957
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.3,16.430740248991057
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.35,17.516796785125592
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.4,18.48800838888889
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.45,19.389989833333335
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.5,20.378782166666667
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.55,21.266461
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.6,22.16188727777778
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.65,23.161866166666666
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.7,24.11111111111111
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.75,24.833333333333336
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.8,26.11111111111111
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.85,28.166666666666664
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.9,30.41664922822006
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.95,37.4431810538322
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.975,41.80434080907172
+2026-05-09,24,0,wk inc covid hosp,2026-05-09,quantile,0.99,51.91976342070343
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.01,3.9980838197308257
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.025,6.661306
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.05,8.35865205
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.1,10.041967
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.15,11.465
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.2,12.698991437988386
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.25,14.045136245658778
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.3,15.104284999999999
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.35,17.092059283783833
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.4,17.58970078743115
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.45,19.47047555743491
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.5,20.20549785714286
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.55,20.782788045739693
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.6,22.696896149076792
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.65,23.29175987494633
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.7,26.5137338246122
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.75,28.444444444444443
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.8,30.833333333333336
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.85,34.05555555555556
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.9,37.55555555555556
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.95,44.55555555555556
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.975,51.61604468143278
+2026-05-09,24,1,wk inc covid hosp,2026-05-16,quantile,0.99,65.62305910716049
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.01,3.5694387
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.025,6
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.05,8
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.1,9
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.15,10.96
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.2,12.522337
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.25,14.150208
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.3,15.796041
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.35,17.22222222222222
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.4,18.57405440233399
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.45,19.22222222222222
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.5,21.07971855714283
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.55,22.59874929735156
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.6,22.855691711951724
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.65,25.539327316742835
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.7,27.037534713428663
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.75,36
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.8,38.90352469563811
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.85,44
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.9,50
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.95,59
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.975,67.57884133412901
+2026-05-09,24,2,wk inc covid hosp,2026-05-23,quantile,0.99,83.77888888888889
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.01,3.039522898152406
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.025,6
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.05,7
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.1,9
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.15,10.236020279694849
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.2,12.09
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.25,13.643367
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.3,15.666666666666666
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.35,16.77777777777778
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.4,17.84444444444445
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.45,19
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.5,24.787784
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.55,27
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.6,30
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.65,33
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.7,36
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.75,40
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.8,45
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.85,52
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.9,60
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.95,70.12224912467812
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.975,77.58832932253968
+2026-05-09,24,3,wk inc covid hosp,2026-05-30,quantile,0.99,92.44555555555556
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.01,11.120760869565217
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.025,13.082543934715858
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.05,17.061570874766844
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.1,21.665028386831466
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.15,23.625818120623343
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.2,25.16873489380898
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.25,26.933795120382705
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.3,28.216553768266426
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.35,29.295670190705476
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.4,29.999459391244674
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.45,30.629628353424906
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.5,31.143421052631577
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.55,32.0628716465751
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.6,33.14338374601023
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.65,34.31729855929452
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.7,36.20744623173357
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.75,38.23682987961729
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.8,40.58011126003717
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.85,43.11449437937665
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.9,47.134517067713986
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.95,55.43592912523315
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.975,61.60956132844203
+2026-05-09,25,-1,wk inc covid hosp,2026-05-02,quantile,0.99,65.62205414078106
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.01,8.16073573066097
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.025,11.222222222222221
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.05,13.555555555555555
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.1,16.9995591562259
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.15,19.455062589964957
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.2,22.11809711318547
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.25,24
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.3,25
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.35,26
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.4,27
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.45,28
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.5,32
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.55,33.39
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.6,34.56
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.65,35.82
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.7,37
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.75,38.7
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.8,40
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.85,42.57
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.9,45.37
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.95,49.8
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.975,61.39722222222221
+2026-05-09,25,0,wk inc covid hosp,2026-05-09,quantile,0.99,76.99675958303317
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.01,7.222222222222222
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.025,9.555555555555555
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.05,11.666666666666666
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.1,14.444444444444445
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.15,17.213503641938914
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.2,20.43047088629722
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.25,23
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.3,24
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.35,26
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.4,28
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.45,30
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.5,31.72
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.55,33.13
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.6,34.62
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.65,36.21
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.7,37.96
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.75,39.92
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.8,42.2
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.85,45
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.9,49.542335770604026
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.95,64.23046465590477
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.975,72.60032674937801
+2026-05-09,25,1,wk inc covid hosp,2026-05-16,quantile,0.99,94.22444444444444
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.01,6.055555555555555
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.025,8.333333333333332
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.05,9.886111111111111
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.1,13.049034042176018
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.15,16.456544008255413
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.2,19
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.25,20.5
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.3,22.5
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.35,24
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.4,26
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.45,29.075
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.5,30.869999999999997
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.55,33.2
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.6,35.58
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.65,38.03
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.7,40.58
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.75,44.265
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.8,48.155
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.85,53.370000000000005
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.9,60.185
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.95,72.53373842465257
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.975,85.66944444444445
+2026-05-09,25,2,wk inc covid hosp,2026-05-23,quantile,0.99,108.61031233306278
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.01,4.166666666666666
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.025,6.333333333333334
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.05,8
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.1,12.706174936389036
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.15,15.947015343543388
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.2,18.044444444444444
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.25,19.77777777777778
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.3,21.261111111111113
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.35,22.833333333333336
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.4,24.11111111111111
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.45,27.389299918233814
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.5,30.955
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.55,32.394999999999996
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.6,35.39
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.65,38.97
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.7,42.165
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.75,46.025
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.8,51.120000000000005
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.85,58.105000000000004
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.9,67.28999999999999
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.95,81.3376754193642
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.975,101.30694444444444
+2026-05-09,25,3,wk inc covid hosp,2026-05-30,quantile,0.99,128.74111869158344
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.01,8.28
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.025,9.51
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.05,10.69
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.1,13.979621213719222
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.15,17.592381296734224
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.2,20.288266617228498
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.25,23.34106
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.3,24.515004
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.35,25.335069
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.4,26.488151
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.45,27.453866
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.5,28.417394
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.55,29.399275
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.6,30.63002
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.65,31.779409
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.7,33.239216
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.75,34.697071
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.8,36.383337
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.85,38.541642
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.9,40.703149
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.95,45.269143
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.975,48.7423
+2026-05-09,26,-1,wk inc covid hosp,2026-05-02,quantile,0.99,52.792016
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.01,6.8423023999999995
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.025,9.9282075
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.05,11.480480499999999
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.1,13.5
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.15,14.5
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.2,15.5
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.25,17
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.3,20.5
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.35,21.7672165
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.4,23.671233613678496
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.45,25.639660043308346
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.5,27.640633166666667
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.55,28.845079555555557
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.6,30.19404022222222
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.65,32.049825722222224
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.7,33.884377
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.75,36.113549388888885
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.8,38.66093616666667
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.85,41.94444444444444
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.9,46.548853
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.95,54.7560733719794
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.975,64.34859447629599
+2026-05-09,26,0,wk inc covid hosp,2026-05-09,quantile,0.99,80.2307908281299
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.01,3.5
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.025,6.22053245
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.05,7.6707334
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.1,9.642972499999999
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.15,11.21
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.2,12.995000000000001
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.25,14.697848548624663
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.3,17.365073348760554
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.35,20.125676789586556
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.4,23.437468095102584
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.45,25.415639628933352
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.5,27.31224311111111
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.55,28.497135358368233
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.6,30.183252669976778
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.65,33.300849166666666
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.7,35.80538322222222
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.75,38.83333333333333
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.8,41.611111111111114
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.85,45.33333333333333
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.9,50.44444444444444
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.95,63.770329405051704
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.975,77.91576800655751
+2026-05-09,26,1,wk inc covid hosp,2026-05-16,quantile,0.99,103.33646006544316
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.01,1.34414587352494
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.025,3.7210208
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.05,5.4213422
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.1,8.7413324
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.15,11.453489
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.2,13.311353
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.25,16.071342
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.3,18.69
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.35,20.865162
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.4,22.87936
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.45,25.492192
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.5,28
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.55,31.127281
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.6,34.517892
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.65,36
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.7,38
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.75,41
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.8,43
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.85,48
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.9,55.666666666666664
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.95,73.4215586116203
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.975,99.78888888888888
+2026-05-09,26,2,wk inc covid hosp,2026-05-23,quantile,0.99,133.44908
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.91535014
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.025,2.054507
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.05,3.8810448
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.1,7.1837562
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.15,9.8996718
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.2,12.776004
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.25,15.041048
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.3,20.96
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.35,22.89
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.4,24.86
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.45,27.484568
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.5,31.241598
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.55,33
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.6,35
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.65,37
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.7,39.57
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.75,43.11
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.8,47.36
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.85,52.74
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.9,62
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.95,86.83927940059984
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.975,116
+2026-05-09,26,3,wk inc covid hosp,2026-05-30,quantile,0.99,155
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.01,11.794954851058854
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.025,14.033495756341933
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.05,17.699076498169923
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.1,21.850914481974872
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.15,23.4150234899072
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.2,24.6131016471164
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.25,25.978501429462106
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.3,27.104374974597878
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.35,28.07037021630505
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.4,28.726219263839134
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.45,29.36571042192892
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.5,29.914736842105263
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.55,30.625678466959975
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.6,31.44583955969028
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.65,32.33595790869495
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.7,33.618291692068794
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.75,35.18879023720456
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.8,36.95997527596052
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.85,39.0309140100928
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.9,41.64999460893422
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.95,47.545923501830075
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.975,52.11124108576333
+2026-05-09,27,-1,wk inc covid hosp,2026-05-02,quantile,0.99,55.261132105462885
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.01,6.8327404919712125
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.025,9.607844561899578
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.05,12.084884342024402
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.1,15
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.15,17
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.2,19.48414982036445
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.25,21.220680611953423
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.3,22.847792880187495
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.35,24.36036227328875
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.4,25.81119737521582
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.45,27.202279394529416
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.5,28.657567538111646
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.55,30
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.6,31
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.65,31
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.7,32
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.75,33
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.8,34
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.85,35
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.9,36
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.95,43.39806697293767
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.975,51.724999999999994
+2026-05-09,27,0,wk inc covid hosp,2026-05-09,quantile,0.99,61.52501560441446
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.01,3.888888888888889
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.025,6.222222222222222
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.05,9.050782653373238
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.1,12.681518640789609
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.15,15
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.2,17
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.25,21.3415930066035
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.3,22.427764130471388
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.35,23.51525833524355
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.4,27.977690430843328
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.45,29
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.5,30
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.55,31
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.6,32
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.65,33
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.7,34
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.75,36
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.8,37
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.85,39
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.9,42
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.95,45.00555555555555
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.975,56.94722222222222
+2026-05-09,27,1,wk inc covid hosp,2026-05-16,quantile,0.99,67.6
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.01,5.840962110342114
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.025,7.333333333333334
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.05,9.5
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.1,12.26808598267878
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.15,14.526763057011678
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.2,17.1411746439572
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.25,19.195623401140672
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.3,21
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.35,22.66386945856506
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.4,24.703558543915914
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.45,29.09881524017144
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.5,31.675
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.55,32.935
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.6,34.730000000000004
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.65,36.585
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.7,38.019999999999996
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.75,40.07
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.8,42.79
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.85,45.785
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.9,49.28
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.95,55.989999999999995
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.975,62.19666666666667
+2026-05-09,27,2,wk inc covid hosp,2026-05-23,quantile,0.99,78.17448618448219
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.01,5.166666666666667
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.025,6.611111111111111
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.05,8.555555555555555
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.1,11.625816403558375
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.15,14.513892217016156
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.2,16.5
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.25,17.5
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.3,19
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.35,20.5
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.4,23.807482499686067
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.45,26.60345160160438
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.5,30.935
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.55,32.775
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.6,34.66
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.65,36.614999999999995
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.7,38.665
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.75,41.345
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.8,44.225
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.85,47.925
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.9,52.7
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.95,60.385000000000005
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.975,67.4
+2026-05-09,27,3,wk inc covid hosp,2026-05-30,quantile,0.99,83.63132328082632
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.01,5.05
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.025,5.53
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.05,5.98
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.1,7.1705691849160775
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.15,8.124037657225887
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.2,8.962606504341394
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.25,9.951211124791408
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.3,10.615620619030633
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.35,11.362620641809627
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.4,11.661077536365536
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.45,11.941043425604983
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.5,12.142105263157893
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.55,12.523956574395017
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.6,13.015000895007015
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.65,13.52800435819037
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.7,14.447046047636032
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.75,15.390455541875259
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.8,16.212035
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.85,17.037825
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.9,18.215765
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.95,20.250443
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.975,22.347929
+2026-05-09,28,-1,wk inc covid hosp,2026-05-02,quantile,0.99,24.91693
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.01,2.0850013065521296
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.025,3.403450824628426
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.05,4.154999999999999
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.1,5.261791553267139
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.15,6.297562196643176
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.2,7.054148500640792
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.25,7.716097982416067
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.3,8.30348251661612
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.35,8.888043544359867
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.4,9.338929621058316
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.45,10.262115626429466
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.5,11.254772388248881
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.55,11.889463825395602
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.6,12.376261388888889
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.65,13.082840277777777
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.7,13.686172555555554
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.75,14.354923743317734
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.8,15.263479333333333
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.85,16.501936
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.9,17.954863222222222
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.95,21.10110261111111
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.975,23.972779
+2026-05-09,28,0,wk inc covid hosp,2026-05-09,quantile,0.99,26.751776066307222
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.01,1.6790291629261267
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.025,2.8083333333333336
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.05,3.5633333333333335
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.1,4.575
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.15,4.835
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.2,5.5600000000000005
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.25,5.907126958935835
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.3,6.658045091442686
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.35,7.611111111111111
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.4,8.208298351158316
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.45,9.377999325282527
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.5,10.5586445
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.55,11.193489777777778
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.6,11.942911166666667
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.65,12.6688695
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.7,13.393542777777778
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.75,14.476154170000044
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.8,15.839188111111111
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.85,17.453409333333333
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.9,19.550284666666666
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.95,23.151379
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.975,26.839994410320337
+2026-05-09,28,1,wk inc covid hosp,2026-05-16,quantile,0.99,30.506363919615303
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.01,1.6666666666666667
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.025,2.4381093452489697
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.05,3.01
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.1,3.72
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.15,4.29
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.2,4.78
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.25,5.24
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.3,6.663733731158676
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.35,7.777777777777778
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.4,8.883372488604651
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.45,10.018781
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.5,10.740297
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.55,11.523032
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.6,12.358343
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.65,13.192392
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.7,14.211863
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.75,15.354847
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.8,17.115729
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.85,19
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.9,21
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.95,25.555555555555557
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.975,31.667245
+2026-05-09,28,2,wk inc covid hosp,2026-05-23,quantile,0.99,33.45600803362639
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.01,1.3327759237046437
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.025,2.2222222222222223
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.05,2.76
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.1,3.51
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.15,4.1
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.2,4.62
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.25,5.12
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.3,6.304640807196922
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.35,7.666666666666667
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.4,8.6503251
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.45,9.4368045
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.5,10.326801
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.55,11.263867
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.6,12.306359
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.65,13.768138
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.7,14.991657
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.75,16.403923
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.8,18
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.85,19
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.9,22.11111111111111
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.95,28.88888888888889
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.975,36.117315143220885
+2026-05-09,28,3,wk inc covid hosp,2026-05-30,quantile,0.99,39.07946586108598
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.01,15.07
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.025,16.42
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.05,17.391548
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.1,18.489257
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.15,19.155725
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.2,19.754601
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.25,20.284476
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.3,20.773971
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.35,21.218776
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.4,21.713138
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.45,22.171846
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.5,22.541557
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.55,22.978934
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.6,23.458835
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.65,23.894624
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.7,25.94694624876101
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.75,28.561202602539694
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.8,30.52
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.85,31.8
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.9,33.46
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.95,36.05
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.975,38.44
+2026-05-09,29,-1,wk inc covid hosp,2026-05-02,quantile,0.99,41.37
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.01,5.7316179546120605
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.025,9.620059042715397
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.05,11.608333333333334
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.1,12.944444444444445
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.15,14.5
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.2,15.31699790020142
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.25,15.769815316706893
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.3,16.853579293636816
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.35,17.86661604085414
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.4,18.779918024252318
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.45,19.830637822506745
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.5,20.708888260546125
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.55,21.42467907634156
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.6,22.447275834497482
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.65,23.331738361875253
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.7,24.37023427777778
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.75,25.584243555555556
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.8,28.874590868662562
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.85,31.416846186211238
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.9,35.04386336790128
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.95,39.852160425508686
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.975,49.028999428426474
+2026-05-09,29,0,wk inc covid hosp,2026-05-09,quantile,0.99,54.47292658381016
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.01,4.4960333059004665
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.025,7.573462275296089
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.05,9
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.1,11.661990409607917
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.15,13.219196636583192
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.2,14.397504783297194
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.25,15.438483918148805
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.3,16.962039832852618
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.35,17.860704764145183
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.4,18.741185515651072
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.45,19.746437781713368
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.5,20.834227372903293
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.55,21.905971740024363
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.6,23.35389225849714
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.65,25.920672502123445
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.7,26.830953449979685
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.75,29.175502225010536
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.8,33.169466013196214
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.85,35.24431857742272
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.9,37.97614579400941
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.95,43.81420523337205
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.975,57.04194444444444
+2026-05-09,29,1,wk inc covid hosp,2026-05-16,quantile,0.99,70.4157316410701
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.01,3
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.025,7.1018145892864295
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.05,10
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.1,11.273719818045173
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.15,13.333333333333334
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.2,14.444444444444445
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.25,16.059369335785583
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.3,17.433131016929867
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.35,19.03506863908928
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.4,20.210122387074918
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.45,22.044003252170445
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.5,23.918685
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.55,25.560542
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.6,27.204718
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.65,28.699473
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.7,30.616365
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.75,38.89
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.8,41.57
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.85,44.89
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.9,48.38037921744995
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.95,51.407882
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.975,63.74
+2026-05-09,29,2,wk inc covid hosp,2026-05-23,quantile,0.99,81.67666666666666
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.01,2
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.025,7
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.05,9
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.1,11.431219929014071
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.15,12.88888888888889
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.2,14.381185995255986
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.25,17.005234
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.3,18.636276
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.35,20.234815
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.4,21.815244
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.45,23.679283
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.5,25.705782
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.55,28.358283
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.6,30.519683
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.65,37.29
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.7,39.61
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.75,42.24
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.8,45.35
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.85,49.2
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.9,54.43
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.95,63.376526950145305
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.975,82.237333
+2026-05-09,29,3,wk inc covid hosp,2026-05-30,quantile,0.99,100.50163
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.01,1.9210381
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.025,2.2387257
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.05,2.6593898
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.1,3.142565
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.15,3.5367741
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.2,3.9075174
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.25,4.2009705
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.3,4.5068952
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.35,4.7781773
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.4,5.0770992
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.45,5.3433181
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.5,5.6243539
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.55,5.9175858
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.6,6.2820355
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.65,6.675343
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.7,7.0485058
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.75,7.5330617
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.8,8.0535204
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.85,8.634422
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.9,9.6788372
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.95,11.264759
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.975,12.807783
+2026-05-09,30,-1,wk inc covid hosp,2026-05-02,quantile,0.99,14.592883
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.820076502302173
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.025,1.2803051258146794
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.05,2.166666666666667
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.1,2.4444444444444446
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.15,3.1973082
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.2,3.411855051251072
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.25,4.0748616
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.3,4.2831285999999995
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.35,4.950177050000001
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.4,5.406254483333333
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.45,5.6838980285714324
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.5,6.111111111111111
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.55,6.450032828571423
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.6,6.655184123749656
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.65,7.277777777777778
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.7,7.722284999999999
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.75,8.003720300000001
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.8,8.2797365
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.85,9.265204449999999
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.9,10.379408999999999
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.95,11.814131
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.975,13.021971
+2026-05-09,30,0,wk inc covid hosp,2026-05-09,quantile,0.99,15.71597911110106
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.49836694123449743
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.025,0.7617259115808377
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.05,1.6889089656706133
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.1,2.2330175659215343
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.15,3.14444385
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.2,3.3242017500000003
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.25,4.00551125
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.3,4.191985600000001
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.35,4.36937845
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.4,5.06370605
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.45,5.24716405
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.5,6.333333333333334
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.55,6.701017555555556
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.6,7.209054783333333
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.65,7.862037572222222
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.7,8.55991391111111
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.75,9.34068975
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.8,10.2737077
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.85,11.2791685
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.9,12.913562500000001
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.95,14.714255999999999
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.975,16.6427805
+2026-05-09,30,1,wk inc covid hosp,2026-05-16,quantile,0.99,19.215939575521052
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.16946270544544298
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.025,1
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.05,1
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.1,2.309871715927786
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.15,3
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.2,3.4116249
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.25,4
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.3,4.1946916
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.35,4.6462832
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.4,5.555555555555555
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.45,6.111111111111111
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.5,6.666666666666667
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.55,7.222222222222222
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.6,7.666666666666667
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.65,8.444444444444445
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.7,9.11111111111111
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.75,9.88888888888889
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.8,11
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.85,12.88888888888889
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.9,16.22222222222222
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.95,20.77777777777778
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.975,25
+2026-05-09,30,2,wk inc covid hosp,2026-05-23,quantile,0.99,28
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.4444444444444444
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.025,1
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.05,1.3375611025922773
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.1,2
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.15,2.8786806
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.2,3.111111111111111
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.25,3.7777777777777777
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.3,4.2156035
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.35,4.666666666666667
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.4,5.222222222222222
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.45,5.6619089
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.5,6.2275245
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.55,6.888888888888889
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.6,7.555555555555555
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.65,8.222222222222221
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.7,9.333333333333334
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.75,10.222222222222221
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.8,11.555555555555555
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.85,13.444444444444445
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.9,17.444444444444443
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.95,22.338888888888885
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.975,28.613888888888887
+2026-05-09,30,3,wk inc covid hosp,2026-05-30,quantile,0.99,35.19841223571429
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.01,1.6031139
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.025,1.9599007
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.05,2.2285919
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.1,2.5961681
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.15,2.9173735
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.2,3.2299349
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.25,3.4221032
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.3,3.6244096
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.35,3.8037884
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.4,4.0056092
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.45,4.2405438
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.5,4.4622924
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.55,4.7017552
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.6,4.9187018
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.65,5.1862466
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.7,5.667437351516407
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.75,6.328507386805617
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.8,7.304985679916664
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.85,8.537083333333333
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.9,9.5
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.95,10.22
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.975,10.88
+2026-05-09,31,-1,wk inc covid hosp,2026-05-02,quantile,0.99,11.69
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.028997248095698782
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.6403711681633495
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.05,1.2648176090956507
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.1,2
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.15,2.111111111111111
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.2,2.2222222222222223
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.25,2.833333333333333
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.3,3.0555555555555554
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.35,3.458033244976944
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.4,4.0663639499999995
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.45,4.588175837625361
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.5,4.8490075
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.55,5.29547477152526
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.6,5.666666666666666
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.65,5.833333333333334
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.7,6.062394905555555
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.75,6.581383188888889
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.8,7.316047688888888
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.85,8.057289333333333
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.9,9.245229511111111
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.95,11.339761859518063
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.975,12.641819923617009
+2026-05-09,31,0,wk inc covid hosp,2026-05-09,quantile,0.99,15.414213687417021
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.013316533534993413
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.025,0.5036920315567347
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.05,1.2222222222222223
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.1,1.7777777777777777
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.15,1.9444444444444444
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.2,2.111111111111111
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.25,2.7222222222222223
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.3,3.0752447379064884
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.35,3.495059422401681
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.4,4.1475349
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.45,4.390756161111112
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.5,5.065649919047618
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.55,5.6293903
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.6,5.82408075
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.65,6.5167482
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.7,6.833333333333334
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.75,7.190562816666667
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.8,8.222222222222221
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.85,9.14402398888889
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.9,10.693097444444444
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.95,13.328821999999999
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.975,14.966983
+2026-05-09,31,1,wk inc covid hosp,2026-05-16,quantile,0.99,18.253899071420896
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.02411088545606232
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.7777777777777778
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.05,1.1111111111111112
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.1,1.9365437
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.15,2
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.2,2.3333333333333335
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.25,3
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.3,3.2892448480225087
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.35,3.7750987
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.4,4.1188247
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.45,4.4515625
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.5,6
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.55,6
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.6,7
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.65,7
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.7,8
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.75,8
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.8,9
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.85,10.333333333333334
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.9,12.88888888888889
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.95,17.5
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.975,19.51
+2026-05-09,31,2,wk inc covid hosp,2026-05-23,quantile,0.99,22.08
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.07836925415538766
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.10837434448139381
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.05,1
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.1,1.4444444444444444
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.15,2
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.2,2.111111111111111
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.25,2.9126173316081765
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.3,3.129732
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.35,3.4633553
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.4,4
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.45,4.2016588
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.5,6
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.55,7
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.6,7
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.65,8
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.7,8
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.75,9
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.8,10
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.85,11.11111111111111
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.9,14.222222222222221
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.95,19.77777777777778
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.975,22.52
+2026-05-09,31,3,wk inc covid hosp,2026-05-30,quantile,0.99,26.155245
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.01,1.4
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.025,1.58
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.05,1.76
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.1,1.98
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.15,2.8622274926900886
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.2,3.6626602627635796
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.25,4.799271832080267
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.3,5.1681825
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.35,5.5048542
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.4,5.813181
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.45,6.1287634
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.5,6.4387606
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.55,6.8084241
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.6,7.2091096
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.65,7.664278
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.7,8.055637
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.75,8.5815649
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.8,9.0594693
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.85,9.705047
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.9,10.464504
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.95,11.746323
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.975,13.140698
+2026-05-09,32,-1,wk inc covid hosp,2026-05-02,quantile,0.99,14.706734
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.9444444444444444
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.025,1.175
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.05,1.876424577634936
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.1,2.420823861677225
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.15,2.8219168280625535
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.2,3.5098434218306824
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.25,3.9455400761049435
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.3,4.493456587137942
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.35,5.0110239801676055
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.4,5.363062547871563
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.45,5.944444444444445
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.5,6.440462025692917
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.55,6.833333333333334
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.6,7.055555555555555
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.65,7.666666666666666
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.7,8
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.75,8.666666666666668
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.8,9.277777777777779
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.85,10.11111111111111
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.9,11.666666666666668
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.95,15.040557886997917
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.975,17.87145311017045
+2026-05-09,32,0,wk inc covid hosp,2026-05-09,quantile,0.99,22.60242283370959
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.5585394277777778
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.025,1
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.05,1.6524016733805997
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.1,2.366329957610899
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.15,2.9444444444444446
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.2,3.302550797657644
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.25,4
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.3,4.222222222222222
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.35,5
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.4,5.38574859994695
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.45,6.166666666666666
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.5,6.5
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.55,7.333333333333334
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.6,7.611111111111111
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.65,8.38888888888889
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.7,8.7896358373945
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.75,9.53634108176568
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.8,11.08244240878469
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.85,12.046093737376266
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.9,13.77012305513708
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.95,17.155656837774025
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.975,21.118667136014306
+2026-05-09,32,1,wk inc covid hosp,2026-05-16,quantile,0.99,29.25864929348983
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.086184733
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.67450206
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.05,1.5184284868498872
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.1,2.0930907
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.15,2.43
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.2,3.2613384242409147
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.25,3.7777777777777777
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.3,4.555555555555555
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.35,5.222222222222222
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.4,6
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.45,6.7062126
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.5,7.222222222222222
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.55,7.777777777777778
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.6,8.444444444444445
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.65,9
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.7,10.11111111111111
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.75,11.88888888888889
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.8,13.222222222222221
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.85,15.333333333333334
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.9,18.91321
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.95,22.474612996526066
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.975,27.13520735515929
+2026-05-09,32,2,wk inc covid hosp,2026-05-23,quantile,0.99,36.00185536827474
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.1356203926756892
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.35571759
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.05,1
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.1,1.5921103
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.15,2.4548198
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.2,3.2847466
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.25,3.888888888888889
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.3,4.6517169
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.35,5
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.4,5
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.45,7.111111111111111
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.5,7.444444444444445
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.55,8.333333333333334
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.6,8.777777777777779
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.65,9.666666666666666
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.7,11.222222222222221
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.75,13
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.8,15
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.85,17.11111111111111
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.9,22.77777777777778
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.95,27.37565445720005
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.975,31.751553680426934
+2026-05-09,32,3,wk inc covid hosp,2026-05-30,quantile,0.99,44.13687010952426
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.01,3.6273533
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.025,4.1750806
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.05,5.2056381
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.1,6.1844908
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.15,7.0051684
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.2,7.6365746
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.25,8.154501
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.3,8.649058
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.35,9.1399484
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.4,9.6048987
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.45,10.049077
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.5,10.522853
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.55,11.03483
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.6,11.654699
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.65,12.343164
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.7,12.933992
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.75,13.723775
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.8,14.598124
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.85,15.660089
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.9,17.136346
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.95,19.157687
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.975,20.755154
+2026-05-09,33,-1,wk inc covid hosp,2026-05-02,quantile,0.99,23.826145
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.01,1.414493812161596
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.025,2.3582500679181724
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.05,2.8540206564610453
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.1,3.8480751547784564
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.15,4.772806943688517
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.2,5.52834500586704
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.25,5.874818889220144
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.3,7.13285645
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.35,7.433294075167071
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.4,8.036535163690512
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.45,8.558296000913757
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.5,9.125475037950526
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.55,9.749198483047014
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.6,10.390463045220137
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.65,11.115783505621838
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.7,11.873134340492726
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.75,12.701760302254385
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.8,13.815337587464072
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.85,14.537262062438899
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.9,16.500422
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.95,18.177709999999998
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.975,19.416714777777777
+2026-05-09,33,0,wk inc covid hosp,2026-05-09,quantile,0.99,23.643159166666667
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.8888888888888888
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.025,1.6111111111111112
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.05,2.246843833333333
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.1,2.978829619567332
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.15,3.5946544366445057
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.2,4.217882022824291
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.25,4.839000628737109
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.3,5.872993788742858
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.35,6.225489872915626
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.4,6.972083808946062
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.45,7.65200456426447
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.5,8.347015730740061
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.55,9.15652301099264
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.6,10.03817246494383
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.65,11.11499842514409
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.7,11.940831866947569
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.75,13.086267654458824
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.8,14.671690533788638
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.85,15.504822
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.9,17.255172
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.95,19.889741830413527
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.975,22.010934499999998
+2026-05-09,33,1,wk inc covid hosp,2026-05-16,quantile,0.99,26.391483690795184
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.01,1
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.025,1.4901419
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.05,1.9340447
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.1,2.5314921
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.15,3.1436449
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.2,3.6377881
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.25,4.1733245
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.3,5.173445407808331
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.35,6
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.4,7
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.45,8.523861176921855
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.5,9.91794965964624
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.55,10.613119436051836
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.6,12.772789886521663
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.65,14
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.7,15
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.75,16
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.8,17
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.85,18
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.9,20
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.95,23
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.975,26
+2026-05-09,33,2,wk inc covid hosp,2026-05-23,quantile,0.99,29.556666666666665
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.73021932
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.025,1.1029605
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.05,1.5181128
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.1,2.0502120346523824
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.15,2.58313087149984
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.2,3.39693852046629
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.25,4.100994506151525
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.3,5
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.35,6.252088882095256
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.4,7.958343075899902
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.45,9.280848590386816
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.5,10
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.55,11
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.6,12
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.65,13
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.7,14
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.75,15
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.8,16
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.85,18
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.9,20
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.95,23
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.975,27
+2026-05-09,33,3,wk inc covid hosp,2026-05-30,quantile,0.99,32.89111111111111
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.01,42.56
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.025,45.22
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.05,47.63
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.1,54.525725631103235
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.15,57.610642430714975
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.2,61.10701809042497
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.25,63.59558
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.3,64.598164
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.35,65.493585
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.4,66.529895
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.45,67.434061
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.5,68.249456
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.55,69.245021
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.6,70.064702
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.65,71.110757
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.7,72.262403
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.75,73.350028
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.8,74.666052
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.85,76.114212
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.9,78.195384
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.95,81.490373
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.975,84.293598
+2026-05-09,34,-1,wk inc covid hosp,2026-05-02,quantile,0.99,88.32
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.01,27.48298107188053
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.025,31.611111111111114
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.05,36.82388888888889
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.1,41.32666270238671
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.15,45.87249243228095
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.2,49
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.25,51.039850212501236
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.3,53.33462642740046
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.35,55.520677712486304
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.4,57.57400722962477
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.45,59.58444907775696
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.5,62.02717320583099
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.55,64.10792460616
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.6,65.96770737461418
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.65,68.05826941588153
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.7,70.87290045426536
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.75,73.6929785938907
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.8,77.63981401469006
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.85,87.0011337346462
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.9,90.7762955
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.95,96.2101615
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.975,105.118275
+2026-05-09,34,0,wk inc covid hosp,2026-05-09,quantile,0.99,125.2508761111111
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.01,22.291111111111114
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.025,27.104166666666668
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.05,31.776111111111113
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.1,36.64069239099541
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.15,42.111111111111114
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.2,45.266666666666666
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.25,47.77777777777778
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.3,50.20046836576611
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.35,53.069104050166466
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.4,55.50687864682321
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.45,57.50037612220858
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.5,59.85622611308375
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.55,62.05749488136345
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.6,64.82079710083565
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.65,67.92701179528424
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.7,71.0357217638144
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.75,75.331071500373
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.8,78.91775235646583
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.85,83.99699521169407
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.9,96.11551213228302
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.95,113.39687905646379
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.975,126.68079373993133
+2026-05-09,34,1,wk inc covid hosp,2026-05-16,quantile,0.99,152.7738088174106
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.01,21.01
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.025,24.46
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.05,28.105555555555554
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.1,34.099999999999994
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.15,40
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.2,43
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.25,46
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.3,49
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.35,51
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.4,54
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.45,56
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.5,58
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.55,61
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.6,64
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.65,67
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.7,70
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.75,82.98134014186827
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.8,108.36884
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.85,115.45977
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.9,126.35859
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.95,138.77213405576816
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.975,155.95012279152073
+2026-05-09,34,2,wk inc covid hosp,2026-05-23,quantile,0.99,187.62995
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.01,17
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.025,20.444444444444443
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.05,25.11111111111111
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.1,30.444444444444443
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.15,36
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.2,41
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.25,44
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.3,47
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.35,49
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.4,52
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.45,54
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.5,57.63568511223493
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.55,67.77437558869833
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.6,78.0486142715615
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.65,88
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.7,95
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.75,104
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.8,114
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.85,128
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.9,145
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.95,163.1106392024163
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.975,181.09631077706575
+2026-05-09,34,3,wk inc covid hosp,2026-05-30,quantile,0.99,227
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0.96139556
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.025,1.207715
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.05,1.4966151
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.1,1.9132549
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.15,2.251044
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.2,2.5442751
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.25,2.8095138
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.3,3.0472298
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.35,3.2730853
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.4,3.5538013
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.45,3.7805617
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.5,3.9872361
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.55,4.2023838
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.6,4.4662367
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.65,4.8201989
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.7,5.119614
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.75,6.23664528769758
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.8,7.746659033999647
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.85,8.76
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.9,9.33
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.95,10.23
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.975,11.07
+2026-05-09,35,-1,wk inc covid hosp,2026-05-02,quantile,0.99,12.11
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.017786040747459434
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.5294421683345849
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.05,0.9429359020749649
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.1,1.2850050265761932
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.15,1.8888888888888888
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.2,2.0555555555555554
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.25,2.292739014698415
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.3,3.0079908267636073
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.35,3.2903166055555557
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.4,3.5966215524414165
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.45,4
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.5,4.055555555555555
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.55,4.829032183333334
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.6,4.959894046675058
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.65,5.416248891876139
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.7,6.0079793171469245
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.75,6.604195385641551
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.8,7.423554011111111
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.85,8.419082472846029
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.9,9.753272194444445
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.95,11.951360471377878
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.975,13.755498139544247
+2026-05-09,35,0,wk inc covid hosp,2026-05-09,quantile,0.99,16.021820213023855
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.01113519472517708
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.025,0.3558250728084219
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.8837262487491933
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.1,1.2777777777777777
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.15,2.04010575
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.2,2.2111111111111117
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.25,2.5
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.3,3.0555555555555554
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.35,3.1407538081872994
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.4,3.6340695611820504
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.45,4.136941599870441
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.5,4.845226707541613
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.55,5.295059649689254
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.6,5.890702771424988
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.65,6.35193674650096
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.7,7.122026822222223
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.75,7.755477844444445
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.8,8.722235307115426
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.85,10.095301917211838
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.9,12.291244333333333
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.95,15.079364361917012
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.975,17.625218993271545
+2026-05-09,35,1,wk inc covid hosp,2026-05-16,quantile,0.99,21.023043054339144
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.04065408727376437
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.07865844510573841
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.05,0.90177156
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.1,1.7260691
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.15,2
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.2,2.4444444444444446
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.25,2.7777777777777777
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.3,3
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.35,3.4068645589300863
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.4,4
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.45,5.112893655619052
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.5,6.173695807491458
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.55,7.017978573269996
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.6,8.1319831
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.65,8.5064069367417
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.7,9.815443781013693
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.75,10.475854478136288
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.8,11.394119979614919
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.85,12.561054055218825
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.9,14.79
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.95,18.207804089975916
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.975,25.05833333333333
+2026-05-09,35,2,wk inc covid hosp,2026-05-23,quantile,0.99,27.546048304005947
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.030379415
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.13165942150255047
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.68714142
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.1,1
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.15,2
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.2,2
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.25,3
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.3,3.0012613508822374
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.35,3.83333628361991
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.4,4.074608253914709
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.45,6.457529129622301
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.5,7.5362340199564954
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.55,7.743717084815964
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.6,9.172940805839994
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.65,9.241739582388545
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.7,11.044496026554095
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.75,11.573021393650043
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.8,13.020429615345925
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.85,14.09076034604903
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.9,17.08
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.95,21.11111111111111
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.975,26.88960365987735
+2026-05-09,35,3,wk inc covid hosp,2026-05-30,quantile,0.99,34.12576330294199
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.01,94.92
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.025,100.34
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.05,105.21
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.1,113.52935001859085
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.15,120.6948491240493
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.2,126.15457386176627
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.25,132.66215739259007
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.3,138.01934461889397
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.35,142.06483886262743
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.4,143.47296187918008
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.45,145.279616179288
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.5,146.11578947368417
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.55,149.4114949318231
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.6,153.18507733650617
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.65,157.46016113737255
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.7,162.71806
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.75,164.77858
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.8,166.98762
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.85,169.67732
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.9,172.7396
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.95,178.05061
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.975,181.05744
+2026-05-09,36,-1,wk inc covid hosp,2026-05-02,quantile,0.99,185.6852
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.01,66.10261791965395
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.025,79.16318941182698
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.05,90.67288451311134
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.1,100.71666666666667
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.15,106.76944444444445
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.2,111.16666666666666
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.25,114.70833333333334
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.3,118.5
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.35,121.38888888888889
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.4,125.0222222222223
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.45,128.47605285748162
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.5,136
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.55,139.5238134960241
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.6,143.30554774184836
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.65,146.68693159028555
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.7,151.83495107698428
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.75,156.97406282854985
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.8,163.6633510642955
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.85,168.0458391309529
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.9,177.73241500000017
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.95,191.9574711111111
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.975,209.3398561111111
+2026-05-09,36,0,wk inc covid hosp,2026-05-09,quantile,0.99,237.67771064365215
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.01,54.72026382085188
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.025,69.49636421626107
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.05,78.94444444444444
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.1,88.55
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.15,95.27777777777777
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.2,99.93333333333334
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.25,104.16666666666666
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.3,108.77777777777777
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.35,112.38888888888889
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.4,119.5
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.45,123.5
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.5,127
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.55,132
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.6,136.05370700221363
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.65,141.98627053901083
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.7,147.37753363449218
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.75,155.69827720405777
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.8,163.13392272388413
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.85,172.9341083050645
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.9,187.40131559002262
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.95,207.20938339703625
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.975,233.12619
+2026-05-09,36,1,wk inc covid hosp,2026-05-16,quantile,0.99,274.3312872222222
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.01,46
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.025,58.77777777777778
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.05,69.4388888888889
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.1,80.77777777777777
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.15,87.76111111111112
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.2,93.22222222222223
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.25,97.11111111111111
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.3,102.11111111111111
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.35,109
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.4,114
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.45,119
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.5,124
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.55,128
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.6,134
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.65,139
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.7,145
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.75,152
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.8,160.90072503326684
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.85,176.62083399244747
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.9,198.93663113766672
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.95,236.35996862506008
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.975,267.0388485104266
+2026-05-09,36,2,wk inc covid hosp,2026-05-23,quantile,0.99,322.93468
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.01,39.65503818758576
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.025,55.05277777777778
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.05,65.55000000000001
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.1,75.1
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.15,82.53888888888889
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.2,87.3111111111111
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.25,94.39647629158716
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.3,100
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.35,105
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.4,110
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.45,115
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.5,121
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.55,126
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.6,131
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.65,137
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.7,143
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.75,150
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.8,159
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.85,175.48798587419327
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.9,200.85886972183908
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.95,233.9128829165349
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.975,281.03849330619096
+2026-05-09,36,3,wk inc covid hosp,2026-05-30,quantile,0.99,388.4318427396863
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.01,49.594378
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.025,54.993754
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.05,59.758528
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.1,65.738601
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.15,69.449374
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.2,72.379362
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.25,75.181095
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.3,77.93102
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.35,80.726698
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.4,83.11941
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.45,85.628403
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.5,87.973302
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.55,90.316833
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.6,92.769738
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.65,95.646431
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.7,98.185001
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.75,101.15225
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.8,104.04487
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.85,108.29647
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.9,113.28631
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.95,120.57938
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.975,129.47067345127226
+2026-05-09,37,-1,wk inc covid hosp,2026-05-02,quantile,0.99,135.8191282891518
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.01,33.220787033666895
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.025,39.07038902883065
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.05,44.41832839611004
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.1,53.907945130558076
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.15,58.19279148852539
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.2,61.85013953574165
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.25,65.05306031543645
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.3,68.8528570013005
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.35,72.13958522675122
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.4,75.40529412920822
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.45,78.63653743345373
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.5,81.8384379784394
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.55,85.04078355423765
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.6,88.6628031828512
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.65,92.4449047072556
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.7,95.08546999615072
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.75,98.67544349388508
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.8,101.44155766309868
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.85,104.13949709860437
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.9,111.22683231457573
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.95,118.87128290473439
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.975,127.95296256545222
+2026-05-09,37,0,wk inc covid hosp,2026-05-09,quantile,0.99,148.98055555555555
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.01,23.97854795780019
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.025,29.54200121657245
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.05,34.84099215620857
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.1,42.51988193996772
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.15,47.21269917062345
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.2,52.971764
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.25,58.824296270641725
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.3,62.00138335784116
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.35,68.9006320914192
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.4,72.70592661978411
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.45,78.00293139555245
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.5,82.68900780742823
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.55,87.75570881705596
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.6,93.00487822845673
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.65,97.28456626426271
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.7,102.15794266351142
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.75,107.11509313861367
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.8,111.345
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.85,116.86500000000001
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.9,122.28978016628263
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.95,131.53167196019484
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.975,145.87526434434983
+2026-05-09,37,1,wk inc covid hosp,2026-05-16,quantile,0.99,169.71646345679596
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.01,12.666666666666666
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.025,20.989427764921764
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.05,27.966093903994278
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.1,40.64023771506295
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.15,48
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.2,51
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.25,54
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.3,57
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.35,61.913614
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.4,68.935663
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.45,75.618811
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.5,82
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.55,86
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.6,92.08
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.65,95.48
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.7,100
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.75,105
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.8,112
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.85,120
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.9,131
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.95,147
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.975,162
+2026-05-09,37,2,wk inc covid hosp,2026-05-23,quantile,0.99,189.25919464521937
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.01,11.666666666666666
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.025,17.31696219762195
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.05,25.391785381372394
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.1,38
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.15,44
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.2,48
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.25,51
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.3,54
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.35,59.471423
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.4,65
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.45,69
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.5,74
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.55,79
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.6,91.64
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.65,95.41
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.7,99.51
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.75,104.1
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.8,110
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.85,120
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.9,133
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.95,155
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.975,175
+2026-05-09,37,3,wk inc covid hosp,2026-05-30,quantile,0.99,207.89654147706202
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.01,1.48
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.025,1.65
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.05,1.9703563
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.1,2.4864326
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.15,2.9262279
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.2,3.2151318
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.25,3.5492151
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.3,3.8062204
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.35,4.1048266
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.4,4.4098293
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.45,4.7196706
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.5,5.027073
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.55,5.132803339593871
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.6,5.285806252088253
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.65,5.437366611709545
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.7,5.768997611445611
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.75,6.045408119638675
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.8,6.40147445349943
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.85,6.908628969054766
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.9,7.559286555284578
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.95,8.682543296308435
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.975,9.633314724904277
+2026-05-09,38,-1,wk inc covid hosp,2026-05-02,quantile,0.99,10.133366642720247
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.6400653933333333
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.9825508199999999
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.05,1.2196852055555556
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.1,1.81471585
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.15,1.95
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.2,2.514957406827617
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.25,2.915823731665997
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.3,3
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.35,3.4143379140366994
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.4,3.9842388919176317
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.45,4
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.5,4.723192410215589
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.55,5.005353487781004
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.6,5.182645336623214
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.65,5.86354547700992
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.7,6.148211145487284
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.75,6.910461501265612
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.8,7.2823484999999994
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.85,8.178741200000001
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.9,9
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.95,10.48687
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.975,12
+2026-05-09,38,0,wk inc covid hosp,2026-05-09,quantile,0.99,14.001666666666665
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.1527227332904491
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.025,0.5811357433333333
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.958266975
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.1,1.1668180525771632
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.15,1.7581081833333334
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.2,2
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.25,2.10973498306775
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.3,2.56729864128235
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.35,3.059155176477814
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.4,3.2756973641479004
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.45,4.055823942835533
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.5,4.26284885
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.55,4.535552355555556
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.6,5.2251358
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.65,5.4518714500000005
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.7,6.2000326
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.75,6.5
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.8,7.4795801
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.85,8.5
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.9,9.11111111111111
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.95,11.277777777777779
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.975,13.555555555555555
+2026-05-09,38,1,wk inc covid hosp,2026-05-16,quantile,0.99,15.69448636424536
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.26983719
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.05,0.8888888888888888
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.1,1.080334
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.15,1.3333333333333333
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.2,1.8888888888888888
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.25,1.983359519944239
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.3,2.6183590930606404
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.35,2.88
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.4,3.09
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.45,3.819408593155074
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.5,4.5023483
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.55,5
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.6,5.574416
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.65,6
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.7,6.6808186
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.75,7
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.8,8
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.85,8
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.9,9.222222222222221
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.95,12.11111111111111
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.975,15.555555555555555
+2026-05-09,38,2,wk inc covid hosp,2026-05-23,quantile,0.99,16.95183043900274
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.14137032990724518
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.34326457
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.1,0.89007089
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.15,1.2222222222222223
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.2,1.4444444444444444
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.25,1.8888888888888888
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.3,2.5182960685907947
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.35,2.820846122857973
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.4,3.5370468
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.45,3.9359639
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.5,4.3978068
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.55,5
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.6,5.7725635
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.65,6
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.7,7
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.75,7
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.8,8
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.85,8
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.9,10.11111111111111
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.95,13.227777777777773
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.975,16.94722222222222
+2026-05-09,38,3,wk inc covid hosp,2026-05-30,quantile,0.99,18.718816777361337
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.01,28.53
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.025,31.4
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.05,34.07
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.1,36.816298
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.15,38.665011
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.2,40.116609
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.25,41.349694
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.3,42.532024
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.35,43.518782
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.4,44.755551
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.45,45.785852
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.5,46.75691
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.55,47.683052000000004
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.6,49.087574
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.65,50.29544
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.7,54.62935524750817
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.75,59.8496136155422
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.8,62.54
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.85,65.43
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.9,69.21
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.95,75.16
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.975,80.65
+2026-05-09,39,-1,wk inc covid hosp,2026-05-02,quantile,0.99,87.45
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.01,12.222222222222221
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.025,19
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.05,23.22222222222222
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.1,28.54444444444444
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.15,31.203230701633004
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.2,35.269898814330254
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.25,38.92788169874333
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.3,41.96849550817889
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.35,45.20583604381921
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.4,48.587659787147444
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.45,51.262486
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.5,54.566482320598325
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.55,57.26026898975328
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.6,60.81438658425176
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.65,64.24943525449241
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.7,66
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.75,69.335101
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.8,73.641175
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.85,79.689189
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.9,84.65116698775064
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.95,87.66666666666667
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.975,109.87697
+2026-05-09,39,0,wk inc covid hosp,2026-05-09,quantile,0.99,123.45589276026439
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.01,10.333333333333334
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.025,17
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.05,20
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.1,26.87148948226678
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.15,30.555555555555557
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.2,34.249791
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.25,37.796563
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.3,41.996021
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.35,45.899746
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.4,50.067557
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.45,53.608291
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.5,64.53999347619049
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.55,69.36541794603409
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.6,74.04561077640645
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.65,79.22
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.7,83.36
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.75,86.751893
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.8,93.46
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.85,100
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.9,109.13
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.95,116.56280732679586
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.975,137.52
+2026-05-09,39,1,wk inc covid hosp,2026-05-16,quantile,0.99,171.5722222222222
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.01,8.078092168030004
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.025,15.666666666666666
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.05,19
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.1,24.444444444444443
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.15,28.444444444444443
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.2,32.333333333333336
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.25,35.536917
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.3,40.585007
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.35,45.364067
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.4,49.992996
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.45,55.603369
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.5,72.1908716904762
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.55,74.61807779601767
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.6,86.25
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.65,90.93
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.7,98.050221
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.75,103.33347321906022
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.8,122
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.85,130
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.9,138.8862052483014
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.95,150.20916850285633
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.975,174
+2026-05-09,39,2,wk inc covid hosp,2026-05-23,quantile,0.99,192.22444444444443
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.01,7.29100668057636
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.025,14.777777777777779
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.05,18.37930957898765
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.1,23.555555555555557
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.15,26.555555555555557
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.2,30.444444444444443
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.25,33.333333333333336
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.3,37.655128
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.35,44.58251
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.4,54.17736590031719
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.45,73.89965262835199
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.5,82.95743490635229
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.55,90.74
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.6,95.76
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.65,101.19
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.7,108.19526966536957
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.75,114
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.8,135.84382077765682
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.85,154.0474322219577
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.9,154.10363878436914
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.95,173.70436534106005
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.975,218
+2026-05-09,39,3,wk inc covid hosp,2026-05-30,quantile,0.99,240
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.01,2.2500924
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.025,2.8532156
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.05,3.2704571
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.1,3.8366303
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.15,4.2611799
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.2,4.6790695
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.25,5.0542022
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.3,5.4004894
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.35,5.6807066
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.4,5.9623934
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.45,6.3229412
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.5,6.6361104
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.55,6.9965704614282265
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.6,7.7333336282273795
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.65,8.634065399774414
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.7,9.2
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.75,9.61
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.8,10.09
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.85,10.66
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.9,11.43
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.95,12.65
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.975,13.79
+2026-05-09,40,-1,wk inc covid hosp,2026-05-02,quantile,0.99,15.266095
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.6979053427976936
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.025,1.5834135687241995
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.05,2.4597582222222223
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.1,3.233261616666667
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.15,3.7215044944444444
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.2,4.252292422222222
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.25,4.692360094444444
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.3,5.07635215914429
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.35,5.860344311893047
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.4,6.438349758576848
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.45,7.0549511768568465
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.5,7.811725610346885
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.55,8.295008551023319
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.6,9.027391985320646
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.65,9.61111111111111
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.7,10.38888888888889
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.75,11.37888888888889
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.8,11.722222222222221
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.85,12.722222222222221
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.9,14.545
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.95,16.625
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.975,18.665
+2026-05-09,40,0,wk inc covid hosp,2026-05-09,quantile,0.99,22.762636599804836
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.48075021531576734
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.025,1.1188403813229506
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.05,1.9286712000000001
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.1,2.7741492
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.15,3.0985499
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.2,3.90984015
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.25,4.1963817
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.3,4.833940785038806
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.35,5.687299670389139
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.4,6.894517374143799
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.45,7.7641528436576674
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.5,8.333333333333334
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.55,9.11111111111111
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.6,9.61111111111111
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.65,10.5
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.7,11
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.75,11.944444444444445
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.8,13.166666666666668
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.85,14.53857
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.9,17.072490055555555
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.95,20.588832500000002
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.975,23.952177
+2026-05-09,40,1,wk inc covid hosp,2026-05-16,quantile,0.99,29.1519225
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.56898613
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.94905003
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.05,1.3825896
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.1,2.1732232
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.15,2.9067407
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.2,3.6358492
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.25,4.795033924049379
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.3,5.777777777777778
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.35,6.222222222222222
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.4,6.777777777777778
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.45,7.555555555555555
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.5,9
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.55,10
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.6,10.446294
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.65,11.64679
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.7,13.014996
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.75,14.789061
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.8,16.798014
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.85,19.376421
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.9,22.47
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.95,26.6434666596203
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.975,33.931498
+2026-05-09,40,2,wk inc covid hosp,2026-05-23,quantile,0.99,41.102448
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.17317252157846763
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.75102753
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.05,1.2799371
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.1,2.1814661
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.15,2.9735485
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.2,3.995401397968713
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.25,5.333333333333333
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.3,5.888888888888889
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.35,6.606547
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.4,7.5893831
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.45,8.801246
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.5,10.130138
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.55,11.357003
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.6,13.114556
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.65,14.86248
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.7,16.478359
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.75,19.186628
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.8,22.049322
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.85,25.526851
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.9,28.649404346132794
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.95,32
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.975,42.61388888888889
+2026-05-09,40,3,wk inc covid hosp,2026-05-30,quantile,0.99,58.22999999999999
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.01,2.5087181
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.025,3.1529615
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.05,3.41
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.1,3.7
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.15,3.91
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.2,4.08
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.25,4.362268411882068
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.3,5.2597363471096665
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.35,6.162060522929538
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.4,6.5658102594755885
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.45,6.940885982641284
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.5,7.205263157894736
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.55,7.771891795136492
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.6,8.482817191504802
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.65,9.47231447707046
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.7,10.187721
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.75,10.762192
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.8,11.371565
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.85,12.183229
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.9,13.231427
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.95,14.585447
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.975,15.745853
+2026-05-09,41,-1,wk inc covid hosp,2026-05-02,quantile,0.99,17.110415
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.01,1.2222222222222223
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.025,1.3888888888888888
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.05,2.4871402025562883
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.1,3.1994768818720365
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.15,3.7922639981064994
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.2,4.384247424976346
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.25,4.919523495517195
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.3,5.788905891371149
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.35,6.166666666666666
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.4,7
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.45,7.197222222222223
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.5,7.944444444444445
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.55,8
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.6,8.333333333333332
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.65,8.886399968009748
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.7,9.277777777777779
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.75,10.166666666666668
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.8,11.222222222222221
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.85,12.166666666666668
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.9,14.033993293092813
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.95,17.588984266289952
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.975,20.385401640589016
+2026-05-09,41,0,wk inc covid hosp,2026-05-09,quantile,0.99,24.39089757813139
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.6137683390892859
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.025,1.4444444444444444
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.05,2.2260270239216706
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.1,2.9412698488519737
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.15,3.645
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.2,4.577238933691902
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.25,5.465704672401047
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.3,6.333333333333334
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.35,6.666666666666666
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.4,7.263899391319544
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.45,7.833333333333333
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.5,8.136993168571431
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.55,8.96100175366075
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.6,9.290628828397454
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.65,10
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.7,11.298786495943508
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.75,12.444444444444445
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.8,13.622222222222224
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.85,14.38888888888889
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.9,16.77777777777778
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.95,20.44249591099137
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.975,23.167828835310935
+2026-05-09,41,1,wk inc covid hosp,2026-05-16,quantile,0.99,26.378268520210312
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.22135076005580737
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.025,1
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.05,1.646606361447504
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.1,2.836827887965431
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.15,3.22
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.2,4.910079643944147
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.25,6.222222222222222
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.3,7.222222222222222
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.35,7.777777777777778
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.4,8.555555555555555
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.45,9.333333333333334
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.5,9.777777777777779
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.55,10.444444444444445
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.6,11.11111111111111
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.65,11.777777777777779
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.7,13.527388662391118
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.75,14.443386682459128
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.8,15.444444444444445
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.85,17.666666666666668
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.9,22.22222222222222
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.95,31
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.975,40.623984
+2026-05-09,41,2,wk inc covid hosp,2026-05-23,quantile,0.99,42.01565757619047
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.2403769004945253
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.025,1
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.05,1.3952363849488345
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.1,2.84
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.15,3.78297798994392
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.2,5.493527196309227
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.25,6.555555555555555
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.3,7.333333333333333
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.35,8.11111111111111
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.4,8.88888888888889
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.45,9.777777777777779
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.5,11.475859264066688
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.55,14
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.6,15
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.65,16
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.7,17
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.75,18
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.8,20
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.85,22
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.9,25.08612209626525
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.95,34.82230292451112
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.975,46.67222222222222
+2026-05-09,41,3,wk inc covid hosp,2026-05-30,quantile,0.99,54.480241930733314
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.01,69.37222598337434
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.025,75.91982669625231
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.05,87.065877
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.1,92.69459
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.15,96.721422
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.2,99.913423
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.25,102.60629
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.3,105.32893
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.35,107.94042
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.4,110.24363
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.45,112.49391
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.5,114.8077
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.55,116.98956
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.6,119.17199
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.65,121.61746
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.7,124.1255
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.75,127.60103
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.8,131.28932
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.85,135.87104
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.9,140.4835
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.95,148.11359
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.975,156.76059
+2026-05-09,42,-1,wk inc covid hosp,2026-05-02,quantile,0.99,165.09605
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.01,44.88333333333333
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.025,53.06944444444444
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.05,60.20912018441014
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.1,71.11523618197819
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.15,78.69603135784338
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.2,84.81703793738139
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.25,88.76314127777778
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.3,92.07600838888888
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.35,95.4926462358096
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.4,98.46278566666666
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.45,107.38888888888889
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.5,110.15829798576563
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.55,113.92591743677553
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.6,117.7614646188266
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.65,122.07757976946398
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.7,126.64833829573554
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.75,131.19910994436663
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.8,137.69776501084948
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.85,144.5
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.9,152.5
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.95,163
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.975,175.81805555555553
+2026-05-09,42,0,wk inc covid hosp,2026-05-09,quantile,0.99,199.55666666666667
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.01,33.617777777777775
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.025,40.55361111111111
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.05,48.302741999999995
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.1,58.09220596758044
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.15,66.81539932718731
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.2,71.72223883333334
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.25,75.60537144444444
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.3,79.66522172222221
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.35,83.38170644444443
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.4,87.56286921497193
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.45,92.96719971410747
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.5,102.85716257570076
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.55,106.85912523127624
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.6,112.4038114197244
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.65,117.83111091499674
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.7,123.10065399119122
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.75,129.9155788073294
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.8,136.25118651545557
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.85,143.08690637049344
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.9,155.412831141756
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.95,180.02808413091307
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.975,203.85587214953168
+2026-05-09,42,1,wk inc covid hosp,2026-05-16,quantile,0.99,241.22555555555556
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.01,27.64
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.025,33.53
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.05,39.41
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.1,49.025693
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.15,54.605404
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.2,60.391472
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.25,65
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.3,71
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.35,76.11111111111111
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.4,84
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.45,91
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.5,97
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.55,105
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.6,113
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.65,122
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.7,127
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.75,132
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.8,139.20000000000027
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.85,147
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.9,158.58340007335804
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.95,190.8483066749282
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.975,217.28709328007315
+2026-05-09,42,2,wk inc covid hosp,2026-05-23,quantile,0.99,292.6755573315806
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.01,20.393021
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.025,26.357393
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.05,32.997523
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.1,44.48630103611333
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.15,52.55555555555556
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.2,57.77777777777778
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.25,61.888888888888886
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.3,67.07777777777778
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.35,76.12
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.4,81.22
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.45,86.41
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.5,91.8
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.55,97.46
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.6,105
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.65,115
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.7,124
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.75,131
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.8,137
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.85,147.8
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.9,164.52
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.95,192.15
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.975,226.65492813579118
+2026-05-09,42,3,wk inc covid hosp,2026-05-30,quantile,0.99,327.6488442291461
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.01,2.6653306
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.025,3.0742183
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.05,3.4865003
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.1,3.9672987
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.15,4.3626988
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.2,4.6577357
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.25,4.935106
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.3,5.1997703
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.35,5.4194316
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.4,5.6322837
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.45,5.868152
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.5,6.1084592
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.55,6.377891
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.6,6.6527182
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.65,7.0245743
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.7,7.3331375
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.75,7.7946008
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.8,8.2010596
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.85,8.61
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.9,8.99
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.95,9.57
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.975,10.926676933089103
+2026-05-09,44,-1,wk inc covid hosp,2026-05-02,quantile,0.99,11.589215221806672
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.9444444444444444
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.025,1.1642360677632517
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.05,1.8811822536446394
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.1,2.628675597213719
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.15,2.9861950443631193
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.2,3.610068805981113
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.25,3.716635297682391
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.3,3.833333333333333
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.35,4.483146874881915
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.4,4.624026975301398
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.45,5
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.5,5.9617928
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.55,6
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.6,6.3850584571102775
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.65,6.888970811164388
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.7,7.1538913
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.75,7.84858735
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.8,8.622209250000001
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.85,8.910148249999999
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.9,9.8249369
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.95,11.514444444444445
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.975,12.5935705
+2026-05-09,44,0,wk inc covid hosp,2026-05-09,quantile,0.99,14.434812
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.8333333333333333
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.025,1
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.05,1.6715642287636423
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.1,2
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.15,2.7222222222222223
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.2,2.833333333333333
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.25,3.0555555555555554
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.3,3.666666666666667
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.35,3.7777777777777777
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.4,4
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.45,4.428343351865028
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.5,5.095544805082277
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.55,5.627971340585379
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.6,5.861180455675103
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.65,6.515174755555556
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.7,7.185177899999999
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.75,7.9303709
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.8,8.74768995
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.85,9.696524
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.9,10.689361944444444
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.95,12.362128
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.975,13.958218500000001
+2026-05-09,44,1,wk inc covid hosp,2026-05-16,quantile,0.99,16.012615500000003
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.5555555555555556
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.025,1
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.05,1
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.1,2
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.15,2.3333333333333335
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.2,2.5555555555555554
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.25,3
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.3,3.111111111111111
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.35,3.381113623176196
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.4,4.261954931857306
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.45,5
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.5,5
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.55,6
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.6,6
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.65,7
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.7,7.8684727
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.75,8.5035122
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.8,9.3489032
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.85,10.490454
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.9,11.5
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.95,14.005555555555551
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.975,16.451359
+2026-05-09,44,2,wk inc covid hosp,2026-05-23,quantile,0.99,20.345141
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.17353155459653313
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.025,1
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.05,1
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.1,1.8888888888888888
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.15,2
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.2,2.6444444444444457
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.25,2.7777777777777777
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.3,3.111111111111111
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.35,3.4120959860905278
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.4,4
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.45,5
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.5,5
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.55,6
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.6,6.832652342462424
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.65,7
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.7,7.795778221862262
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.75,9.13
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.8,9.77
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.85,10.57
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.9,11.777777777777779
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.95,15
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.975,18.909465
+2026-05-09,44,3,wk inc covid hosp,2026-05-30,quantile,0.99,22.275861172241328
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.01,19.444277
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.025,21.367797
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.05,22.500739
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.1,24.176866
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.15,25.396894
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.2,26.254897
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.25,27.219668
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.3,28.017327
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.35,28.897791
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.4,29.666622
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.45,30.279709
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.5,30.869319
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.55,31.598601
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.6,32.365969
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.65,33.120287
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.7,34.039663
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.75,35.211209
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.8,36.562983
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.85,38.13841084867228
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.9,41.01666227584469
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.95,45.47
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.975,47.24
+2026-05-09,45,-1,wk inc covid hosp,2026-05-02,quantile,0.99,50.080047
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.01,8.642584098738162
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.025,11.730965732334912
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.05,14.63141198255019
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.1,17.803164940061524
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.15,19.790492347546774
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.2,21.658886240355578
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.25,23.00824259131442
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.3,24.50420148024802
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.35,25.894094891330276
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.4,30.573925848517764
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.45,31.606355501129002
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.5,33.91511631765398
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.55,35.583052059954326
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.6,36.98652045661389
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.65,37.94309733960644
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.7,39.26665612720734
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.75,40.765
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.8,41.885000000000005
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.85,43.125
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.9,44.59
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.95,47.80590003329121
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.975,52.8625
+2026-05-09,45,0,wk inc covid hosp,2026-05-09,quantile,0.99,65.93937133166887
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.01,7.388333333333334
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.025,10.166666666666668
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.05,12.333333333333332
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.1,15.94809392749707
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.15,18.598791972296
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.2,20.960108921898822
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.25,23.013761602978292
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.3,24.657010796848567
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.35,26.13051291574246
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.4,31.007468444644665
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.45,31.94566708229388
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.5,34.49587773233468
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.55,35.701511203420395
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.6,36.28175683890613
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.65,40.93
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.7,42.065
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.75,43.769999999999996
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.8,45.585
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.85,47.565
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.9,49.85
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.95,53.864999999999995
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.975,59.40138888888882
+2026-05-09,45,1,wk inc covid hosp,2026-05-16,quantile,0.99,75
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.01,6.111111111111111
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.025,8.4795536
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.05,11
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.1,13.11111111111111
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.15,17.8817339730855
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.2,21.443262945444175
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.25,25.36444229581298
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.3,28.686629478172463
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.35,30.55
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.4,31.74
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.45,32.92
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.5,40
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.55,42
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.6,44
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.65,45
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.7,47
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.75,50
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.8,52
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.85,55
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.9,59
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.95,65
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.975,70
+2026-05-09,45,2,wk inc covid hosp,2026-05-23,quantile,0.99,85.44777777777777
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.01,5.444444444444445
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.025,7.719444444444444
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.05,9.6530492
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.1,13.133242783582364
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.15,18.595131143427338
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.2,22.67030806827904
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.25,26.815433595136238
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.3,29.69
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.35,31.03
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.4,32.34
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.45,37
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.5,39
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.55,41
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.6,43
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.65,45
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.7,47
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.75,50
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.8,53
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.85,56
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.9,61
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.95,69
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.975,75
+2026-05-09,45,3,wk inc covid hosp,2026-05-30,quantile,0.99,94.57333333333332
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0.17537799
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.05,0.384883
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.1,0.5068226424627981
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.15,0.8372039204195121
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.2,1.0902278419907756
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.25,1.3790815099877136
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.3,1.5397703
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.35,1.7209731
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.4,1.9021191
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.45,2.0186865951153212
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.5,2.063157894736842
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.55,2.195757849329123
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.6,2.352496416921304
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.65,2.5883391955151573
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.7,2.985750107076871
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.75,3.4459184900122852
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.8,3.9572796
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.85,4.4580985
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.9,5.174995539355383
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.95,6.3553089
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.975,7.451054
+2026-05-09,46,-1,wk inc covid hosp,2026-05-02,quantile,0.99,8.23417131632899
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.01,0
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.025,0
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.05,0.20208718486018912
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.1,0.5085161728794734
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.15,0.6634917483333334
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.2,0.8486229129095048
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.25,0.9794123924652265
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.3,1.0555555555555556
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.35,1.261903745500705
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.4,1.3935881408673503
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.45,1.590043376247484
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.5,1.9468719444444444
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.55,2.1048410807462354
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.6,2.5254681277777777
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.65,2.8713771993699586
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.7,3.198559785949123
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.75,3.7392270466242
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.8,4.379946478350737
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.85,4.961491028668663
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.9,6
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.95,7.450397324627412
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.975,8.841348100231794
+2026-05-09,46,0,wk inc covid hosp,2026-05-09,quantile,0.99,10.620496918909044
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.01,0
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.025,0
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.09826047748012186
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.1,0.27390109087314346
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.15,0.5682186742899136
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.2,0.6952391679655582
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.25,0.8339688825239222
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.3,1.0078114500000002
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.35,1.2079784558197524
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.4,1.390715705709201
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.45,1.7633026241600005
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.5,2.042613050793651
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.55,2.3547239722222226
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.6,2.7145956482571933
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.65,3.320327216605884
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.7,3.7777777777777777
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.75,4.611111111111111
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.8,5
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.85,6
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.9,6.898414738888889
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.95,8.411173029213039
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.975,11.078018475816632
+2026-05-09,46,1,wk inc covid hosp,2026-05-16,quantile,0.99,14.320230833707324
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.025,0
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.05,0
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.1,0.2733971554298652
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.15,0.3912621597433723
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.2,0.52717551
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.25,0.75709939
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.3,0.94781325
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.35,1.2190441
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.4,1.39
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.45,1.714342549757487
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.5,2.2222222222222223
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.55,2.5555555555555554
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.6,2.7777777777777777
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.65,3.2222222222222223
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.7,3.6666666666666665
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.75,4.444444444444445
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.8,5
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.85,6
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.9,7
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.95,8.5504509
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.975,10.525668
+2026-05-09,46,2,wk inc covid hosp,2026-05-23,quantile,0.99,13.271536
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.025,0
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.13524773436630955
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.1,0.23476173318042906
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.15,0.3271871823436908
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.2,0.44061947
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.25,0.64502497
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.3,0.88799794
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.35,1.1759502
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.4,1.4398669
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.45,1.86
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.5,2.5555555555555554
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.55,3
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.6,3.5555555555555554
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.65,3.7777777777777777
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.7,4
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.75,5
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.8,5.0336473
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.85,6
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.9,7.7220898
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.95,10.14738
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.975,12.906557
+2026-05-09,46,3,wk inc covid hosp,2026-05-30,quantile,0.99,17.605632
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.01,21.98
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.025,23.58
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.05,26.30163903143827
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.1,34.409082
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.15,36.333718
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.2,38.195704
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.25,39.795274
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.3,41.074919
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.35,42.280548
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.4,43.633802
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.45,44.902105
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.5,46.030075
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.55,47.199898
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.6,48.47794606835576
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.65,49.86411531827157
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.7,51.64647
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.75,53.174864
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.8,55.064222
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.85,57.793134
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.9,60.953558
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.95,65.072503
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.975,69.95565
+2026-05-09,47,-1,wk inc covid hosp,2026-05-02,quantile,0.99,76.51545
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.01,17.335
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.025,19.88888888888889
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.05,22.333333333333336
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.1,25.71666666666667
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.15,27.880555555555553
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.2,29.333333333333336
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.25,30.666666666666664
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.3,32.33333333333333
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.35,33.44444444444444
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.4,34.76510021756036
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.45,36.05987018762873
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.5,37.63793528746062
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.55,38.580875345697166
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.6,39.75794380212823
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.65,44.43959208314534
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.7,45.965532235790185
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.75,47.84075088371625
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.8,50.27598906115088
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.85,53.43579168888573
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.9,57.16784535535338
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.95,64.32492110681443
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.975,71.52783153575756
+2026-05-09,47,0,wk inc covid hosp,2026-05-09,quantile,0.99,87.72530094444444
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.01,10.925
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.025,14.135
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.05,16.406076
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.1,20.062154938646785
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.15,23.444444444444443
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.2,25.5
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.25,26.88888888888889
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.3,28.427777777777777
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.35,29.607247319544214
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.4,32.73235372222222
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.45,34.41719855555556
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.5,36.077459306091555
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.55,37.936779
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.6,39.8742185
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.65,42.006038000000004
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.7,44.314728
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.75,47
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.8,50
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.85,53
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.9,58.5
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.95,67.7279231902437
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.975,78.55249798673663
+2026-05-09,47,1,wk inc covid hosp,2026-05-16,quantile,0.99,101.30141601075178
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.01,7.4169609
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.025,9.5814822
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.05,12.053154
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.1,16.04399
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.15,18.341218
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.2,20.948783
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.25,23.22386
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.3,25.329444
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.35,27.11111111111111
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.4,28.77777777777778
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.45,31.570657
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.5,33.669515
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.55,35.85057
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.6,38.849876
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.65,41.947558
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.7,45.470458
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.75,49
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.8,52
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.85,54
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.9,58
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.95,67.04480059053586
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.975,80.50277777777778
+2026-05-09,47,2,wk inc covid hosp,2026-05-23,quantile,0.99,110.8199973303969
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.01,3.8434954
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.025,5.9864229
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.05,8.9573112
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.1,12.8
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.15,14.761155
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.2,16.980781
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.25,19.019012
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.3,21.049966
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.35,23.186522
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.4,25.400534
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.45,29
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.5,30.666666666666668
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.55,33.018041
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.6,37.353122
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.65,40.576969
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.7,45.113977
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.75,49
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.8,52
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.85,55
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.9,60
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.95,69.77777777777777
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.975,86.44999999999999
+2026-05-09,47,3,wk inc covid hosp,2026-05-30,quantile,0.99,120.37908184906493
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.01,53.336148
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.025,60.102285
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.05,65.445651
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.1,72.131008
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.15,76.480203
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.2,80.892318
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.25,84.209222
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.3,87.370407
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.35,89.35
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.4,91.21
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.45,93.03
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.5,94.86
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.55,96.71
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.6,101.07658575384303
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.65,108.22040282477474
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.7,112.81874
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.75,116.81703
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.8,120.49471
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.85,125.84237
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.9,131.89362
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.95,142.89271
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.975,152.00022
+2026-05-09,48,-1,wk inc covid hosp,2026-05-02,quantile,0.99,167.74157
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.01,23.88888888888889
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.025,50.464107
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.05,59.008712
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.1,66.75
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.15,70.72
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.2,74.01
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.25,76.93
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.3,79.64
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.35,82.22
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.4,85.70123183083832
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.45,94.6255556567564
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.5,98
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.55,101
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.6,103
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.65,106
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.7,106.64924374774853
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.75,108.34502162297316
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.8,116
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.85,121
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.9,134.67777777777778
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.95,171.88888888888889
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.975,201.05410851512812
+2026-05-09,48,0,wk inc covid hosp,2026-05-09,quantile,0.99,235.8258507142857
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.01,18.694371119428332
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.025,36.579382
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.05,45.493224
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.1,55
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.15,59
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.2,63.111111111111114
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.25,67.66666666666667
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.3,74.48
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.35,77.71
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.4,81.33333333333333
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.45,91.6259253619048
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.5,98
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.55,101.74140349523805
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.6,108
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.65,114
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.7,120
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.75,125.21872626582488
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.8,132.92254388697532
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.85,134.28748166701482
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.9,155.94444444444446
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.95,188.17965384606205
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.975,215.25809028468987
+2026-05-09,48,1,wk inc covid hosp,2026-05-16,quantile,0.99,291.02431661179463
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.01,14.35045201895022
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.025,24.88888888888889
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.05,37.665104
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.1,47
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.15,54.44444444444444
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.2,60
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.25,66
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.3,72
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.35,78
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.4,83
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.45,88.44444444444444
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.5,96
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.55,103
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.6,109
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.65,118
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.7,126
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.75,137
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.8,149
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.85,164
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.9,180.1264440947964
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.95,218
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.975,247
+2026-05-09,48,2,wk inc covid hosp,2026-05-23,quantile,0.99,333.53603495872045
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.01,10.867383209566029
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.025,22.77777777777778
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.05,31.383172
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.1,42.333333333333336
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.15,51.888888888888886
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.2,59.08888888888888
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.25,65.22222222222223
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.3,69.44
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.35,73.34
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.4,84.22222222222223
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.45,89
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.5,93.11111111111111
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.55,98
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.6,107
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.65,118
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.7,128
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.75,142
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.8,159
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.85,179
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.9,207
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.95,248.3886006038123
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.975,294.8293883306123
+2026-05-09,48,3,wk inc covid hosp,2026-05-30,quantile,0.99,391.022331229605
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.01,1.202647
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.025,1.5721437
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.05,1.8805419
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.1,2.3120937
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.15,2.6196554
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.2,2.8688399
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.25,3.0759387
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.3,3.2802294
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.35,3.4952822
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.4,3.7387655
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.45,3.9384792
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.5,4.1710892
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.55,4.41
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.6,4.6658062
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.65,4.9531176
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.7,5.2794255
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.75,5.5462033
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.8,5.9492761
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.85,6.3482949
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.9,6.9500595
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.95,7.8955473
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.975,9.0070332
+2026-05-09,49,-1,wk inc covid hosp,2026-05-02,quantile,0.99,10.443688
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.403619591994379
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.5821103123861505
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.05,1
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.1,1.573000427351348
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.15,2.1161514401456074
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.2,2.637004194143092
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.25,3
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.3,3.571455672222222
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.35,3.874143694283807
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.4,4.383517400000001
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.45,4.6184706
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.5,5
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.55,5.185935305555555
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.6,5.440624511111111
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.65,5.972943344444445
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.7,6.410907816666667
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.75,6.941732144444445
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.8,7.83183185
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.85,8.7211566
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.9,9.85820915
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.95,11.138193000000001
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.975,12.3588625
+2026-05-09,49,0,wk inc covid hosp,2026-05-09,quantile,0.99,15.616560260977057
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.01,0.008150326760843884
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.025,0.48780871769019785
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.05,1
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.1,1.7945808032216486
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.15,2.2054674
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.2,2.9624356
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.25,3.1816692
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.3,3.786773238888889
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.35,4.182909780385634
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.4,4.72509075
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.45,5
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.5,5.147993630952379
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.55,6
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.6,6.166666666666666
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.65,7.055555555555555
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.7,7.888888888888889
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.75,8.444444444444445
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.8,9.376322250000001
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.85,10.4281525
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.9,12.410384
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.95,15.570277
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.975,18.783927
+2026-05-09,49,1,wk inc covid hosp,2026-05-16,quantile,0.99,23.242679999999993
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.01,0.019091222787726885
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.025,0.07558349730982211
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.05,1
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.1,1.455882751661611
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.15,2.1898522
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.2,2.6364954
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.25,3.303121
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.3,3.9217719
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.35,4.555555555555555
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.4,5
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.45,5.09
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.5,6
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.55,6.333333333333333
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.6,7
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.65,7.666666666666667
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.7,8.666666666666666
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.75,10.11111111111111
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.8,11.444444444444445
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.85,13.222222222222221
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.9,16.208375
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.95,21.286897
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.975,25.764514
+2026-05-09,49,2,wk inc covid hosp,2026-05-23,quantile,0.99,33.966163
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.01,0.06640833490499304
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.025,0.41707582
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.72929053
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.1,1.4016795
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.15,2.0598115
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.2,2.6378626
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.25,3.2565189
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.3,4.0336503
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.35,4.777777777777778
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.4,5.04
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.45,5.28
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.5,6.333333333333333
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.55,6.777777777777778
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.6,7.333333333333333
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.65,8.222222222222221
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.7,9.222222222222221
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.75,10.333333333333334
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.8,12.333333333333334
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.85,14.555555555555555
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.9,20.311364
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.95,27.160186163163146
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.975,30.56663013817512
+2026-05-09,49,3,wk inc covid hosp,2026-05-30,quantile,0.99,41.07113447921699
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.05,0.033
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.1,0.03684210526315789
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.15,0.092565527
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.2,0.24438872
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.25,0.40586511
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.3,0.53616061
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.35,0.67529601
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.4,0.74
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.45,0.77
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.5,0.81
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.55,0.84
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.6,0.88
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.65,0.92
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.7,0.96
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.75,1.01
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.8,1.06
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.85,1.260423233587193
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.9,1.7836116534921593
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.95,2.7314735435281348
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.975,3.6376910532163604
+2026-05-09,50,-1,wk inc covid hosp,2026-05-02,quantile,0.99,4.036877305240447
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.01,0
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.025,0
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.05,0
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.1,0
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.15,0
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.2,0.02435841495483232
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.25,0.12652565124294837
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.3,0.20809866450986847
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.35,0.6283333333333333
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.4,0.7050935738888888
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.45,0.885545554260309
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.5,0.9660761
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.55,1.0555846
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.6,1.1563519
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.65,1.2600840500000001
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.7,1.8446549
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.75,1.992885
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.8,2.1995761
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.85,2.9272621
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.9,3.24031495
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.95,4.1473896
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.975,4.928704295864827
+2026-05-09,50,0,wk inc covid hosp,2026-05-09,quantile,0.99,6.123947602846442
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.01,0
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.025,0
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.05,0
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.1,0
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.15,0
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.2,0.005670535286340327
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.25,0.03499946872553369
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.3,0.10690856750646555
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.35,0.17285364091877506
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.4,0.26307313622167244
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.45,0.32945729259066536
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.5,0.89138518
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.55,0.975391675
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.6,1.0614441000000001
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.65,1.2058301391011013
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.7,1.549777624090527
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.75,1.9104953787641592
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.8,2.4048409032499034
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.85,2.8892014
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.9,3.6772587000000003
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.95,4.7634356
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.975,5.287827500000001
+2026-05-09,50,1,wk inc covid hosp,2026-05-16,quantile,0.99,6.3558584071508815
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.025,0
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.05,0
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.1,0
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.15,0
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.2,0.05066263824592511
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.25,0.09538249405739188
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.3,0.09601136094401092
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.35,0.1532044
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.4,0.28930449
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.45,0.44909336
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.5,0.66
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.55,0.79349598
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.6,0.96191448
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.65,1.2176861014663165
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.7,1.9225011814654507
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.75,2.4874048917329077
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.8,3
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.85,3
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.9,4
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.95,5
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.975,6
+2026-05-09,50,2,wk inc covid hosp,2026-05-23,quantile,0.99,8.00798650780015
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.025,0
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.05,0
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.1,0
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.15,0
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.2,0.07923479030379438
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.25,0.11608827578559958
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.3,0.11621412723469238
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.35,0.12371789743781036
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.4,0.17628803
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.45,0.63
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.5,0.7
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.55,0.78
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.6,1.4741058523590878
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.65,2
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.7,2
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.75,3
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.8,3
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.85,3
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.9,4
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.95,5.359798
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.975,6.8875727
+2026-05-09,50,3,wk inc covid hosp,2026-05-30,quantile,0.99,9.50735420071591
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.01,32.875062
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.025,35.348852
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.05,37.360581
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.1,40.004443
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.15,41.93661
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.2,43.758989
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.25,44.971624
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.3,46.28602
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.35,47.301349
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.4,48.509315
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.45,49.651829
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.5,50.73
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.55,51.6
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.6,52.49
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.65,53.43
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.7,54.44
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.75,55.54
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.8,58.04305662095125
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.85,61.576695
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.9,64.451212
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.95,68.255682
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.975,72.117993
+2026-05-09,51,-1,wk inc covid hosp,2026-05-02,quantile,0.99,76.236037
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.01,16.341299792665446
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.025,22.844147976536412
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.05,25.720233937110365
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.1,29.943841896155284
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.15,32.66974040085587
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.2,37.634582149042295
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.25,40.11466034358803
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.3,42.16588225956751
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.35,44.12669797587253
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.4,45.81964667260495
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.45,47.43381217658539
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.5,49.21146765124999
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.55,50.99553542506631
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.6,52.614999999999995
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.65,53.775
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.7,54.985
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.75,56.265
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.8,57.66
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.85,61.20479602047046
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.9,64.86980226895218
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.95,71.7787581863671
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.975,83.72204993428846
+2026-05-09,51,0,wk inc covid hosp,2026-05-09,quantile,0.99,101.41876679824094
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.01,12.16359560452457
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.025,18.54954972621338
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.05,22.18385452564999
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.1,26.894594933899967
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.15,30.227991963015235
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.2,36.05730403305492
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.25,38.76422890892791
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.3,41.003526
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.35,43.191303000000005
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.4,45.294791000000004
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.45,47.1462525
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.5,49.675000999999995
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.55,51.965
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.6,53.72
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.65,55.525
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.7,57.394999999999996
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.75,59.86
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.8,61.97
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.85,64.815
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.9,70.03369935892029
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.95,82.00341468666505
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.975,91.88429445106381
+2026-05-09,51,1,wk inc covid hosp,2026-05-16,quantile,0.99,117.84388888888887
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.01,12.861383
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.025,17.240538
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.05,20.257439
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.1,25
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.15,30.403123
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.2,33.899513
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.25,37.159098
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.3,40.623759
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.35,43.862935
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.4,47.442771
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.45,51.085581
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.5,55.289195
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.55,59
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.6,61
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.65,64
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.7,68
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.75,71
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.8,75
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.85,80
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.9,87
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.95,98
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.975,106
+2026-05-09,51,2,wk inc covid hosp,2026-05-23,quantile,0.99,123.71104776958497
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.01,10.474418
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.025,14.092688
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.05,17.640231
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.1,23.578609160068854
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.15,30.148854380965492
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.2,34.01
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.25,36
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.3,38.43425
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.35,42.011007
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.4,46.804424
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.45,50.85047
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.5,54.719136
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.55,58
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.6,62
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.65,65
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.7,69
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.75,74
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.8,80
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.85,86
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.9,95
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.95,110
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.975,122
+2026-05-09,51,3,wk inc covid hosp,2026-05-30,quantile,0.99,137.60780139251446
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.01,13.450116
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.025,14.76
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.05,15.55
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.1,16.51
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.15,17.260701984600498
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.2,19.637388579115246
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.25,21.797284903897793
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.3,22.976773
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.35,23.939819
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.4,24.734669
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.45,25.539665
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.5,26.448764
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.55,27.358399
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.6,28.277287
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.65,29.329934
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.7,30.474385
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.75,31.551124
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.8,32.616496
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.85,34.248286
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.9,36.096069
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.95,40.060678
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.975,42.508637
+2026-05-09,53,-1,wk inc covid hosp,2026-05-02,quantile,0.99,45.698476
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.01,9.555555555555555
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.025,11.966120547619045
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.05,14.090446
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.1,15.571897400661344
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.15,17.085984921061947
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.2,18.455982704054666
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.25,19.747333726190476
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.3,21.61111111111111
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.35,22.444444444444443
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.4,23.5
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.45,24.666666666666664
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.5,25.555555555555557
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.55,26.27583514231912
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.6,26.80106230798252
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.65,27.65750052401164
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.7,28.87801783745328
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.75,30.073166691961227
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.8,31.979609622674765
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.85,34.877806864773135
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.9,38.20943116307532
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.95,44.56020318251737
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.975,49.81790232102996
+2026-05-09,53,0,wk inc covid hosp,2026-05-09,quantile,0.99,57.07318438325915
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.01,6.753955600440602
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.025,9.03749445
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.05,10.754999999999999
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.1,12.52998552416779
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.15,14.574751248440537
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.2,17.477847040357176
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.25,19.04771097054471
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.3,20.791471970415593
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.35,22.062899284430657
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.4,23.403591513157096
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.45,24.490830619541057
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.5,25.6860538007375
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.55,26.39908361708108
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.6,27.543396987303662
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.65,28.610388791112165
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.7,29.96925699296357
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.75,32.3743838706979
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.8,34.464954447229076
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.85,36.82676052798145
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.9,40.92361320183157
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.95,48.09828129431363
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.975,52.938358038200406
+2026-05-09,53,1,wk inc covid hosp,2026-05-16,quantile,0.99,69.00455250608181
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.01,5.1333026
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.025,6.8443789
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.05,9.0648344
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.1,12.757301
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.15,15
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.2,17.388983
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.25,19.669294
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.3,21.911693
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.35,23.29444444444444
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.4,24.666666666666668
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.45,25.88888888888889
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.5,27
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.55,28.333333333333332
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.6,29.15555555555555
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.65,30.333333333333332
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.7,31.77777777777778
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.75,33.77777777777778
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.8,36.55555555555556
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.85,39.77777777777778
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.9,46.01111111111111
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.95,54.57264229599635
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.975,57.34649906330179
+2026-05-09,53,2,wk inc covid hosp,2026-05-23,quantile,0.99,77.47939015251298
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.01,2.8009839
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.025,5.1301545
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.05,7.323035
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.1,11.760393287936502
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.15,14
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.2,16.782772
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.25,19.27773
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.3,21.870177
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.35,24
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.4,25.444444444444443
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.45,26.444444444444443
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.5,28.11111111111111
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.55,29.22222222222222
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.6,30.333333333333332
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.65,31.88888888888889
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.7,33.55555555555556
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.75,35.888888888888886
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.8,39.44444444444444
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.85,43.111111111111114
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.9,50.233333333333334
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.95,61.46967874969169
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.975,70.90313422722923
+2026-05-09,53,3,wk inc covid hosp,2026-05-30,quantile,0.99,90.36956064630907
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.01,6.194658227742362
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.025,7.0522888563402795
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.05,8.314113146984786
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.1,9.88886241525178
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.15,10.51762710271776
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.2,10.988650055543552
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.25,11.485170047898594
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.3,11.922764565724968
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.35,12.331141424370259
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.4,12.63756936028918
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.45,12.942881922597893
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.5,13.18026315789474
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.55,13.500173632957665
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.6,13.84850907108337
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.65,14.241671075629743
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.7,14.786568767608365
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.75,15.358996618768074
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.8,16.04134994445645
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.85,16.81987289728224
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.9,17.920076978687618
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.95,20.688886853015212
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.975,22.588763775238668
+2026-05-09,54,-1,wk inc covid hosp,2026-05-02,quantile,0.99,23.990559163561983
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.01,2.2211111111111115
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.025,3
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.05,4.145049200544012
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.1,5.618274182238127
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.15,6.525971035487028
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.2,7.331942998957853
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.25,8.138139150031826
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.3,8.902640083850164
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.35,9.567350320170782
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.4,10.270128578151343
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.45,10.97923513184499
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.5,11.72978711032621
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.55,12
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.6,13
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.65,14
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.7,14
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.75,15
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.8,16
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.85,17
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.9,18
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.95,20
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.975,22.1374857036279
+2026-05-09,54,0,wk inc covid hosp,2026-05-09,quantile,0.99,28.624294703308934
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.01,1.4444444444444444
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.025,2.2222222222222223
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.05,2.6666666666666665
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.1,4.011343745790014
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.15,5.398701911984747
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.2,6.61421939583631
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.25,7.706230846103237
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.3,8.894055604865672
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.35,9.948760511242286
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.4,11
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.45,11
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.5,12
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.55,12
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.6,13
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.65,14
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.7,14
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.75,15
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.8,16
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.85,17
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.9,19
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.95,21
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.975,25.666666666666668
+2026-05-09,54,1,wk inc covid hosp,2026-05-16,quantile,0.99,33.888888888888886
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.01,2.2222222222222223
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.025,2.7777777777777777
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.05,3.7777777777777777
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.1,4.611111111111111
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.15,5.8264602153138
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.2,7.161695101679254
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.25,8
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.3,9
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.35,9.825000000000045
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.4,10
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.45,11
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.5,11.82924338095238
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.55,14.153910238325224
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.6,15.468609269967295
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.65,16.112250601053987
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.7,17.005527765102105
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.75,18.813754438390703
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.8,20.08415404626829
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.85,20.83744018459577
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.9,23.915
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.95,26.890555555555558
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.975,31.55388888888889
+2026-05-09,54,2,wk inc covid hosp,2026-05-23,quantile,0.99,39.21035718344925
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.01,1.8333333333333335
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.025,2.6666666666666665
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.05,3.0555555555555554
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.1,3.9444444444444446
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.15,5.33118479797198
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.2,6.125580962012151
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.25,7.5
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.3,8.5
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.35,8.5
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.4,9.5
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.45,10.706786867504785
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.5,11.321508782142855
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.55,11.880221346780928
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.6,15.467130066612553
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.65,16.473958936874993
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.7,18.13367553907446
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.75,19.586801996133467
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.8,21.184091055115992
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.85,22.370427866887788
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.9,25.165
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.95,29.405
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.975,34.888333333333335
+2026-05-09,54,3,wk inc covid hosp,2026-05-30,quantile,0.99,43.803755127383745
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.01,6.55
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.025,7.43
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.05,11.029528740770232
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.1,17.516917093826606
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.15,18.985704
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.2,19.720452
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.25,20.511571
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.3,21.179934
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.35,21.684801
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.4,22.245733
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.45,22.845789
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.5,23.478513
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.55,24.048346
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.6,24.747755
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.65,25.275302
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.7,25.987624
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.75,26.681394
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.8,27.504907
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.85,28.596816
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.9,29.754804
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.95,32.253749
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.975,33.994765
+2026-05-09,55,-1,wk inc covid hosp,2026-05-02,quantile,0.99,37.16681
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.01,6.133333333333333
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.025,7.769444444444445
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.05,9.962525931752932
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.1,13.000933276686814
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.15,14.911352691208283
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.2,16.11111111111111
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.25,17.26388888888889
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.3,17.61111111111111
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.35,18.444444444444443
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.4,19.27777777777778
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.45,19.833333333333336
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.5,20.77777777777778
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.55,21.77777777777778
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.6,23.43470186687985
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.65,24.503552030869102
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.7,25.1746781959724
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.75,27.555555555555557
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.8,29.22222222222222
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.85,30.72222222222222
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.9,33.66666666666667
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.95,40.6919147194443
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.975,45.71044192780854
+2026-05-09,55,0,wk inc covid hosp,2026-05-09,quantile,0.99,56.86658102911626
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.01,5.5744444444444445
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.025,6.74
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.05,7.85
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.1,9.878921291697282
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.15,12.20550116141693
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.2,13.88888888888889
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.25,14.944444444444445
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.3,16.055555555555557
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.35,17
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.4,18
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.45,18.944444444444443
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.5,21.970957470238083
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.55,23.555555555555557
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.6,24.77777777777778
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.65,26
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.7,27.72222222222222
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.75,29.38888888888889
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.8,31.22222222222222
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.85,33.72222222222222
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.9,37.72222222222222
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.95,43.66666666666667
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.975,53.84779447722351
+2026-05-09,55,1,wk inc covid hosp,2026-05-16,quantile,0.99,70.54354531523575
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.01,4.93
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.025,6.24
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.05,7.59
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.1,9.45
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.15,12.555555555555555
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.2,14.11111111111111
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.25,15.333333333333334
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.3,16.333333333333332
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.35,17.444444444444443
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.4,18.555555555555557
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.45,19.666666666666668
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.5,24
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.55,25
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.6,26
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.65,27
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.7,29
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.75,30
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.8,32
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.85,35.77777777777778
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.9,41.77777777777778
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.95,50.333333333333336
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.975,63.50277777777777
+2026-05-09,55,2,wk inc covid hosp,2026-05-23,quantile,0.99,87.43203198207648
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.01,3.9481285
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.025,5.5365299
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.05,7.3320879
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.1,9.6399233
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.15,12.444444444444445
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.2,13.784712
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.25,15.669229
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.3,17.45
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.35,18.84
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.4,20.26
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.45,22
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.5,23.21
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.55,25
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.6,26.52
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.65,28.39
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.7,30.48
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.75,32.88
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.8,35.73
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.85,39.31
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.9,45.666666666666664
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.95,55.77777777777778
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.975,70.22222222222223
+2026-05-09,55,3,wk inc covid hosp,2026-05-30,quantile,0.99,95.8146980340241
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.01,0.26007752
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.025,0.383633
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.05,0.54228626
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.1,0.79502547
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.15,1.0043982
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.2,1.225786
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.25,1.4298032
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.3,1.5
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.35,1.56
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.4,1.62
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.45,1.68
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.5,1.74
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.55,1.8
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.6,1.87
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.65,1.94
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.7,2.02
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.75,2.1
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.8,2.2
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.85,2.32
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.9,2.547394003636956
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.95,3.4679437947975233
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.975,4.247816275610801
+2026-05-09,56,-1,wk inc covid hosp,2026-05-02,quantile,0.99,4.6117726657613165
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.01,0.08362004208501676
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.025,0.19482909
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.05,0.3709346033832139
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.1,0.5555555555555556
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.15,0.7611111111111105
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.2,0.94186124
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.25,1.0297660083340687
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.3,1.1886731730177218
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.35,1.2887083598835425
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.4,1.6350218352761525
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.45,1.9445906
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.5,2.111111111111111
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.55,2.4444444444444446
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.6,2.5555555555555554
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.65,2.9757584
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.7,3.3152078
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.75,3.7219677
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.8,4.263939
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.85,4.8980175
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.9,5.7252602
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.95,7.076857
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.975,8.600758078515947
+2026-05-09,56,0,wk inc covid hosp,2026-05-09,quantile,0.99,10
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.01,0
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.025,0
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.05,0.18261532
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.1,0.35098972
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.15,0.6643323686363038
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.2,0.7538472764605103
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.25,1
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.3,1.0424606
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.35,1.2143073
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.4,1.64
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.45,1.75
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.5,1.87
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.55,2.0867021
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.6,2.3940032
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.65,2.7381132
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.7,3.0956393
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.75,3.5021872
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.8,4.0629849
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.85,5.0508472295173945
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.9,6.634056462391443
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.95,7.9461573
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.975,9.2081926
+2026-05-09,56,1,wk inc covid hosp,2026-05-16,quantile,0.99,10.854791679409725
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.01,0
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.025,0
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.05,0.1535275843668348
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.1,0.28008084
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.15,0.43133589
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.2,0.626807938220738
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.25,0.70308886
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.3,0.88389962
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.35,1.0949058
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.4,1.2696733
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.45,1.5184238
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.5,1.97
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.55,2.11
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.6,2.2902604
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.65,2.6099856620957502
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.7,3.4592578003002847
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.75,4.460053745742553
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.8,5
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.85,6
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.9,6.959588881776344
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.95,8
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.975,9.7058692
+2026-05-09,56,2,wk inc covid hosp,2026-05-23,quantile,0.99,12.179946
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.01,0
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.025,0
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.05,0.074299746
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.1,0.24865739102724044
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.15,0.32159522
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.2,0.6856427537446923
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.25,0.773109729868452
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.3,0.8037239955847861
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.35,0.95587642
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.4,1.1504014
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.45,1.4761573791379468
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.5,1.99
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.55,2.15
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.6,2.34811674950355
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.65,3.241030291398421
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.7,4.322931399858707
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.75,5
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.8,5
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.85,6
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.9,7
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.95,8.3178707
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.975,11.832219599575133
+2026-05-09,56,3,wk inc covid hosp,2026-05-30,quantile,0.99,13.687245
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.01,11.693247931339815
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.025,12.85547134995493
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.05,14.890297600045301
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.1,17.20947764945517
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.15,18.22485992827547
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.2,19.019615384615385
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.25,19.673129594483612
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.3,20.223842128307407
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.35,20.737850959324266
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.4,21.056004555194566
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.45,21.36063112089688
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.5,21.585789473684212
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.55,21.865757767992008
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.6,22.232132699707396
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.65,22.629336540675737
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.7,23.311824538359257
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.75,24.009370405516393
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.8,24.80076923076923
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.85,25.57139007172453
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.9,26.57991628993877
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.95,29.34120239995469
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.975,31.897160228992437
+2026-05-09,72,-1,wk inc covid hosp,2026-05-02,quantile,0.99,33.250882503442796
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.01,8.391538305689346
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.025,11.069152885166233
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.05,14.331016015120394
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.1,19.978283275762625
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.15,21.54130822908741
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.2,23.858860022923572
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.25,25.13512022119106
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.3,26.133914131076917
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.35,27.166666666666664
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.4,28.38888888888889
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.45,29.666666666666664
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.5,30.943848710464117
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.55,32.05555555555556
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.6,32.77777777777778
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.65,34.33333333333333
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.7,35.68333333333333
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.75,37.33333333333333
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.8,39.77777777777778
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.85,41.84166666666667
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.9,45.27942663588256
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.95,50.915941911703186
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.975,55.3969987627583
+2026-05-09,72,0,wk inc covid hosp,2026-05-09,quantile,0.99,63.169952077634605
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.01,5.222222222222222
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.025,7.420317931658795
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.05,11.495510952884427
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.1,16.59587832792553
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.15,21.486533964782467
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.2,25.61944762034348
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.25,27.92894343890947
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.3,29.221672000269706
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.35,29.862824688164167
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.4,30.301267086373812
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.45,32.428521285821
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.5,35.42657098334958
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.55,36.28706222423533
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.6,37.51775657385669
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.65,38.98436370802179
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.7,41.55555555555556
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.75,43.72142259421246
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.8,47.111111111111114
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.85,50.611111111111114
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.9,56.13257514468309
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.95,63.38630310887371
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.975,76.09065185103452
+2026-05-09,72,1,wk inc covid hosp,2026-05-16,quantile,0.99,91.72342031395948
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.01,4.166666666666666
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.025,6.111111111111111
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.05,10.220290827271631
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.1,14.829374503171834
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.15,19.679757281174645
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.2,23.662631776407437
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.25,26.120259357800855
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.3,28.325123590658205
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.35,30.724967273702845
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.4,31.393037789440108
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.45,33.659930923537786
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.5,39.0587038809809
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.55,41.02765342408982
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.6,42.64963599094772
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.65,44.352349564285305
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.7,48.368980318506686
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.75,51.097720802523284
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.8,53.356814859316856
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.85,57.7282042327765
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.9,63.00814635619488
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.95,75.76522768774035
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.975,86.44722222222222
+2026-05-09,72,2,wk inc covid hosp,2026-05-23,quantile,0.99,102.94555555555556
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.01,3.5805555555555553
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.025,5.277777777777778
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.05,7.764747749920368
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.1,12.872531192919915
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.15,17.115199729690218
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.2,20.599190540962802
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.25,22.5
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.3,25
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.35,27.61111111111111
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.4,29.70070743653024
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.45,32.111111111111114
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.5,39.85861177735549
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.55,42.36808111854401
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.6,45.344258007383466
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.65,47.53907389206532
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.7,51.85022284735328
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.75,54.9474968458979
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.8,60.9280189022151
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.85,67.9612529585661
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.9,73.68802764808788
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.95,80.3234541845024
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.975,90.88888888888889
+2026-05-09,72,3,wk inc covid hosp,2026-05-30,quantile,0.99,110.33444444444444
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.01,1075.95
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.025,1143.97
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.05,1204.77
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.1,1277.57
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.15,1328.33
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.2,1369.64
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.25,1405.76
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.3,1438.73
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.35,1469.75
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.4,1499.6
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.45,1528.86
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.5,1558.02
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.55,1587.56
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.6,1639.9519627069128
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.65,1695.7357
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.7,1708.3763
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.75,1722.0169
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.8,1762.95
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.85,1812.8
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.9,1876.83
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.95,1974.43
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.975,2061.72
+2026-05-09,US,-1,wk inc covid hosp,2026-05-02,quantile,0.99,2166.34
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.01,765.98
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.025,957.52
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.05,1035.99
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.1,1157.299312148616
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.15,1254.65463738002
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.2,1314
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.25,1363
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.3,1409
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.35,1452
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.4,1495
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.45,1536
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.5,1579
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.55,1623
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.6,1668
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.65,1714
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.7,1767
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.75,1807.6406058118278
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.8,1888
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.85,1984.8918
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.9,2064
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.95,2207.0838269641067
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.975,2339
+2026-05-09,US,0,wk inc covid hosp,2026-05-09,quantile,0.99,2476
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.01,638.4763219854592
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.025,791.181991562698
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.05,917.49
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.1,1030.61
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.15,1112.15
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.2,1180.03
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.25,1240.47
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.3,1296.51
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.35,1347
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.4,1399
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.45,1453.65
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.5,1540
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.55,1614
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.6,1694
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.65,1780
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.7,1876
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.75,1982.4292000612697
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.8,2026.544932406268
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.85,2101.1411821375577
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.9,2198.507521139113
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.95,2711.3025
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.975,3079
+2026-05-09,US,1,wk inc covid hosp,2026-05-16,quantile,0.99,3382
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.01,496.98855396921476
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.025,756.7484594314508
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.05,885.720170748947
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.1,1025.6200000000001
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.15,1098.08
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.2,1158.73
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.25,1215.95
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.3,1265.865
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.35,1313.9650000000001
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.4,1360.92
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.45,1408.7649999999999
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.5,1655.4783715401784
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.55,1835.2376
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.6,1909.0189402656265
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.65,2017.0943691722296
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.7,2130.3234428995256
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.75,2287.3879500000003
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.8,2404.6056506132463
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.85,2564.2933775110196
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.9,2748.4219643250062
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.95,3283.219436904549
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.975,3856.5672999999997
+2026-05-09,US,2,wk inc covid hosp,2026-05-23,quantile,0.99,4395.878100232079
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.01,465.1463717098667
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.025,718.6769098409752
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.05,876.8446927866933
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.1,990.9100000000001
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.15,1070.44
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.2,1139.295
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.25,1199.005
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.3,1255.815
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.35,1310.775
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.4,1363.12
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.45,1560.926826269051
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.5,1823.3590267734376
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.55,1966.8667335452467
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.6,2027.3555107096215
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.65,2137.3198979316567
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.7,2242.399953513184
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.75,2410.539329543817
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.8,2596.6602209190787
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.85,2870.8902181862695
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.9,3143.320541105196
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.95,3790.076471327752
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.975,4570.825140215224
+2026-05-09,US,3,wk inc covid hosp,2026-05-30,quantile,0.99,5226.6173963719975
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,9.085486207812805e-4
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0010832814187608142
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0011873693760956396
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0013186554219840254
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.001398562716668999
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0014743073319552502
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0015279196138960527
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0015889865436207117
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0016293451577572106
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0016690326907114158
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0017094291140159511
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.001761856020242398
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.001813228779695088
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0018575684826160521
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.001916620140037213
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.00197696905575252
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0020494915053978113
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0021252203138004693
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0022422164889795695
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0024396765001900808
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002679716917797825
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0030182205747311276
+2026-05-09,01,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0035124429807922987
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.356528638474437e-4
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.729971444229255e-4
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.708912667479458e-4
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0011023703911966199
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0011795595137668344
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.001247321512277337
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0012911455740821879
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0013443335069721943
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.001382157916401834
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0014169134672064104
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0014528007118927314
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.001501050981956375
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0015445884969214549
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0015862324602240391
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.001642727725362841
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0016967697098580312
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0017600328679403927
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0018292281102233205
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001934463652550031
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.002106851032398242
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0023448869119596515
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0025755504288791633
+2026-05-09,01,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0027959093746634228
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.220279095888951e-4
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.214769453127172e-4
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,7.099768420484398e-4
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,8.232715376015829e-4
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,9.137362390004493e-4
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,9.904633500236715e-4
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.001052280387609273
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.001112571562317107
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.001175267209740922
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0012335415733940487
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0012937260677397837
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.001351681954462621
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0014141559844711416
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0014754364430513598
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0015441361679705487
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0016115059051713143
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.001686507623259669
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.00183644058320398
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.002030860059611876
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.002255659849664122
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.002741370678155602
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0030963272183964115
+2026-05-09,01,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0035352940024339693
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,4.7590308192241125e-4
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,5.777371729005843e-4
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,6.796565235004405e-4
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,8.038760675279789e-4
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,9.079509939068797e-4
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,9.89663553605212e-4
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0010564392598862425
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.00112357295742042
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0011825351301721946
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.001248690800771799
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0013153225273249169
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.001388636159335065
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0014661137331108422
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0015442203371615342
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.001638758589005827
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0017431240584804852
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0018442359170027334
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001984268093030295
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.002190886113792952
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0024235382534952875
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0028077955293217428
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.003261155020062058
+2026-05-09,01,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0038159601480960968
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.0415830590228826e-4
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,4.884981055669836e-4
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.159463399475173e-4
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,7.530905240554632e-4
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,8.56229385776951e-4
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,9.413777795439034e-4
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0010298277155462773
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0011079025752570907
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0011785513118970214
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0012577302805730196
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0013461445834885345
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0014254958090173014
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0015150158810710507
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0016203173116775007
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.001734661433733759
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0018752555134634093
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.002020642952321689
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0021701586107324496
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0024321294612850266
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0027522913499895343
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.00330570449491343
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0038552001208218088
+2026-05-09,01,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004385122608671494
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0010872949318595426
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0012554151061265888
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0013701112393933285
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0015050057329782812
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0015914188846826748
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0016770929858086348
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0017380040159399957
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0018049268771264733
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0018534099770910178
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0019009688591902995
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001943274585070917
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.002003994477186122
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.002062569120949478
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0021118136416336092
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0021786070337689854
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0022416719097958864
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0023238172447639996
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002409285529509562
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.002541263250396922
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0027503326107589025
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0029999516578101864
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0033517526292645987
+2026-05-09,02,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0038202416938322285
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,4.5461513963199174e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,5.427920967847258e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,6.063646635577097e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.701796899861405e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,7.05249673768049e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,8.283927303618321e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,8.64286533390061e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,9.71764406324337e-4
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0010617009894471829
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0011200975501845754
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0012290210990062297
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.001272424941874374
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0013811702621337283
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0014343409251067162
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0015334366959650807
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0016508851589051251
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0017423345846359563
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0018318843113976934
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001928694988526734
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0020675050489708815
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002296884883258461
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0025027828579143505
+2026-05-09,02,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0027630429752271038
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,0.00031422417120834497
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,3.872245107207977e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,4.6976463684044264e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,5.233560980470643e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,5.653859662761497e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,5.99298083959321e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,6.422744610706874e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,7.053510662679925e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,8.175363496992583e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,8.6452104946966e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,9.80137376022032e-4
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0010858875196733367
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0011528606475616808
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0012695520542531438
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.001391953102474209
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.001527215422632466
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0016823551685187172
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0017959876123789745
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0019081649702490035
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.002057937426753542
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0022841509738135437
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0025010820311147214
+2026-05-09,02,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0027874288941405197
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.4687159623905336e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,4.146740982373696e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.02135869028202e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,5.934102892101172e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,6.708764688715084e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,7.213611656390444e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,7.682821182177806e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,8.124441984721161e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,8.549420302491152e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,8.997600380607016e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,9.403981300826904e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,9.862363002684795e-4
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0010246419047283653
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.001065566337808071
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.001128955721555506
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.001194639221103011
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0012548713674608168
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.00135311551141415
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0014809255698640192
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0016536108352283344
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.001953927320321334
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.002279924918837848
+2026-05-09,02,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0027122514764303845
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.900189416139275e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.636320901460427e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.372491512290725e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,5.424011484610472e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,6.134739073205793e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,6.749577848246303e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,7.307593961556976e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,7.786155252555074e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,8.25777325917685e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,8.802542407832146e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,9.308518557516483e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,9.753932032901906e-4
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.001023446810273194
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001083220616419053
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0011505617284193264
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0012307859510287667
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0013162465005610012
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0014038492204188954
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0015563162566174032
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0017789155123425302
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0021539461500016373
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0025464085447861823
+2026-05-09,02,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0029922349437194926
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,6.70712781365421e-4
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,8.424295396583232e-4
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,9.602458003085382e-4
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0011117818965252514
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0012076126205157836
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0012930875481289008
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.001362967725109958
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0014376017792193919
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0014844860616177555
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.001534330113643902
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0015784976946961397
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.001642404862447577
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0017012705512730068
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0017588720064084852
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.001821033041420545
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0018916146650603013
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0019677042557762116
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0020402785893371615
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0021594577643452785
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002351894150929927
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002566635702186253
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0029095179920022004
+2026-05-09,04,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0034107041079649166
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,5.924892500038918e-4
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,7.34268566399828e-4
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,8.39586855077973e-4
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,9.84652515575705e-4
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0010715434231570796
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0011496951481489341
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0012055321657083794
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0012677656298736078
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.001309855566743751
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0013509352084232415
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0013946568972421727
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0014510789707851998
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.001500973496425384
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.001551399164245344
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0016129538939768106
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0016750181663013888
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0017458417101164556
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0018183528126242809
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001930044212492591
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.002126120303328765
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002333801149907424
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0024842686976042595
+2026-05-09,04,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0027033414391737097
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,4.4508865285926074e-4
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,5.667200854429643e-4
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,7.235073409647161e-4
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,8.654205528093164e-4
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,9.765378572986861e-4
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0010572002001473341
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0011241121622420959
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.001186565877516514
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0012500477446622219
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0013039010745593915
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.001377484333754463
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0014414465732546433
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0015132424693523794
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0016099455037007823
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.001714374120268134
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0018121381090397653
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0019456730145476356
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0020974315108802746
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0022551379422327705
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.002481940301075189
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.002963155978023245
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.003364937096725704
+2026-05-09,04,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.003816674460667992
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.6530573011286536e-4
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,4.574226547147625e-4
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.623128262243016e-4
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,6.825918986636315e-4
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,7.866156367239954e-4
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.703506263935431e-4
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,9.364188036482527e-4
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0010070766737194524
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0010628370429373716
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0011285486684499103
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0012026489558922694
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0012821987655745925
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0013671937446716256
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0014577569391788416
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.001556774696217361
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0016757236880755489
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0017862250184986867
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0019385754420528358
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0021714684743977574
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002421680031233569
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.002817282722049288
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.003330873124433768
+2026-05-09,04,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003916210404062518
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.0395183694694394e-4
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.8971041091063726e-4
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,5.129217811135608e-4
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,6.564766721040759e-4
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,7.624030769093982e-4
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,8.422013304419992e-4
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,9.284608059447082e-4
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.001009918996868454
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001086395236181527
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0011714406027902903
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0012729440779604437
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0013660053976470232
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0014724680787063873
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001598433356622785
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0017296065050907347
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0018916634852964046
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0020668598927573063
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0022264798708079305
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0025466221826571066
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002908841636145374
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0035469516170703384
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.004177119752914935
+2026-05-09,04,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004761054654848769
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0011474649846392269
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0013256827849222272
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.001442250057913641
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0015879817348581587
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.001678203063637534
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.001758457776038293
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0018202877051729921
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0018868759586077775
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0019304215906275825
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0019756843783698477
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.002016417062654724
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0020724753723943253
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0021247609112909154
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0021743413969259216
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.002231199760754659
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.002292893245445751
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.002362290056675271
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0024313171648071975
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0025404346878182328
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0027124012474703902
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0029129290086440827
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.003207266510447567
+2026-05-09,05,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0036219915537124654
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,6.689202098469057e-4
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,7.530229160629452e-4
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,8.905085373583951e-4
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0010804946339516889
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0011871782512832697
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.001270657624659739
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0013491191420867488
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0014488145542198164
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0015329617574490256
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0016019197359305609
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0016571718757766188
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0017041526384539243
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.001746517837012982
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0017859596897920951
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0018408630007175502
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0018913588184398505
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0019505832084156793
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0020160247820845225
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0021138468662435404
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0022749441926411215
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0024900257832853176
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0027577628772962864
+2026-05-09,05,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.003170074282848456
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.579846949678123e-4
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.719348190889254e-4
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,7.640157945251301e-4
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,8.997560638606538e-4
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,9.947121372793277e-4
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0010769096379429734
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0011720646149102176
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.001298455960431533
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0014303849872711973
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0015342077555786744
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.001592173355098104
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0016431857988187032
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0016975999429912506
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0017708329545251574
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0018528838015597288
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.001930594069466265
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0020363456580405523
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.002157855892919362
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.002279326449676934
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.002461063235954953
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0028414825977596523
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0031510735195462193
+2026-05-09,05,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0035452025239040346
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.965141859547167e-4
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.966179108962899e-4
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,8.096461741867909e-4
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,9.406824843851862e-4
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.0010503703891734252
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.001132204275783393
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0012007834389185516
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.001270460646755373
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0013299999257693753
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0013968359073144683
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0014672926770551873
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0015402543579156468
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0016144109112447508
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.001694061742780259
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0017878212462305591
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0018938251340144272
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0019958222690192526
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0021312470984343928
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.00233069875601413
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0025633327474461507
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.002912716314361845
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0033490950924476483
+2026-05-09,05,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0038322847599859076
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,5.235489440863102e-4
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,6.17349136965999e-4
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,7.455256278047627e-4
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,8.959220930352596e-4
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.0010036096886900225
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0010871360755857823
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0011710937520322908
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.001255510442827261
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0013258395653749063
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0014014192081284798
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0014935556054335413
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0015758472961733719
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0016620915790594706
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0017645438085225362
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0018783279628491495
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0020136343045126766
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.002153275478465449
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.002295502941350163
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0025435731675948784
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002834197528999679
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0033151764834413607
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0037929737354205307
+2026-05-09,05,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004282026268345331
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,2.3251899901002255e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,3.242037662688094e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,3.911729235746013e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,4.7852874195973533e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,5.360319452364021e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,5.874281749082171e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,6.298197609565877e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,6.746297912019774e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,7.059199427179463e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,7.382124978007846e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,7.668125124062525e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,8.061368048750596e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,8.433255243272178e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,8.807721957095634e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,9.202149651740249e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,9.654681850598984e-4
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0010159543677171817
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0010662674355324713
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0011455274677350982
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.001270587677520242
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.001420927729966836
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0016502321594323887
+2026-05-09,06,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.00198349323052595
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,1.827086186057324e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.542383966492e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,3.099090005341175e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,3.869955853040284e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,4.349921665175583e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,4.785084506802311e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,5.098296734294245e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,5.449298794406574e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,5.701404190164113e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,5.946999337914607e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,6.204923849966442e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,6.527745020618013e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,6.823804864348276e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,7.119722684355886e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,7.484814854823511e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,7.854198654583232e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,8.28765512195316e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,8.752528912085627e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,9.456560542981346e-4
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0010419188838088102
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0011217122781452156
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0012035804127695378
+2026-05-09,06,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.001341693768626401
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.2945861325538231e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,1.6351357684045632e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.3035720040302638e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.0277763990470697e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,3.6068394293876997e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.0515823023579524e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,4.432537767805552e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,4.790217377964996e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,5.157346077590975e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,5.473543121899408e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,5.892549711758304e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,6.27538130037855e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,6.696566863677064e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,7.241589332596522e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,7.845054006644617e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,8.432536011077995e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,9.138155917629537e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,9.817144482557522e-4
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0010455839292611406
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0011367320726172199
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0013139447736493159
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0014824308026321331
+2026-05-09,06,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.001735756671213841
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,8.189129567170995e-5
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,1.3002492203588673e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,1.8082450524028104e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,2.4517779089735186e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,2.9926845483837486e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,3.4510638343575187e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,3.847253018245399e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,4.253841060641206e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,4.594686754216831e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,4.974004145145653e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,5.414019209256556e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,5.879456341690361e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,6.395090028619415e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,6.94341940838098e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,7.549855124819206e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,8.270492598166767e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,8.993663968911957e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,9.908850126157458e-4
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0011353474143596179
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0013038891643230733
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0015711278807602606
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0019113154870189987
+2026-05-09,06,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0023185796348736297
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,6.955524902730562e-5
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.0686052820152076e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,1.601498180861848e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,2.3303045706492634e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,2.856732636392467e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,3.269764289461054e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,3.727730952156846e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,4.18709316041701e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,4.6414118744923295e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,5.127649008424703e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,5.680771999518491e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,6.221111599227932e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,6.816592236935262e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,7.526561220336609e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,8.317011827687782e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,9.305430859296634e-4
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0010382884780247691
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0011456664452617806
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0013435161564102403
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0015795151729015222
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0020106199171289357
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.002446072728301446
+2026-05-09,06,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0028637660378305688
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,7.206393899566557e-4
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,8.725687561905729e-4
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,9.697899004906663e-4
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0010902096915580478
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0011648989268966904
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0012331141738059139
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0012887215302556715
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0013477095051576563
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0013853469841750247
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0014226714261347
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001457973899932052
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0015071668328978122
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0015537909084128462
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0015981189119384784
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0016453146069561877
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.00169878430304011
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0017567921989335995
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0018120555451429249
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0018997931696870171
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0020486637935494554
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002212355479340743
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002468671271176527
+2026-05-09,08,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.002843524703497934
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,4.139022664197617e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,4.6694643195439585e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,5.389144314850912e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.398577455195004e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,7.199343607208175e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.850100354059597e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,8.407608864292592e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,8.879886396954502e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,9.392314534964456e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,9.906000196087e-4
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.001039540597252316
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0010836769020066354
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0011304138354272407
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0011836359845140457
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0012375467820651411
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.001297889219681444
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0013654694752686504
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0014386059514657874
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001535854961076843
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0016623309117734743
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0018607109775967815
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0020326360461140358
+2026-05-09,08,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.002300386996815982
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,3.448551393980973e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,4.2222123954160256e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,4.942572096517925e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,5.976549177984792e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,6.701365338362097e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,7.273515927156573e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,7.88350241822632e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,8.469549294948676e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,8.974202503268434e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,9.501659459702486e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,9.98249267634786e-4
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0010463018864946827
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0010987485907400798
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0011561385137664538
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.001210910908691517
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0012705382376503242
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.001345957820691338
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.001426643343870785
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.001528521866886002
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.001674402812331033
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0018756819386342694
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.002083482672237369
+2026-05-09,08,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002258857937035338
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.773424539913206e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,4.5449372545466004e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.488941718876454e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,6.54492195154641e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,7.434549718425931e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.127681319459359e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,8.659584035343402e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,9.228221663003761e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,9.699661339916156e-4
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.001021611122679843
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0010815203672690041
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0011427975054143797
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0012057022237202408
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0012753858527772952
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0013528905465890963
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0014405324850332874
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0015247965197113995
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0016285621936322453
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0017942780745663915
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0019834931232814513
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.00228253731353187
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.002652572320442011
+2026-05-09,08,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003090146026892629
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.3709102072347646e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,4.1286360379394065e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,5.126834235422734e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,6.344622186143483e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,7.220712383769025e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,7.883089263473119e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,8.586348453146592e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,9.236576366062176e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,9.82162536357075e-4
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.00104775561948882
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0011216167230862107
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0011917969687611559
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.001268137406653457
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001358999114695409
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0014566948497402726
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0015734993454373583
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0016941475484086987
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.00181245780019497
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0020315453240721208
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0022926894132639887
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0027419950855595027
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0031799021008278275
+2026-05-09,08,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0036394935186827193
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,9.21719772628978e-4
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.001083588877937773
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.001173814625029457
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0012870130017276153
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0013534832215161127
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0014229572410558555
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.001465088454298438
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0015181028774459869
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0015493076713022228
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.001581862591223423
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0016157547427767202
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0016643607936750176
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0017114061567388098
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0017447265295674136
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0018054776071763782
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0018588230361117398
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0019295062179905645
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0020045238216373842
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.002125984176734488
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002334232559062343
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002580171281211845
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0029317446963369144
+2026-05-09,09,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0034359436999737273
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.100153329319208e-4
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.336127588012578e-4
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.420440517362589e-4
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0010709524098500094
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0011578967695675
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.001236044524285378
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0012963923237272906
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0013558553546843682
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0014091508556068329
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0014564752865223202
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0015067860871542226
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0015616566657990468
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0016114542323331243
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0016636682807341006
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0017271238539203408
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0017907854757791347
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0018622079079777328
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.001946844703359607
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0020618848661300287
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.002230959590242751
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0024662844288095235
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0027239352375501443
+2026-05-09,09,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.003080252697201691
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.898860885101296e-4
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,7.026086745845539e-4
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,8.321390682808764e-4
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.604072422441826e-4
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.001065653516023349
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0011399329087471816
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0012056816777968227
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0012672709332337507
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.001324963733989661
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0013841950992512391
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0014453086917864872
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0015022972644511494
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0015657650230991513
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0016384310640053146
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0017154790060061973
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0017956620317563588
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0018974761969362995
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.002010663490377966
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.002139144575802576
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0023172777991935286
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0026789013287900256
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0029737998940770095
+2026-05-09,09,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.003337221862999186
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.277410560582536e-4
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.35354694967113e-4
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,7.509035209882654e-4
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,8.772448020923008e-4
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,9.8531448156051e-4
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.001075125518156785
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.001145336135015621
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.001220734790970858
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0012780754675731482
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0013487410083857579
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0014242908174792652
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.001500046569667799
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0015783346211055709
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0016633647954623228
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.001758902365748469
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.001866018004852165
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0019804808595102327
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0021197473515699814
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0023206491082842858
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0025592284220013733
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0029500463481697253
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.003398042734415996
+2026-05-09,09,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003956283147924268
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.6896473302911196e-4
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.554858894213946e-4
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.9285105748775e-4
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,8.393287881143527e-4
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,9.469188612502969e-4
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0010356998288526499
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0011244627263219899
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.001206115720161883
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0012866062210985703
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.001371614914225164
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001468936083370849
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0015551402093628812
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0016520612751562377
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0017654751273707288
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0018852149401015707
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.002024755623351738
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0021774785900639517
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.002339113925029777
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0026139723155683787
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0029413155338444442
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0034951466693380114
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.004043701196662888
+2026-05-09,09,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004577719353363089
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,5.120163804299737e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,6.281924255764403e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,6.836900737082734e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,7.553347716147557e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,7.944794772919933e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,8.397490667069132e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,8.634525285767005e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,8.974648420799362e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,9.137565877508964e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,9.313127755798312e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,9.531661899353524e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,9.851325096897215e-4
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0010166791907704363
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0010347380080628571
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0010787741932831555
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0011145535781180208
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0011639820500544305
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0012171013548654141
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0013058916609267873
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0014694785282281999
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.001658867136003361
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0019379248341257352
+2026-05-09,10,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.002356301416867528
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,6.580882574436086e-4
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,7.799920619662803e-4
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,8.90607864813456e-4
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0010086135480154603
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0011177993477315066
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0012323002280120398
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0013380812322870243
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0014337597451853134
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0015152384470465045
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0015933291968227821
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0016873649093466889
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0017675699364054372
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0018512638701005035
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0019320637058738294
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.002035751750370388
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0021655650338778232
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.002272277282183097
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.002422991997129764
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0026117488925365396
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.002845177571691562
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0033153456786145833
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0037111058118391607
+2026-05-09,10,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.004219403209157545
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.952880026697833e-4
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.988046082694073e-4
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,7.989138009996796e-4
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.301243052831635e-4
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0010300809019783681
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.001111495127180738
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0011940108985706863
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.001312430684183098
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0014487204450391506
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0015690045573947355
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0016991365779187016
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0018388501565143912
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.002001322199583071
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0021683044039731746
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.002353509875091868
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0025664893709376846
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0028396465898287053
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.003156855327709336
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0035477325525780897
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.004182226271807966
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.004869039932316875
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.005310014269432951
+2026-05-09,10,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.005460715531294156
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,6.433737512983955e-4
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,7.768702586341645e-4
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,9.392445327595474e-4
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,0.0011580705374823184
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.0012976540293183024
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0014382196268558217
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0015501452870518623
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0016800142818227627
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0017852400744543038
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0018967621450669487
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.00204711065557869
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0021809290170782
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0023730373069461366
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0025627758450320385
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0027281519326617923
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0029347055101107255
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.003134388044547325
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.003353454797522723
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0037038940850357823
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.004027405366608487
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.004466717574469762
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.005087904371671225
+2026-05-09,10,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.005701924496022974
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,6.207762528015212e-4
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,7.237656157990797e-4
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,9.214070591924216e-4
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,0.0011423201570651012
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.0013118698204279016
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.001444573775966648
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0015711623702813191
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0017179187119817196
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001873097453899951
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0020144032871440495
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0021974593509188206
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0023849204034964303
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.002592023293778336
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0028475259670050043
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.003097872660481249
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0033914738855717295
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0036806353077912285
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.00398939854779002
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.004543033027109383
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.004985313848036144
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.005818055168815605
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.006528884699010767
+2026-05-09,10,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.00707324250871596
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,6.3248623066199e-4
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,7.546296711503257e-4
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,8.310312607609318e-4
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,9.290726646298998e-4
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,9.894931500880936e-4
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.001050166491238128
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0010859456438311124
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0011306600709031752
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0011600734122235536
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0011921922013811712
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0012223160008665427
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0012651150675824082
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0013060870245356732
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0013362051049026302
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0013921679653988456
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.001440449885059868
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.001506990824281124
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0015803990015342698
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0016983109794323243
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0018866102205055202
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0021251202139156047
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002453147069348442
+2026-05-09,11,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0029107534998292174
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.029575851818276e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.6732268473794946e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,3.1564611639972395e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,3.6738198132120335e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,3.958888176248661e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,4.2912286959713854e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,4.4596391266068705e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,4.7386725825029734e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,5.060120182543239e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,5.348469411091855e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,6.295601444348816e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,6.742270315883823e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,7.105063991011188e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,8.031554069500066e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,8.655257974373562e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,9.490096081720995e-4
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0010337059738404018
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0011631847712928766
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001283739430747268
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0014614180642192388
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.001747262882901119
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002016288068360704
+2026-05-09,11,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0022437557638643256
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.1100763355936415e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,1.639589402578458e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.2634313131747032e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,2.696095429030475e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,3.042513262868158e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,3.324198667910521e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,3.455689058294239e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,3.58286278674871e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,3.765613228315883e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,3.9029490274869715e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,4.091977923881381e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,4.2885127965654966e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,5.007177173526491e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,5.238051794183755e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,5.700318434342355e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,6.790859373502152e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,7.514110107954108e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,8.753825230744585e-4
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0010231127961432402
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0012110893159926522
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0015629167857530038
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0019292241275779564
+2026-05-09,11,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002219862954240617
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.044840519738659e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.640598626803721e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.264159503303932e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,3.9261203652678255e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,4.548121310457402e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,5.007260942567633e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,5.376740231446826e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,5.749125168361479e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,6.087094729340601e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,6.445521056118232e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,6.79839896132446e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,7.205737229604692e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,7.555576680408295e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,7.91810539286945e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,8.403243964478026e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,8.95703266842031e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,9.545896940086889e-4
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0010336059121918825
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0011473729825735917
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0012934845570831302
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0015563628024895574
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0018381340166017204
+2026-05-09,11,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0022292410220158807
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.5167562485716112e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.1445741445667724e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,2.863980159387826e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,3.6381329233449986e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.188893771953612e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,4.6593704671495486e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,5.132831993060816e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,5.529279129545333e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,5.88665349425008e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,6.315905011430754e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,6.75025056356311e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,7.161760238527371e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,7.586842493941513e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,8.123744428118248e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,8.700524122555689e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,9.401085334063019e-4
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0010214775149624492
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0010965263321912322
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0012334664541412527
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.00143534927848626
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0017651629879674334
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.002106957209803139
+2026-05-09,11,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.002502379037770075
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,9.865084376871219e-4
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0011625492805736968
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.001290063666292731
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0014481848723495463
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0015508005943266612
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0016396326798643471
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0017127925467271068
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0017876235017862548
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0018423275067632838
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0018975527258581015
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0019448712381891092
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.002007967431338123
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.002067430766214174
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0021284794829944833
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0021893792793751033
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0022594446843012986
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0023374947715225003
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002415514240969213
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0025340654616257817
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002711291309077282
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0029259029061613987
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.003236575412552532
+2026-05-09,12,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0036627904642027066
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,9.32602369642824e-4
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,0.0010816088718831308
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,0.0011933416009200094
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0013416798359848147
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0014016207473327065
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.00144558790149782
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0014788398420902684
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0015116791880122925
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0015427282279712694
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0015682186055709676
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0015965840267612875
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0016232159001817153
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0016463159354991365
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0016731017893602104
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0017086868900216992
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0017444194884726
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0017783296198599725
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0018094711744751674
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0018978827981499854
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0020251054520424292
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002245343661596493
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0025132077339297984
+2026-05-09,12,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0027173226882058806
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,6.393388648453895e-4
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,7.3723384351876e-4
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,8.304734155840059e-4
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.285761721625088e-4
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0010110359633846737
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0010770302615811251
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.001132478083670512
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0011973756403132773
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.00124765097844732
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0013052788880265104
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0013617991841194093
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0014206843925147357
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0014863950449032234
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0015549897648551364
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0016160903722952033
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0016917409560558393
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0017767428668238115
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0018801240897439843
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.002000659251795907
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0021568363905002676
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.002410349562982737
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0027065880092318195
+2026-05-09,12,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.00312538154660926
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.327177869776247e-4
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.345858334535773e-4
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,7.463784790819224e-4
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,8.83454840748441e-4
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,9.903984467630083e-4
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0010796580894279002
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0011563023513219135
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0012352108609006117
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.00130162425271522
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0013747899285521574
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.001459526626187595
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0015408705692189382
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0016320212424993834
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.001722447056626478
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0018258514926308782
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0019458063470090341
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0020628533231798044
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0022163279319280475
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.002430563954028162
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0026845860259436067
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.003075364010943815
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0035514361307407427
+2026-05-09,12,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.004089496906241946
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.591660169815314e-4
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.518886322989113e-4
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.780322093658344e-4
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,8.259356798894469e-4
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,9.367794424026681e-4
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0010246611544370912
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.00111142034036042
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0011995361982326642
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0012820295956036992
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0013711749819369816
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0014716340338842711
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0015655565472167776
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0016731132988865556
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0017912789042563877
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.001919913815771997
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.002079029632687738
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.002245357959521242
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0024147387438242683
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.002710589901303638
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0030449455737973784
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0036103093889169966
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.004136621752190384
+2026-05-09,12,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.00466048901221423
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,6.834489090439597e-4
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,8.048079821445693e-4
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,8.797629969706143e-4
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,9.730108612146465e-4
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0010305802001210854
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0010850064109034297
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.001123320202268477
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0011664681821395458
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001196239924721329
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0012255900567841689
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0012542428802160394
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.001291688869825474
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0013282530643847165
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0013599396595375404
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.001402194304383719
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0014446410320276093
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0014967648071361364
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001551657038628429
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0016357675267417964
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0017733030928558998
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0019424935984921272
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0021766997122493704
+2026-05-09,13,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.002508971002937218
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,4.554625153876752e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,5.15259051942981e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,5.662791284716465e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.274199949249347e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,6.734866802435426e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.382410553561503e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,7.883465064828683e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,8.3606785836144e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,8.810124471933306e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,9.27079885163522e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,9.727702209095166e-4
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0010076455043311284
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0010360492274034648
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0010622116528449341
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0011000363941883217
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0011343575871886136
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0011762330832909306
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.001223089526086846
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0012942561431957742
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0014092387397869187
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0015709561886349456
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0017664068623998884
+2026-05-09,13,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0020696422735065317
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,3.2563858628351154e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,3.9190832301727114e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,4.6746302624819887e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,5.620510603321572e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,6.360108508035968e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,6.88421248438197e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,7.438613073310672e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,7.938585364445677e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,8.358827086405267e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,8.754037601388421e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,9.135694847997534e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,9.475978285595349e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,9.822738760026876e-4
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0010297914174800648
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0010834011964678384
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0011352441399428508
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0012093460775999222
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0012934765836046993
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.001377763744759062
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0015041585500995209
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0017287838488239393
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0020161566212492156
+2026-05-09,13,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002333494888704763
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.963746232778462e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,3.72286776631849e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,4.4556910864951434e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,5.352438864500876e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,6.063195335902029e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,6.61333803352419e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,7.100440760371726e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,7.577367314401413e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,7.988262084078488e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,8.46216941558754e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,8.916435140484099e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,9.397770235898662e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,9.918087439328743e-4
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0010491195232782634
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0011159033229741872
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0011855918983733284
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0012591178095128527
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0013556194053505493
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0014962666149217125
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0016623105115630636
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0019286186586417358
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0022456528242358617
+2026-05-09,13,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.00264630440056392
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.622758939144614e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.2380395682926144e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.0429499181443324e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,4.998276396434816e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,5.736262994356237e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,6.302307457229615e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,6.858265018207324e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,7.400546164955591e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,7.890595067566526e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,8.406767177519746e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,9.009156321732881e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,9.535274227966831e-4
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0010160682269618163
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0010886444370833332
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0011619052171119662
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0012536736467526058
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0013483531556293434
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0014514594434794684
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0016180256522452291
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.001839773969642267
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0022044549018763564
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0025878995985408226
+2026-05-09,13,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0029344768145774976
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,4.838655085246068e-4
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,6.247771239576895e-4
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,7.154340487721838e-4
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,8.305228851939909e-4
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,9.027289439454435e-4
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,9.710114878374579e-4
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0010236971511613107
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0010817553624164157
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0011196715595532267
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0011572991841387863
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0011939415312066427
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0012443519331886274
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0012930208986809768
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0013373519914842854
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0013901444985781638
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0014470649901845187
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.001512576234492199
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001578106873327506
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0016817290667974275
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0018589735530193164
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002065733933319076
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0023792984376740096
+2026-05-09,15,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0028447619445030052
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,4.0660784270485356e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,4.786256421768798e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,5.488382417044035e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.51125992121822e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,7.327230324883731e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.893719189578407e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,8.500145167281689e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.00089745049959178585
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,9.418375763538194e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,9.883122266618038e-4
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0010414766884081848
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0010911373950708522
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0011385100796829607
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0011878658946447283
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0012431487031325948
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0013045101286798019
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0013674153342770911
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0014426338128726499
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0015402207650578078
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0016553678381445562
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0018685283099310979
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0020551981108233707
+2026-05-09,15,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.002268428741337931
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,3.6450629724917174e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,4.4762228391474925e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,5.256577512689545e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,6.148590047268922e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,6.898456503706357e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,7.504025549103111e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,8.069489271710483e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,8.556685297153573e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,9.031657741866173e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,9.540880815769827e-4
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.001006075702685734
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0010644367653000414
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0011206184455711265
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0011830411425934983
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0012365659164380416
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0013046427921130455
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0013683060825789295
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.001447101105849465
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0015476614077688591
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0016860074370051003
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0018838671833621458
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0021017612139376547
+2026-05-09,15,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002460522897504498
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.5063280142974464e-4
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,4.372341730514703e-4
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.516991915194887e-4
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,6.862084184485078e-4
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,7.865954790510039e-4
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.771713498642088e-4
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,9.504236029332961e-4
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0010293109254198764
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0010988206821113023
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0011690567867007331
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0012615842553896925
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0013490546229012815
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0014558086305209383
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0015632768811549595
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.00167434977659673
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0018108663033151076
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0019433181574548988
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0021029919018536753
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0023550364007467366
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0026255695940928026
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.00303901014817395
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0035514186869809016
+2026-05-09,15,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.004164903832417314
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.106112235750979e-4
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.775330092111799e-4
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.965871123757638e-4
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,6.470302106347681e-4
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,7.604660418446036e-4
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,8.49651955681251e-4
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,9.376448471549144e-4
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0010339288836214728
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0011255418716717776
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0012207856778491104
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0013342645134416114
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.001443671594413241
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.001564774232561929
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0017147463359822143
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.001869060159910753
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0020607318457262725
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0022511114637060346
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0024512554367416743
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0028085388421220676
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0031879765812643165
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0038683189122262294
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.004516522423622063
+2026-05-09,15,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.005102496784265337
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0010903272865964888
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.001246872989071985
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0013454262636284965
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0014718803740948572
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0015485258314757878
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0016190892239766835
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.001666148902576042
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0017212386039195135
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0017554576805553573
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0017935645041011214
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001828077289126133
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0018768705606659244
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0019219817818694482
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.001960046132515097
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.002016570018376971
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0020709779039194643
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0021376955895604584
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002207474877270002
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0023203593534567813
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0024964092370929765
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0027093393016406576
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0030088992073811715
+2026-05-09,16,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0034262508504128253
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.070562574899963e-4
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.381435774845588e-4
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.449841808891757e-4
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0010678530885811282
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.001164606814641183
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0012506227475671083
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0013253648005793473
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0013896575232110798
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.001455013566768722
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.001515431965326403
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.001582058829664419
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0016467449589602427
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.001709210062785268
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0017824468970459848
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0018507554776189677
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0019354895812138946
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0020356082538580803
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0021472571742295575
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.002287353553507455
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.002451207702547695
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002740331453774571
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002990234017926752
+2026-05-09,16,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0033678269110638107
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,6.211131114779923e-4
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,7.262908100880881e-4
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,8.325086084438777e-4
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.709193773907312e-4
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0010725858310353664
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0011598635925121827
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0012426167774924383
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0013116535942951145
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0013784930770468315
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0014425063662064682
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0015105573845912302
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0015854788490380143
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0016524440317308164
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0017246181385740466
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.001803610847432859
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.00188258813673697
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0019801844712269397
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.002105094524975712
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.002312465522117594
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.002598969885968127
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.00308688839610494
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.003611953005160826
+2026-05-09,16,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.00436797921251126
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,7.275165735026907e-4
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,8.686634904934369e-4
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,0.001011061281128648
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,0.0011897128654904743
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.001320015871420574
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0014366119484595808
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0015264181014318324
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0016270774472706595
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0017076966740637721
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0017942961482823728
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0019025919450328486
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.002006908516922882
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0021289052398731807
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0022507101475390838
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0023728918522917305
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.002519590571466005
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.002661790041327681
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.002828364748328609
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.003076408556157597
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0033575002344540155
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.003772370325269059
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.004269053696131965
+2026-05-09,16,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.004793596401945834
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,6.677935739805527e-4
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,7.82233112126315e-4
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,9.559279100256988e-4
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,0.0011482937884458248
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.0012864433247811546
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0013968714839966024
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0015031122569949644
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0016135518038093055
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0017244935383308809
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0018331998029843142
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001963840784694728
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.002093853773591543
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.002235007866831378
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.002397665104395324
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0025608316381842172
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0027565727553790233
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0029580933470378557
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0031676452032639293
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0035204770448393997
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0038892479533843127
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.004534917427906073
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.005135766485838392
+2026-05-09,16,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0056549441878434945
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,3.1874396237779705e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,4.3015908995656243e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,4.877315076735236e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,5.65876716792289e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,6.09847958265942e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,6.54041228226427e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,6.82640673632787e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,7.194870911366143e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,7.372379600065824e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,7.564047257287217e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,7.796143090576124e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,8.114765374388391e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,8.42340318979672e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,8.655594070691869e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,9.043139634657758e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,9.425298689025103e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,9.873212090599662e-4
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0010331348683931653
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0011103308035672332
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0012556648001750997
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0014233846120032406
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0016816035539407746
+2026-05-09,17,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.002095059590788305
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,1.6399446502346577e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,1.8238363199090765e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,2.2338774595495587e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,2.775847714573694e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,3.0490023236902917e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,3.3388648871446444e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,3.478262043566966e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,3.687461588519925e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,3.806858459579144e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,3.8917301909230714e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,4.021306140187784e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,4.242651869775587e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,4.412391474863681e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,4.566009386834224e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,4.852438007487261e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,5.078421712858512e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,5.372683795618443e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,5.669401933628139e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,6.204653998583416e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,7.194735311325474e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,8.58189635880183e-4
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.001037281439395318
+2026-05-09,17,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0013581147975532542
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,8.928845486288552e-5
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,1.3301675274073586e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.0553952011889776e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,2.485574984155061e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,2.874113737237278e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,3.100420425106909e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,3.213690679531802e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,3.326353650956252e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,3.4726973239111107e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,3.5953178698494077e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,3.80519573330629e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,3.9499402596224106e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,4.089847047887097e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,4.410103341235458e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,4.75902459813163e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,5.066876810695746e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,5.619153414033462e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,6.216480982550024e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,6.726003007288228e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,7.469325381720174e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,9.780735556906102e-4
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0011707663377671985
+2026-05-09,17,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0014060567506653965
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.4483077592044127e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,1.9543619645321752e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,2.524288043310337e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,3.1453200970248926e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,3.728870099229893e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,4.130466734541972e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,4.444161686814954e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,4.814180971080961e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,5.092992137089077e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,5.411915883460651e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,5.739902336182211e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,6.103541755825847e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,6.43864942246239e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,6.834762369449784e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,7.328466235291344e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,7.888863232841498e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,8.379562517204053e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,9.094707938661626e-4
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0010228661209359536
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0011646106176761587
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0013984339315652487
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.001688089676202642
+2026-05-09,17,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0020746012016270004
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.2826501644925842e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.7680270792872342e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,2.4239367885617492e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,3.1875610101208705e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,3.7487169754193495e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,4.156525101676928e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,4.616010713685267e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,5.013947068227063e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,5.331744645620119e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,5.703168480465884e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,6.151738294905835e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,6.588809737470612e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,7.002745513572563e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,7.542396462166595e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,8.162482245025074e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,8.865502563130917e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,9.657561951001612e-4
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0010335844435349227
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0011724781976903654
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0013658721290175585
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0017171586876165643
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0020901364666703376
+2026-05-09,17,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0024165267335161476
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,2.5240079454533817e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,3.4735985466268415e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,4.007622423616733e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,4.7383296999653073e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,5.164120742658311e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,5.58459205591555e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,5.852747692000754e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,6.197059237845454e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,6.371342310833388e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,6.573262208303037e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,6.788799041168217e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,7.098875058229019e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,7.391263910001587e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,7.613994265196196e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,7.998590415396657e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,8.365856894851516e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,8.811688593090684e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,9.275716349124105e-4
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0010068526167569909
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0011464416479639173
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0013117548971172605
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0015643463545785728
+2026-05-09,18,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0019565816846894976
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.581034674402973e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,3.322132459651956e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,3.9556896386622057e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,4.754877853342096e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,5.278210977855471e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,5.81382109594933e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,6.237311446535478e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,6.679570261161319e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,7.099615021009801e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,7.480339234779727e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,7.891799725660056e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,8.296566251641174e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,8.70649642004922e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,9.182805556711903e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,9.624962355672627e-4
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.001013416171620232
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0010687254608725723
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0011333128388340314
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0012142238257104839
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0013252398905116585
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0014950312323088553
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0016345575260665432
+2026-05-09,18,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.001808196119494982
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.033552648728199e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.8515540727902647e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,3.6205898025711757e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,4.441370772407929e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,5.063891598799738e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,5.533702505857235e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.00059671312724253185
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,6.395966837974984e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,6.802566416869492e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,7.195974053250265e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,7.587320729409955e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,7.985848452581989e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,8.435411983709498e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,8.936839609448963e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,9.47361360589173e-4
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0010038797190519218
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0010613632869590085
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.001139002484733603
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0012223636194001867
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0013508197963666168
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0016916599978400915
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0021861868003747627
+2026-05-09,18,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0027720793488316634
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.982208787028379e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.736222329883371e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.5350708952854655e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,4.5008830017882333e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,5.28789960449334e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,5.939999116918008e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,6.449548153295145e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,7.050792991375803e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,7.517076045954574e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,8.047240022096302e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,8.710242732661118e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,9.362955193559235e-4
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0010168366904621416
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0010980438910432766
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0011824328720527384
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0012832483039940767
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.001378893718831509
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0014978193231033614
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0016982566280067384
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.001902130802329507
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0022100153711342406
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0026387727118140996
+2026-05-09,18,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003122147416961375
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.752796664605728e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.3379997667710272e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,3.263161664526265e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,4.375196915590062e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,5.21360882837848e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,5.869470302900556e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,6.55070587255823e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,7.264728032238283e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,7.928055375054576e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,8.644309873553299e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,9.522625581221487e-4
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0010364829190501728
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0011301285039268388
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0012455154176375129
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0013647234530982152
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0015100659586213773
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0016623891162143288
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0018090113647919515
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.002101769852993721
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002403910476408552
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0029696572332592462
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003531704650533955
+2026-05-09,18,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0040173835113388
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,6.264070482280885e-4
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,7.875355395408742e-4
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,8.787885943738627e-4
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,9.996861123530898e-4
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.001070974623747503
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0011388648024549196
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0011854809837855513
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0012415001457216936
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0012734630039657451
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0013071095132053945
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001343124893794836
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0013913872488815423
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0014378215136695563
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0014764391074123032
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0015325024393149042
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0015896402253421397
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0016565341817758297
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001725470397453327
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0018374878893500266
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002034095686733397
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0022680034772699347
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0026136561052611308
+2026-05-09,19,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0031436762731456747
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.925428945602833e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,3.4633422439882895e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,4.028711148553803e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,4.7152122148850053e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,5.324005718858423e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,5.733068809321202e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,6.123156022414367e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,6.499284923832268e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,6.861835044122199e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,7.192485244732556e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,7.606398016104086e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,7.964712697185502e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,8.301156406838302e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,8.669382317652708e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,9.095468265526409e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,9.410315857132949e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,9.965457620182622e-4
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0010531882384044223
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001119827062599435
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.001216149427741885
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0013718225699761216
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0015242140908722501
+2026-05-09,19,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0018782794911278405
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.9735223609045158e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.600997093673561e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,3.525572997510198e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,4.0621668640012683e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.536574885042282e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.840075691456492e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,4.976982575355026e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,5.1102505262582e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,5.299232677278218e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,5.450032447149837e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,5.698866762930154e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,5.891562157134319e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,6.209922146998892e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,6.660584822007146e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,7.232506110489703e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,7.842057421673594e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,8.533283932717704e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,9.118251834847036e-4
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.001023399302755874
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0011707236406357773
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.001438414487302442
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0017590151739030318
+2026-05-09,19,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002100758371839881
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.450255928955632e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,3.1221805055180765e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.8234333510031864e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,4.6010974023161764e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,5.361091143290498e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,5.833814036796681e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,6.2254286022688e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,6.627500896137012e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,6.955122936809961e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,7.352496788074858e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,7.735949249337924e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,8.165038093789201e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,8.559842339896503e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,9.004788284142671e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,9.59372029918467e-4
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0010284656473962437
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.001087016493904247
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0011716011055596222
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0013048926369582593
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.001469536179549387
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0017538813362277595
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.002094921918030293
+2026-05-09,19,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0025286709271130766
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.0546278642788457e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.6793558908023236e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,3.4641540963553305e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,4.436940505188438e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,5.112950243355602e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,5.623247807579447e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,6.203707716661382e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,6.691263579626182e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,7.056433696869767e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,7.544111060475119e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,8.068328489113492e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,8.561098589907649e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,9.05733260135187e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,9.681700043406252e-4
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0010322227959967995
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.001112918881537465
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.001200988926999679
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0012828199251832249
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.001449930829796054
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0016884660138391512
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.002099658401035763
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0025045901901094873
+2026-05-09,19,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0029387192078286833
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,4.0194533231990127e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,5.02556542475966e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,5.727114543175282e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,6.666413386919759e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,7.246634754853022e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,7.772567474908479e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,8.14396393065366e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,8.579295259381844e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,8.817607861958561e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,9.118022191987979e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,9.363734912995674e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,9.760624620644612e-4
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.001010662222519227
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0010410762799921453
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0010850489924780352
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.001128449698078004
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0011791311547876306
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0012295496178766137
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0013185952988525778
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0014545464465040956
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0016104507289998087
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0018551009441761968
+2026-05-09,20,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0022045317080325692
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,3.2617654315017774e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,3.996184911619966e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,4.670436115912812e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,5.55476203380475e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,6.267936732024451e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,6.808393199504613e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,7.286842910061257e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,7.715215943441933e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,8.171332471455386e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,8.598739055065661e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,9.015658835697304e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,9.44625738249038e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,9.911610135866038e-4
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0010419582746546124
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0010981742020774073
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0011552072288304566
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0012073638041219304
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0012670594466950237
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0013512934869971335
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.001464899602617102
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0016587653109285828
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0018158659165056783
+2026-05-09,20,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0020213543824234882
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.847827105758635e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,3.6141450192553586e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,4.265836280081504e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,5.295093164560424e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,5.917967739869072e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,6.476893215529341e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,6.965600507792113e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,7.415757090152473e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,7.951098507210563e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,8.384499963350773e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,8.861202827804297e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,9.303844584118057e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,9.733600833616514e-4
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0010310784242451628
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0010840675341504083
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0011421814498471005
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0012099092779306697
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.001282420679603071
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0013780970073686784
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.001506549735272365
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0016922915606079408
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0018636870865228012
+2026-05-09,20,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002084204189814175
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.7599640832723333e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,3.48609651683068e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,4.34416855616239e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,5.393284744251801e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,6.233832711249164e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,6.955494278510061e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,7.514398355461327e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,8.171538575652324e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,8.696961981508104e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,9.259051319033136e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,9.943285684209102e-4
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0010612372882870913
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001141604466931565
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0012248830294320102
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0013121962156754888
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0014154543858102622
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0015141013845827288
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0016372161387591465
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0018306138307432834
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002023601780747739
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.002337053489596678
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.00274009255684261
+2026-05-09,20,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003182604088272119
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.481890447974772e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.0403348177164406e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.0437880527353226e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,5.217696063327352e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,6.077628736204928e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,6.804678768010594e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,7.559311586254303e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,8.271443230716313e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,8.964739194732641e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,9.731405213066498e-4
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0010635459217847327
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0011491175316782124
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.001243701476909557
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0013650108122393845
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0014840923158514424
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0016256347524436872
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0017713401520892777
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0019168259171776013
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0022049353686553435
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0024953620031929044
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0030126042516575727
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0035099042686914236
+2026-05-09,20,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.003946953243513483
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,7.336090760655859e-4
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,8.857680097037938e-4
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,9.635789367853923e-4
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.001065056530281497
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.001121863455280584
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0011791060986837219
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0012159015492735202
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0012624520742870824
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0012856838457962702
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0013103678973930277
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0013390790511737837
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0013791289010944324
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0014176531426384235
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0014462189735008478
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0014939458756242847
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.001539727225648445
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0015942976439202372
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0016497831902097448
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0017421116275472114
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0019111957870282664
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0021022548374638127
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0023894329006640225
+2026-05-09,21,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.002828492544356786
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,5.302781795367509e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,6.142759198005494e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,6.982440662921748e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,8.202643106752675e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,8.967774029243977e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,9.496391749916058e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,9.806863348229688e-4
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.001020326821507296
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0010445094680827298
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0010652180241460182
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0010908331295887358
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0011285899441493817
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0011590076931427772
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0011885206633666795
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0012321173297314423
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0012712842150561096
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0013181508421271472
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0013639195448616242
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0014417819753619954
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0015833846660271353
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.001765862049204038
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0020103911820795487
+2026-05-09,21,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.002406508339769625
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,4.6788840950951345e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,5.599079644272825e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,6.411577028664484e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,7.571582654206246e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,8.368352065797372e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,9.103460125968415e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,9.434421791065761e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,9.74031838959011e-4
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0010076307011667534
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0010356600424046409
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0010791424821997048
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0011118741608853358
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.001146572507912258
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0012066336519650294
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0012702147987541039
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0013266010524744867
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0014166879752285958
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0015128248364044581
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0016016962055962183
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0018311246754334383
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0021624010345316397
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.002388990600465986
+2026-05-09,21,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.00271820933506367
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,4.276372285611928e-4
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,5.18399010674373e-4
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,6.18183252328074e-4
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,7.257258605505925e-4
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,8.192244472143833e-4
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.86664202727476e-4
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,9.405451283930963e-4
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0010017496840028426
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0010431212586567342
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0010975377213247467
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0011538311916569999
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0012160618423792404
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001275043264950829
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0013386250189792624
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0014210142066810299
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0015065664106751614
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0015833966601183358
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0016909357782440562
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0018636626147611537
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0020608299981795843
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.002362345867717248
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0027581259220356967
+2026-05-09,21,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0032477085809295434
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.903398320569321e-4
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,4.634486915389166e-4
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,5.838009842917479e-4
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,7.127628943766123e-4
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,8.053786522752745e-4
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,8.719708186465348e-4
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,9.461823335811727e-4
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.001016912710436718
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0010763797559484776
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0011432427574890921
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001221748864267493
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0012892031019131277
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0013603010393103126
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0014509289948302874
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0015470751395455398
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.00166664339327651
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.001788432722446905
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0018928202181145595
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0021113425189103145
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0023823852102105216
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.00285722193294075
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.00330607180464021
+2026-05-09,21,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0037049258494019836
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0014390402368175503
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0016565500602788207
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0017995420311345096
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.001971564894073853
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.002080230871642103
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0021812797171766943
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0022583031014093186
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.002340324834611966
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.002399141130018693
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0024559287041033494
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0025083958303322184
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0025784451632966704
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0026463127712034124
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.002708725207785712
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0027811400943388766
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.002857234831338908
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.002947934406803634
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0030405092497450747
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0031805459936428433
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0034047437198949297
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.00367243545921596
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.004050842664139485
+2026-05-09,22,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.004572600336304593
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.815011377141103e-4
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.673951419837556e-4
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.717038457422583e-4
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0010959068369481672
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0011994671263967794
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.001266894326532003
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0012971831081444332
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0013374959875481441
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0013654948313476
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0013864551450321156
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0014158660265207099
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0014571706149727232
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0014930127378858318
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0015218425546494798
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0015773856607647957
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0016184862087014792
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0016763041225849238
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0017432546566291736
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001850002744830625
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0020228095646982404
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002277078213910658
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002568572190202803
+2026-05-09,22,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.003045532107547816
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,6.402629598187795e-4
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,7.497871047348288e-4
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,8.619315055136999e-4
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.679123575924331e-4
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0010386531226650158
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0010920927580082157
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.00112229202233052
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0011516454513027616
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.001188232184397902
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.001218022190495074
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0012570251079094996
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.001294465814020004
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0013277978414019845
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0013810267895706684
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0014419403369724936
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.001502046251419839
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0015943357367233842
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.001703732860057967
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0018058629121990746
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.001960955130228358
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0023683398661671594
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.002691125426089613
+2026-05-09,22,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0032335334249474694
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.52808140948119e-4
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.573449858393709e-4
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,7.606850702862346e-4
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,8.795755268787513e-4
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,9.847586179134629e-4
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0010578044540283519
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0011177453516376683
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0011740820016672591
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.001223225758014582
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0012811458608386244
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.001336424114654157
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0014004413612264972
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001460045970879898
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0015189235417146626
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0016007705986249622
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0016915959261781118
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0017789739223559747
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0019000705135676396
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.002079161854595986
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0023011967261824216
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.00269559493762305
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0030966708128771668
+2026-05-09,22,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003652393837920295
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.6109404013636786e-4
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.633099372514325e-4
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.771897201171887e-4
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,8.096716025874423e-4
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,9.064913512017777e-4
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,9.792642439407388e-4
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0010567895753634897
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0011257434926053725
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0011850382947315172
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0012558259491091469
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001326261537482752
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0013889236128787207
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0014620934139053842
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0015441675940641752
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0016323707038756626
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0017381508474379093
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0018619049577560135
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0019902237699303883
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.002192823707387693
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0024815421438985153
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0029528454262578753
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0034484858158496928
+2026-05-09,22,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.00400168435950714
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,6.060291852853858e-4
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,7.631678813637868e-4
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,8.593701484982826e-4
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,9.806198992704232e-4
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.001054202474756098
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0011273016572546518
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0011800974067456976
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0012411995884425645
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0012767869206890272
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0013137612244848327
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0013500266168225564
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0014043220894613356
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0014556872495517991
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0014980276659321357
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.001557054095363654
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0016156319837779811
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0016854413608632197
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0017543575479826298
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.001868923522311428
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002069188846350939
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0022918085257270016
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0026405426112575147
+2026-05-09,23,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.003156762911243045
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,1.5287958774320835e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.160585929770726e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,2.604884361528274e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,3.0897667870672627e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,3.326255243253538e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,3.623555694564929e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,3.74464683697569e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,3.932911319578142e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,4.038898253833581e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,4.092747604310633e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,4.2238080938359853e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,4.449304349328694e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,4.6219933292659677e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,4.7893896830527953e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,5.329839529278809e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,5.550886185172098e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,6.099092863965295e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,6.480106818148493e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,7.217915864233569e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,8.150853509239892e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,9.986425953943901e-4
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0011699992001973007
+2026-05-09,23,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0015263162713464809
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,9.425774299186812e-5
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,1.4189765201283767e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.0956760882379847e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,2.45805106667517e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,2.774706744327418e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,2.9867772065354266e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,3.0348282000122436e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,3.0934975156341686e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,3.214283549254683e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,3.3021150378249203e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,3.4485046908307203e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,3.577353492670316e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,3.6791696603363804e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,3.939917093955957e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,4.234604785026256e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,4.5115473419929207e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,4.997169300717579e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,5.587460614705486e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,6.075558225110314e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,6.820293302494898e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,9.382174659153665e-4
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0011407582707033772
+2026-05-09,23,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.001494442305813643
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.7709192986199262e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.3064343322711097e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,2.890436200030619e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,3.5267395923854685e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,4.1463672105463036e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,4.574476691189971e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,4.904020497321391e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,5.235498339805924e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,5.51095711999656e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,5.861308019732337e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,6.152199780278693e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,6.530435361143698e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,6.818819472781094e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,7.1636637051407e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,7.62207504239632e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,8.143165913604692e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,8.60332388040013e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,9.319975435548233e-4
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.001043223952726777
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0011794978525868703
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0014283231046476725
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0017166875201998018
+2026-05-09,23,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.002123992698646326
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.4619940298703937e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.9138131092863426e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,2.638427702419695e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,3.3457776523156357e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,3.9359903986704164e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,4.3354493894294906e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,4.7955640622653333e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,5.206912359007699e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,5.530901637365457e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,5.918080424158649e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,6.345897288827721e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,6.713226707745285e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,7.083958409242339e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,7.518946627108232e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,8.018245792520888e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,8.681385921009016e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,9.40972127099524e-4
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0010095150038639089
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0011389544147413473
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0013326686803302487
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0016638953480659936
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.002010550019783947
+2026-05-09,23,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0023769596955861066
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0011374144524458694
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0013233635781411824
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0014453730283238652
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0015968699150760218
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0016916935351568045
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0017815019502593222
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0018439511025598121
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0019144080618269921
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0019627910364216324
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.002012695697312245
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.002058060801924172
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0021209900484581647
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0021809143553486055
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0022323755580210673
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.002303638524353245
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.002372881132011899
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.002459750840562227
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002551021253756716
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0026939905305354717
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002919294391555568
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.003194895149667084
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.003580438883145528
+2026-05-09,24,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.004112300779040395
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.13239957645656e-4
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.42377801044277e-4
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.375374280777202e-4
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.001050386324567003
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0011158253094278787
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0011808794875768625
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0012202025447221967
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0012670303797243545
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0012998147246015177
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0013276102873707454
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.00136235545273215
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0014079282092816462
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0014482227777178958
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0014835882525370842
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0015404051401704335
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0015872496343014217
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0016492224696599183
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0017186724732731731
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0018270285612924833
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0020063194306615428
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002257736870403887
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.00256795506316587
+2026-05-09,24,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0030587294838808825
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.267271191668252e-4
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.400476458252283e-4
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,7.709987834199096e-4
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,8.758440330783249e-4
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,9.57359934895966e-4
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0010202587878920422
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0010626592184647056
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.001102383910303356
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.00114776064394756
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0011847233212551964
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.001233098938968951
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0012796048680769787
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0013253168898664735
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0013897162835430183
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0014617168517164895
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0015323052419518757
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.001634364179372846
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0017552292691990214
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0018744220638219184
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.002052316302275354
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0024847225039619832
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0028331974674527987
+2026-05-09,24,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.00327689946736169
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.095659573309747e-4
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.195549919176652e-4
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,7.184673334176845e-4
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,8.419815735679623e-4
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,9.520757179911383e-4
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0010383944712750535
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0011013849268016942
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0011681052757404557
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.001227282637872364
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0012869981143125743
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.001349244499543115
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.001421693055620163
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0014877415401797999
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0015574856609054594
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0016471992261659026
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0017432503476915969
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0018454564146518988
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0019793299251721964
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0021711219805613143
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0024068919418719654
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0028079078467483087
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0032513290465398083
+2026-05-09,24,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003799575993309718
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.266931442068433e-4
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.26885618376086e-4
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.431061262782166e-4
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,7.897276255522179e-4
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,8.904376576041248e-4
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,9.744231390996023e-4
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0010547218152579963
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0011343799848014763
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0011994857011807412
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0012768397343290877
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0013528365367583546
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0014320315948073946
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0015111908390576286
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0016097885656868186
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.001706916291616623
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0018361375605149446
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.001969943558081207
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.002101696005623795
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.002337661142711363
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002662966857251128
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.003189596397367738
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0037421624300243757
+2026-05-09,24,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0042823705727208046
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,8.354879386871169e-4
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.001009267376695292
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0011248896797704689
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.001273116482401986
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0013657040460472592
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0014483832406603234
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0015120612070149103
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.001581537680515586
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0016262705940386318
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0016737361335370767
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0017164862583933453
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0017760299946519389
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0018314080046246206
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0018840008933537467
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0019454770107930422
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.002012319848736706
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.002087502404335852
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002162504934937323
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0022829422125460984
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002474143938094541
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002699150552759372
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0030351402658079295
+2026-05-09,25,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.003518620085246752
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,4.3444731500130745e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,5.33341011168315e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,6.044225442728729e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.882210904526605e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,7.335288268208113e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.81984663556362e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,8.080495709850507e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,8.417523722308485e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,8.632656289931467e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,8.797193315442628e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,9.038509728287202e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,9.386429718124448e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,9.67409266458706e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,9.920626056525877e-4
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0010368884169187226
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0010711854096836619
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0011182248028669664
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0011690998922619614
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001253904751246448
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0014013356838235421
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0016075046145955984
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.001866315580590974
+2026-05-09,25,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0022985990094307037
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,3.2069830889348437e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,4.037350854300349e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,5.094304508012268e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,5.823613703119472e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,6.414669591597998e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,6.843320455513602e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,7.079592763898997e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,7.303530023525912e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,7.5881599198182e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,7.811833409309889e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,8.137506636260168e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,8.429588770614633e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,8.706909045314197e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,9.181603447055677e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,9.704202734867912e-4
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0010199108680876581
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0010980171231561426
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.001189119769639603
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0012732148352512834
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0013972952808780253
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.001742030593826451
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0020181018875574876
+2026-05-09,25,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0024433298530679055
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.4858738048090256e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,4.1992479866597717e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.034895946826201e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,5.930688023219956e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,6.737737462663249e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,7.333468897728834e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,7.773757682406221e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,8.303424649999415e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,8.703548439611896e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,9.148646371666409e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,9.603021423010866e-4
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.001013579902960652
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0010564912629746567
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0011109636783568561
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0011788612770028115
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0012537915274589155
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0013233153117393579
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0014309285536096368
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.001588426840290668
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0017789287251220565
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.00209291830409045
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0024587703646641867
+2026-05-09,25,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.002930659211062373
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.739644096322544e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.6084232556997766e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.5054362534285354e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,5.556387431219669e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,6.317855030747333e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,6.91399247534112e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,7.574842613152192e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,8.137854733606582e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,8.617355791088412e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,9.196417869478865e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,9.799556657246928e-4
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.001036822291192772
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0010980307007179568
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001168601489573996
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0012503170288936548
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0013464138571448818
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.001447719927067523
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0015505518167331822
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0017376846032417042
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0020025311504721505
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.002454647571854105
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0029168745493867642
+2026-05-09,25,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.003395708293958204
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,2.85629309623083e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,3.736468663938558e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,4.2075641581387204e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,4.846184020581173e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,5.20073988463137e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,5.582767929348193e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,5.794457816308668e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,6.095908694426934e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,6.21154248407002e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,6.374370290434586e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,6.541881118941679e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,6.830160581082098e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,7.090258382418356e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,7.24830419704573e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,7.62766116204722e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,7.941023268865087e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,8.351545947929774e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,8.773580992430473e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,9.549377077784176e-4
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0010906167823730635
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0012405901637556828
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0014810880600772767
+2026-05-09,26,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0018436426025978806
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.5496836628549223e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.8902476630338926e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,3.4683136494725175e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,4.272354342320409e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,4.7340522016094426e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,5.171397917434631e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,5.468217579141019e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,5.81134391687822e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,6.01539768258679e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,6.210217387128421e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,6.44154855528449e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,6.770264319255406e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,7.042911875012503e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,7.314642022281238e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,7.679570048263419e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,8.022290002885409e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,8.417204640420267e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,8.798416647669534e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,9.428023322602113e-4
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0010639998123506622
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0012077346026501653
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0014259272956110498
+2026-05-09,26,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0017810765210253849
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.5500829511744954e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.2091942067236118e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,3.151628795796996e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.9361383586095295e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.553058881890707e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.978793719575427e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,5.287841066741059e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,5.5822603283604e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,5.896208845800044e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,6.152712928163548e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,6.539780495874001e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,6.851400631474864e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,7.215021445106256e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,7.77888129900372e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,8.375237538949676e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,8.907589190565461e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,9.667098323690549e-4
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0010537156659140886
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0011389363799036646
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0012591800745627114
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0015278978932724747
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0016879184688123135
+2026-05-09,26,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0019218140449328942
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.97499403074631e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.5727946438706706e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.3119428029857064e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,4.113535955060646e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,4.8182233838126964e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,5.368443047105953e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,5.788350664407615e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,6.28844267570389e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,6.619964005748213e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,7.051606113916287e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,7.536156145900369e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,8.048514895011453e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,8.597825443925134e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,9.1676600015255e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,9.785999186205283e-4
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0010555394619274317
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.001124155532526138
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0012170320826836519
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.001372395660563199
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0015292869040518563
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0017839004601438676
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0021466723326004334
+2026-05-09,26,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0025246292124634453
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.7693958785706143e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.3074903857117724e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,3.137652910968211e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,4.092813811170286e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.8175002383713417e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,5.406767817901846e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,5.991183364277019e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,6.579442711546685e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,7.062400424687702e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,7.61045471079659e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,8.279063464459052e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,8.885563114523864e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,9.5510368439934e-4
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0010407661930512306
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0011270287556284255
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.001234230369178454
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0013427381719387918
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.001445320372619202
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.001663225387507523
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.001903414145659668
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0023356009499324094
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.002758080762107128
+2026-05-09,26,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.003132231179271994
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0013216152688726088
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0015505197993270054
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0016928949134203486
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0018693349393422984
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0019775492260214887
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0020762197414322635
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0021537074645184076
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0022370577350004964
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.002290921851319358
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.002344159774379813
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0023954641137257085
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0024646344153755055
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.002530703213268567
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0025924864995279717
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.002661480816522361
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.002737901762265165
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0028226642780118725
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0029058491081325175
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0030358744426732696
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0032541165731796696
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0035027104609784638
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0038745886665023203
+2026-05-09,27,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.004414739051814364
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,6.526050035819204e-4
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,7.656887522040276e-4
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,8.520466915903037e-4
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,9.37733768675468e-4
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,9.795014880675328e-4
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0010292998065812003
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0010501677182121322
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0010820668555606885
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.001101300292347341
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0011125878758764223
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0011349228056862165
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0011802594823764226
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0012179618699362771
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0012598615820822766
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.001311894024845823
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0013644076899410572
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0014239290390996532
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.001490804741693353
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0015668201972300322
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.001682506090595493
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0018882285760663795
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002161091210134569
+2026-05-09,27,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.002630530892855901
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.322256233699346e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.275231324277467e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,7.516340151476233e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,8.189143709775055e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,8.763508111654747e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,9.15903990963098e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,9.29913494287694e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,9.438017123151014e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,9.668013558964098e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,9.840154544926477e-4
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0010118614839054589
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.001035701554713103
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0010545450974289194
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0010981707302331924
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.001146226631917535
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0011912704290034006
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.001270620817793426
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0013615097673354817
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0014385323742290557
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0016136081784869625
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.001912201833346669
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0021924597027223034
+2026-05-09,27,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0026481589607013018
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,4.939879661871864e-4
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,5.944207848880125e-4
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,6.900205660227607e-4
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,7.883925821406839e-4
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,8.876292611138359e-4
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,9.485438262955411e-4
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,9.998066495296822e-4
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0010529675580316859
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0010947072204138494
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.001141769701013133
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0011872524102991145
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0012419510145034824
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0012855031622724577
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0013378478311037289
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0014087827298683879
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0014830836253962585
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.001552427169634739
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001662568619380351
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0018239939804864521
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0020300172865403295
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0023622239188936618
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0027420673385619575
+2026-05-09,27,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0032888278292548395
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.269210441145936e-4
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.233568502642434e-4
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.253305630685288e-4
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,7.451615199908534e-4
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,8.324073028881688e-4
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,8.983702393666548e-4
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,9.740380916725594e-4
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0010357329653681916
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0010810987267728257
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.001140034180392675
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001205269356035602
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0012599962146176225
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0013190081350573832
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0013875949884151948
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0014688589801576143
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0015690706468251378
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0016731370745658078
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.001770822363991352
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0019524745743883464
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002219575424581602
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.002669703364224715
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003119353597579355
+2026-05-09,27,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.003633660249996903
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,8.519350381481217e-4
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.001000325812405873
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0010843338123333417
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0011943172101623206
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.001258912608390175
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0013209351924705916
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0013596534995439732
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0014077425186873366
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001435827245185537
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0014666204113533896
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001497950703098867
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0015406524837306614
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0015812876850868794
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0016128451270264197
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0016656950443949276
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0017151762156102615
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0017770864670774175
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0018430339786044653
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0019497616965760134
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002126837946837766
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0023422571336143764
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0026450026647288085
+2026-05-09,28,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0030848271372155315
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,5.341166694083775e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,6.219329611405226e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,7.137481381807826e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,8.270267241923809e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,9.121600470438404e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,9.80294259777777e-4
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.001029510815701938
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0010705111941615602
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0010977485423298095
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0011214196845094058
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0011500933054211203
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.001189077409633158
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0012223552758857529
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.001253386458204611
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0012996107668044727
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0013401863612078598
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0013908068896917552
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0014440704691529097
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0015295268287948349
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0016768345284006259
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0018740542264307158
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0021288702354551226
+2026-05-09,28,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0025316905643461623
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,4.6210411827997747e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,5.589520898127717e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,6.477178699820237e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,7.561386686287675e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,8.465918741800926e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,9.03987938688859e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,9.414196832385073e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,9.76098939376946e-4
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0010143584273142386
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0010459250434130003
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0010901577928260505
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0011285069776393675
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0011679452979170748
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0012272291230640197
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0012916414397377105
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0013520351754595181
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0014420751136907672
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0015435983188269915
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0016421531465421488
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0017848767113393797
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0021327829417856718
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0023485386568237155
+2026-05-09,28,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002601833070093934
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,4.0749088973407455e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,5.001518534818701e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.992444634440492e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,7.038442545000926e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,7.916200166635601e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.57202816981164e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,9.119251876194515e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,9.69531376800718e-4
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0010151334582663598
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0010687017469045625
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0011279158482253523
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.001190282774785304
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001250146447770925
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0013156539491790704
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0013924351907760894
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0014808638395216276
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0015646230548165474
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001677202457700192
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.001845935738606196
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002051835264531875
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0023879763451418326
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0027778797617963305
+2026-05-09,28,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0032529884339710883
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.552889162216535e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,4.34953555369277e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,5.350857123494889e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,6.580165802281973e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,7.489396367166272e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,8.173658928486876e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,8.899925409104356e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,9.567433959776029e-4
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0010174851266850202
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0010851632433875242
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0011573572315735328
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0012243298586575241
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0012987111428767024
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001386738495123628
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0014773852290654314
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0015928368364310623
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0017158421229722344
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0018397619291650636
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0020497878164693526
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002321399389631375
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.002769169028480147
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003258158319332786
+2026-05-09,28,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0037115536642861923
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,1.849887409650261e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.1269275489885895e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,2.5203312820763855e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,3.0302109177117204e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,3.339300205400603e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,3.6400442843850686e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,3.9479768410071933e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,4.187051815194511e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,4.433629564708588e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,4.696401847913921e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,4.946352841362579e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,5.213601140738548e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,5.452972147877288e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,5.70452179173049e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,5.997542440327472e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,6.307177808325679e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,6.609175604175442e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,6.963275658469089e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,7.398450188272919e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,7.875387747444809e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,8.875796242672826e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,9.692494514098199e-4
+2026-05-09,29,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.001060884384878858
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.2998545881009773e-5
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,4.6616700842987786e-5
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,6.870621840244335e-5
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.509745623419613e-5
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,1.3158007945404917e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,1.485428012450707e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,1.6930168389923622e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,2.0394593294092056e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,2.3078105045324298e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,2.564213101896317e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,2.800948851639875e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,3.0856478427294227e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,3.3523347205309203e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,3.6503323860726493e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,4.0101605400663545e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,4.339574834180171e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,4.796998380185104e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,5.380431203737071e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,5.859441269828466e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,6.659270485667732e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,7.977158970852681e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,9.868827321522044e-4
+2026-05-09,29,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0011779926569291832
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,1.1165354795802109e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,1.6094516933470537e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,1.779965551568861e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,2.05006532318781e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,2.172122106925352e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,2.3287042932938914e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,2.3703537233172228e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,2.479830100062637e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,2.487837729363801e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,2.52920524116673e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,2.602325576104489e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,2.7151783748994256e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,2.823690934865506e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,2.846857634695001e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,3.058573306037862e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,3.2021895552231735e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,3.418509704463985e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,3.668035906072405e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,4.1291999747034155e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,4.980482444175684e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,5.96964825620553e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,7.504031761475148e-4
+2026-05-09,30,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,9.900959061913256e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,8.161875912066854e-5
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,1.2984020227601616e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,1.6876451890676617e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,2.2403856005823088e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,2.543680039069245e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,2.854722095049859e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,3.073138598534633e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,3.316493813059802e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,3.453913660875709e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,3.587178412247627e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,3.765557548755719e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,3.9914551880475946e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,4.163571795201362e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,4.357903081502696e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,4.5779505698804817e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,4.810220554926904e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,5.078560728536794e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,5.287681546696332e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,5.792631696199045e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,6.77228719342865e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,8.006429056194595e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,9.188783015745015e-4
+2026-05-09,30,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0011627961879918304
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.393240226755463e-5
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,9.84730881399653e-5
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,1.6545177063582536e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,2.2082613800524935e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,2.6568102848889644e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,2.994467310401008e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,3.238181206776916e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,3.4330089377364184e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,3.6517108187301403e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,3.8071129474087086e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,4.096495393935979e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,4.321455369817554e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,4.5850546858307854e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,5.016078448965153e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,5.428621422007147e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,5.783440734388144e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,6.34601851645218e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,6.937906855815883e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,7.529852977337683e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,8.248253321704833e-4
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.001024255507161147
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0011886434255719742
+2026-05-09,30,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.001383302477018035
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.0179319371718802e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,1.5183579410973154e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,2.0562549688472333e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,2.638341584277025e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,3.135986554285056e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,3.5893556541481263e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,3.8982663810730047e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,4.2926935192971223e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,4.547263945871733e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,4.872533418612662e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,5.259750515170434e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,5.662233842591124e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,6.124833416525251e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,6.610623193560026e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,7.097475251317596e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,7.719362060833885e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,8.277353419492828e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,9.003929689721816e-4
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0010151631872167555
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0011451482948523738
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0013277483029766586
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0016062675051973798
+2026-05-09,30,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0018853989222721028
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,9.364153588724348e-5
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.3234842665263072e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,1.9871148230685327e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,2.738405001131278e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,3.316531631820521e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,3.75500695846359e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,4.2323086947701916e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,4.6481791234315585e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,5.049694499093438e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,5.560174219342042e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,6.122422469898053e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,6.687086924799493e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,7.251106518869771e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,7.933743116364147e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,8.635538406146176e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,9.506992441836453e-4
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0010416568397993544
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0011127237982592394
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0012823858135062706
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0014779137214804051
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0018476400266560903
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0021921481673078357
+2026-05-09,30,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0024760018221839106
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,3.6546094956311587e-4
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,4.948343063851245e-4
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,5.931410231316507e-4
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,7.187123500377887e-4
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,8.028575668857439e-4
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,8.760246430194457e-4
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,9.432651315875472e-4
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0010103103883405684
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0010576072982555291
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0011051097357522761
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0011460942703504784
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0012033176919377818
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0012571841845515435
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0013149549327088569
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0013653953097076043
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0014289450082771618
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0014944217903339594
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0015552724220567271
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0016502823495311936
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0018004233399057901
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0019655761842868715
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0022396448799763403
+2026-05-09,31,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.002634507314641465
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,1.0032357901301612e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,1.5370057892666973e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,1.928417522019782e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,2.385475148098108e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,2.6371457636841455e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,2.91437909454222e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,3.055122833459562e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,3.246709524192447e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,3.370265103621263e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,3.458703506642169e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,3.596798164719572e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,3.807413793393885e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,3.9841356236308646e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,4.1279266537959847e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,4.4201343464387926e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,4.630049184946102e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,4.930858433651696e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,5.274900475260234e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,5.850378156215095e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,6.845135943273787e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,8.322946961703622e-4
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0010143627421985448
+2026-05-09,31,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0013375339327942634
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,4.133310786523244e-5
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,8.100771502146491e-5
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,1.348469524530593e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,1.7187429590848297e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,2.026615566929242e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,2.2513823750117308e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,2.3619160584919418e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,2.4750448201972335e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,2.6280024541324587e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,2.750940648268589e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,2.923838238430365e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,3.0849327113057986e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,3.232469121678666e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,3.497532749028125e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,3.80226182526812e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,4.0983418340728494e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,4.5691319698178525e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,5.14478498581448e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,5.673470208635511e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,6.492237820087214e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,8.872976962684939e-4
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0010830951642634126
+2026-05-09,31,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0014185460748855768
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,8.914421080806585e-5
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,1.291715986559134e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,1.7253927844913003e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,2.2375792283304137e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,2.710526056384241e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,3.036947251363536e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,3.3304031850395037e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,3.62694335114326e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,3.884787920189595e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,4.1684652160450927e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,4.4316716275563846e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,4.752179775411805e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,5.025005250073934e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,5.31728912693231e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,5.750310005102628e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,6.221988083062518e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,6.653764699589611e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,7.310978030917668e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,8.282494792032572e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,9.541197928795854e-4
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.001174520257434797
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.001431521639898213
+2026-05-09,31,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0017965239926654893
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,7.824674597486158e-5
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.0321544822561765e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,1.5040411134264998e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,2.041309814033876e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,2.502785815571881e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,2.8619987189484864e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,3.250571642348467e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,3.5751363300632813e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,3.871409177573606e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,4.226214088543127e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,4.588934855076182e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,4.925882700001704e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,5.275215655904225e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,5.68595653035883e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,6.173791946805525e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,6.791033116092297e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,7.434088215753259e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,8.060635442712754e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,9.268804399972686e-4
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0010970925821559441
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0014044133880443017
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0017280377885780483
+2026-05-09,31,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0020556390368611376
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,3.145985572874662e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,3.972942969654279e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,4.4859493892423114e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,5.155425158235973e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,5.56384206213069e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,5.947385359840584e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,6.212538730656258e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,6.523120518116786e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,6.713567817592931e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,6.919400370431299e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,7.116719789735767e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,7.39163919318293e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,7.650905095254853e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,7.872184707657921e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,8.188565993783175e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,8.504112807034658e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,8.883860662354341e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,9.277909693600886e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,9.91787771665583e-4
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0010968907411115494
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.001223779800721265
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0014087381152251613
+2026-05-09,32,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0016794046106723074
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.9909340136310286e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,3.5885822472776763e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,4.213854599998406e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,4.876350925380368e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,5.313357315209075e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,5.798923169746836e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,6.124856596020613e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,6.51728558895157e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,6.835746922663826e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,7.147905194093086e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,7.451472011365595e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,7.734803036411675e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,8.013684397736704e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,8.348521935994087e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,8.649645804714699e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,9.050295075699974e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,9.514782265892047e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,9.950220725635393e-4
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001062100581083009
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0011489250090415616
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.001302346744262051
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0014321974512710232
+2026-05-09,32,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.001607493645707312
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.7737415389557543e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.2518946747426236e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.7498307842855246e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.5399915843745936e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.127572486265652e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.523498205130236e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,4.897374325700162e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,5.257981782064014e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,5.755362783387325e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,6.163930089871312e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,6.600981088805085e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,7.035111190507562e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,7.452464002800619e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,7.874655510360586e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,8.427299962001869e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,9.110961207021552e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,9.77554827243821e-4
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0010492871489840114
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0011657625926264255
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.00129450680459596
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0015719089312477212
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0018574707387616321
+2026-05-09,32,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0022587739916054726
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.0332243012864546e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.6633173999301193e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.3847304099864447e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,4.363654253417373e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,5.079869825558493e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,5.725942902680809e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,6.23868886590251e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,6.823303376864843e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,7.268780484006962e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,7.775215929787221e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,8.446716814288399e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,9.054421340726516e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,9.864544211348697e-4
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0010669916310602893
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.001145207107408207
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0012386104780136124
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.001332177606520189
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001442414026133763
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0016091505515373312
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0017860580860501814
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.002067498365308433
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0024039216437979766
+2026-05-09,32,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0027966289302304996
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.8424420070082252e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.3375360033623624e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,3.2137544452593466e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,4.215346267468097e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.988275217611538e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,5.606852628346384e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,6.224988950844785e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,6.853278923115531e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,7.487763648167944e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,8.139399341549668e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,8.924564743323959e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,9.699886539425424e-4
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0010570039864461057
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0011638869214801815
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0012726509292894515
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0014003668476868269
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0015336336208779007
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0016710709973319754
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.001920624026453739
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0021673428421698495
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0026127591533941594
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003032448603837557
+2026-05-09,32,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0034007379032441566
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,7.205734779205728e-4
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,8.812959776567126e-4
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,9.582197360585175e-4
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0010577839790351189
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0011134869021721327
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0011722633059779728
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0012076413295311862
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0012535944805829131
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0012802935222654998
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.001304619616461322
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001337305081756438
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0013767138698684161
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0014178430012156743
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0014469763097333152
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0014981815255434546
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.001546555487283447
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0016077492858337017
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001674037932990079
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0017763715536538549
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.001970650231719947
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0022072932738049634
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002538184004161908
+2026-05-09,33,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0030531965401109588
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,6.068563937445189e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,7.094087963778658e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,8.007263779113318e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,9.436992048840148e-4
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0010342852472047589
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0011064650206731143
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0011697464822376664
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.001233983757114073
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0012908678800486236
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0013492568742841118
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.001399824760133187
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0014600643376571384
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.001525630184220477
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0015946149097313005
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0016623106970531092
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0017274034452343088
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.001805270500581904
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.001895346431680032
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.00200707253413443
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0021399752003810764
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0023699882730980073
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002552606516088535
+2026-05-09,33,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0027818083072550545
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.239528637628063e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.314838470267702e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,7.342846572718108e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,8.720884487945406e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,9.668579746073227e-4
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0010410194786699342
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0011113211335494417
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.001184344723168485
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0012406379311640286
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0012969269681938791
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0013540452832616332
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0014140753510148124
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.001472212902390944
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0015354430115385666
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0016031929743278743
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0016768871263727536
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0017589722897329923
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0018622748933948686
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0019766875688360915
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0021398671640550497
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.002374448694013255
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0025606544475604933
+2026-05-09,33,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002870303396849287
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.241972476393202e-4
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.344932228758246e-4
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,7.665230145391014e-4
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,9.160606497572565e-4
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.0010320563575598083
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0011258765277211626
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0012034129835281006
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.001287658688076552
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0013588018348939996
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0014320223835083655
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0015205822578653954
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.00161408931420793
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0017199342289381742
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0018252985817140165
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0019409670754982323
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.002074155195185106
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.002201140337947468
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.002365615395491437
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0026234703580994894
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002899349574423552
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0033301577899409736
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0038468039535443713
+2026-05-09,33,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.004493535125571776
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.841896786574026e-4
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.765182678014033e-4
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,7.121286593967733e-4
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,8.823544853769996e-4
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.0010064273160495189
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0010967189736753574
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0011928646355245864
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0012921775074427881
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001382385850592781
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0014744291880590644
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001585621848673193
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0016917683447928433
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0018081038439167062
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001953229017032718
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0021101614995140054
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0022954259549314055
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.002478306800412706
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0026744889710323223
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0030165030274694415
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.003385013629903193
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.004043073896983354
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.004667812373580807
+2026-05-09,33,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.005253883635663833
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.001296749847491962
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.001496886198455851
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0016263571311809601
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0017837265639715654
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0018824177420482388
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0019758746215469904
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.002043491047648749
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0021177567050543983
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0021702287971796363
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.002221806247312684
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.002269864224543828
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0023346381180691907
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0023973368376500243
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.002452491744274903
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.002523090340251921
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0025939428256591774
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.002681247733831705
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002772036431121663
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0029109900995136773
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0031337066489309034
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0034033221101483577
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0037797827380088517
+2026-05-09,34,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.004299580828305445
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,8.712221213259609e-4
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,0.0010079091159797041
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,0.001108935051887867
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0012287476469114685
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.001297202054456588
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0013653611710945951
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0014085834576041552
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.001455061852308051
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0014896039180496265
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0015187161034328311
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0015550465565539722
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0016018777005847823
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0016430142505059191
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0016796508148957993
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0017372852220124177
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0017856385029675038
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0018494979316585932
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0019200229318904782
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0020307606383242888
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0022127580450153365
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002468350479805558
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002781418179037699
+2026-05-09,34,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0032692262655065548
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,6.671240218717083e-4
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,7.914578252350479e-4
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,9.334083399226287e-4
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,0.0010446750982052136
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0011316560299783284
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0011987284044104674
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0012445415940338918
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0012864132508486
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.001333960780749124
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.00137257342853392
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0014239734272810172
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0014725726106072626
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.001519685076138257
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0015865761104408376
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0016604920323340427
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0017328259014121733
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0018396774971478113
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0019631326769317566
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.002084741587119632
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.00226351472169334
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0027010222139414062
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.003041475639907172
+2026-05-09,34,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0034200406765589136
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.858776762775293e-4
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,7.026460208746726e-4
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,8.225348889592607e-4
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,9.535865319826889e-4
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.0010637101733862783
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0011454084538670302
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.001212395453368488
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0012792577617555805
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0013407380684803025
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0014021749497215635
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.001469897140198973
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0015420606574560228
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001612062327421613
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0016859992302712748
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0017791129747166887
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.00188056994383399
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0019787798660096567
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.002114886840601119
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0023139778926396268
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0025669775921099026
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0029796756269860076
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.003423766323140799
+2026-05-09,34,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003993181760234413
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.951236490199219e-4
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,6.050176182135929e-4
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,7.261828055663418e-4
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,8.753068861866284e-4
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,9.817087418192054e-4
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0010637357537472737
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0011531663875434962
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0012361867596410604
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001305740166303915
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.001384936229606186
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001466757308040616
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.001543646377141193
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0016270535936680278
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0017296121987391247
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.001837913743923544
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0019659452336231735
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.002103614564413275
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.002244622442611896
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0024847729875433215
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0028134303591932745
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0033439500119924782
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003906894992216091
+2026-05-09,34,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004447804376051436
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,5.796888084808928e-4
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,7.577373158764038e-4
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,8.816368280255099e-4
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.001040849861994482
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0011426167963443498
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0012332338282504613
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0013124907812318892
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0013949449921216897
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001445890627970624
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0014989565602570576
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0015462683199329033
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0016162699371886685
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0016807786515143216
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.001745665755498372
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0018090457159286092
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0018852173816643674
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0019629951720298144
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0020330987552619815
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0021498906321986222
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002346055286921879
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0025496852464278147
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.00290147977941491
+2026-05-09,35,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.003427689397083592
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,1.8986008078746285e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.65527004135855e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,3.178751763167904e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,3.7924062678984695e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,4.109419929289127e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,4.46852700549022e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,4.8576674806854715e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,5.05598132519943e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,5.550947253102627e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,5.757766976326472e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,6.24017709613796e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,6.618780090067564e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,6.892605650142857e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,7.38621040745902e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,7.817009426906098e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,8.21448310845632e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,8.806862783780513e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,9.4726735073392e-4
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0010210963849677575
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0011259794620175527
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.001307168957821316
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.001510877475544883
+2026-05-09,35,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0017827193308255355
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.2776209330265143e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,1.8281772846438546e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.641912916575323e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.1329118453923247e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,3.548212946756025e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,3.817228087881962e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,3.912576655872179e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,4.023130182587699e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,4.1933552204256956e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,4.32781186106678e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,4.5347860809800413e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,4.8282078895274874e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,5.34438024537726e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,5.782137366153e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,6.289470715267092e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,6.995659497374277e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,7.674897084929529e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,8.70015767311559e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,9.961438149986958e-4
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.001185245129741824
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0015335201547621014
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.001796192914066769
+2026-05-09,35,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0019839140659351257
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.8382475362420392e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.3754433319497827e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.024429559486912e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,3.692733889139951e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,4.3485986768812036e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,4.8193045111006737e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,5.176791381713181e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,5.541926125810677e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,5.835166087242625e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,6.198973384576876e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,6.537396837773793e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,6.957711609796827e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,7.303114968438932e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,7.704846489369845e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,8.205725793966891e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,8.789334211144243e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,9.329811897811505e-4
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0010143375021444234
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0011400284000845564
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0012951227575896287
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0015526924948714306
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.001897037574641902
+2026-05-09,35,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0022947353652065326
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.5531194167867082e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.0506679727843894e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,2.7461086185436793e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,3.5731317069918574e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.1966913552462506e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,4.637073156944627e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,5.146484818588772e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,5.597525597862902e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,5.933259072857268e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,6.368085626874282e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,6.848697135452634e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,7.257791176639569e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,7.709570135623834e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,8.24130298305158e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,8.866687878458419e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,9.655655083805405e-4
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.001050133716182782
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0011205256925817648
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0012692243667630707
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0014815729196972424
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0018817080862421514
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.002314716471220675
+2026-05-09,35,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.002730428383871838
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,8.727492928893882e-4
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0010131880741945409
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.001090832308834043
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0011896384522406766
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0012477682693966773
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0013059048910635642
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0013413920313141872
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.001385508730999232
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0014127535402055434
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0014407637445845592
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0014703220710182026
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0015098102279598692
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0015484242113848203
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0015771691645128769
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0016268397161169575
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0016720108311225306
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0017306835820029562
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0017939192306411062
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.001893762218954288
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0020623051897702112
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0022679642514232194
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002551317989310652
+2026-05-09,36,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.002958478349481402
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.395508840523343e-4
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.608671859213811e-4
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.470758462201906e-4
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,9.955739161178101e-4
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0010436904129660282
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0010851862974226982
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0011416162964461856
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0012032737259071516
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0012677928547415087
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0013206684323071349
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.001372947875980687
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0014242423756232988
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.001461799306490402
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0014988065609480516
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0015460668088344192
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0015923129430626258
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0016467019557311641
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0017036876231962305
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001791252137290564
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.001937678755603338
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002130894761918812
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0023831670021656477
+2026-05-09,36,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0026965633529960173
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.15195839937092e-4
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.085424298466582e-4
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,7.108604823767471e-4
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,8.329493767408401e-4
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,9.268335181467643e-4
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,9.99658436052519e-4
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0010723490753003877
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0011305134898897072
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0011903141784059905
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.001243355758957235
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0013079418799243029
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0013674999274875081
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0014328767654501159
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0015009421713528678
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0015693653331777897
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0016388396652921226
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0017248672239662372
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.001819318091351846
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0019350273177542797
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.00209307021715609
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.002312605662160277
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0025366464060759906
+2026-05-09,36,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0027745917118767306
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,4.781701198261692e-4
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,5.854304705102723e-4
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,6.896375529185692e-4
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,8.154275535810238e-4
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,9.149545909719532e-4
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,9.95811233852248e-4
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0010575194194703745
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.001121537554391234
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0011791156112577889
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0012383959554117655
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.001303373059460588
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0013736776677552678
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0014488675019335795
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0015225624238757284
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0016106238691665502
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0017073098767769583
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0018028409366032782
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001926248484292978
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0021066455189427714
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002319688156484265
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.002664349456228005
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0030738810790875135
+2026-05-09,36,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003556013498458184
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.280349275299736e-4
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.189698426390468e-4
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.34922066768636e-4
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,7.733744394992436e-4
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,8.720739979930421e-4
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,9.492528112331298e-4
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0010284735473462831
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0011054417404888339
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0011748772028842098
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0012449899250498173
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.00133099882088991
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0014102632331289408
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0014998280999244315
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0015982614883141826
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0017068811372312953
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.001840053545695078
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.001975644965666939
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.00210552446003997
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0023362057619736726
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0026160072487185953
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0031013747842181896
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003574912420197008
+2026-05-09,36,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004011989168094351
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0013872775140348359
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0016102942810776286
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0017371713776009664
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0018942170052248341
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0019886365416217633
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0020826598413034737
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0021444012352343288
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.002217183579963806
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.002265833937359954
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.002312508100454982
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.002361813317333052
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0024256253324360195
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.002489268131783315
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0025396839271120005
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0026158807588034295
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.00268841796704903
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0027809890447628815
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002879889405861431
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0030314302843356938
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.00328990698194442
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0036058574956634513
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.004039637369528512
+2026-05-09,37,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.00466260335253037
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,0.0012705241778003433
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,0.0014680141363033485
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,0.0016103731253316286
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0018043762477735548
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.001901487610643104
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.001962527950973216
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.002024761643378449
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0020738902014477735
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0021235625616478253
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0021708335489006316
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.002218986913043299
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0022618653817526226
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0023100882387959835
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.002373048675695807
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0024640367816487177
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0025642693139529926
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0026528531652218615
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0027637934328261903
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0029149597970709925
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.003084080206394198
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0033887356453276233
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.003700276598755684
+2026-05-09,37,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.003948716510856331
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,9.324240948433648e-4
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,0.001074119371637095
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,0.0012214011310303294
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,0.0013714200481884688
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0015000812420197592
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0016048954891318833
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0016989769220694794
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0017803690124562766
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.001857781628085002
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0019364118468406244
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0020152953303780793
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0020924857055297317
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0021736546475518226
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0022673627434356444
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.002368412580528823
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.00250702821465516
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.002625165329505929
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0028048107131401845
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0029996743514126138
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.003267949049067577
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.003730369313452761
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.004281209678723433
+2026-05-09,37,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.005151376167648068
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,8.464925501952265e-4
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,9.988829779369172e-4
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,0.0011497042610574132
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,0.0013440084663088531
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.001494902849266272
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0016125570894189316
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.001712393415933985
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0018121682834592494
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0018971706433546934
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0019896710470270517
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.002094614275605905
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0021973620116655787
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0023186550640603492
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.002446781193715654
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.002580538197482077
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.002734798839997064
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.002886362064125076
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0030723179783246086
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0033517788825986015
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0036897761532236903
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.00419971229291102
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.004815599643492728
+2026-05-09,37,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0055615371505163685
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,7.597336991182083e-4
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,8.843786598082407e-4
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,0.0010607140897106616
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,0.0012682797044145776
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.0014205865091115144
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0015373184649818635
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0016549209801792137
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.001772196820998748
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001882597472159614
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.001993803575066915
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0021200126919294704
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.002244686190243825
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.002375537192402021
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.002531653303105257
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0026997602853361816
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0029057394626914356
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0031214789397405462
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.003345845787718455
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.003716711272475486
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.004154394958228869
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.004904885381608534
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.005630677796502256
+2026-05-09,37,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.006345593027205719
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,5.589591593818966e-4
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,6.842336728356084e-4
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,7.555877656986851e-4
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,8.549797308350137e-4
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,9.13238210694005e-4
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,9.705023257609662e-4
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0010005174554929995
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0010424996513600513
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0010649063565712404
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0010935820966681384
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0011218617645225412
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0011624155480072776
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0012002118409349613
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0012255416987411263
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0012833380704976233
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0013319967632107635
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0013982123432701367
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0014722870821282854
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.001597219770562202
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.001799147385714151
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0020557927365746327
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0024164978671009866
+2026-05-09,38,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0029423742288089043
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,3.6387914162199045e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,4.689459924974616e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,5.495665553954999e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.549538798063227e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,7.172202786156168e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.778305790361595e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,8.189640663131096e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,8.754918723540425e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,9.072661714210487e-4
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0010218893002684813
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0010745047702858065
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0011226646459919713
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.001167397315158579
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0012262568795788657
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.001283092447974815
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0013462269981036638
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0014129994178915207
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0014859996378067909
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001580997939037344
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.001701365753898297
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0019109973111649632
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0020846215065179825
+2026-05-09,38,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.002566972236101913
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.4239753626482266e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,3.3356510835776164e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,4.4742194182461123e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,5.47364495849748e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,6.262928863040183e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,6.869196312814323e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,7.32359633226163e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,7.739034937998371e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,8.192120526891727e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,8.558654866895651e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,9.073400618496296e-4
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.001023369682481117
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0010900467874647053
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0011779276500326424
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0012419377800220875
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0013080347050230786
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0013746838405635526
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0014562286765043612
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0015689217892445992
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0017454311862988058
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.002163504716702787
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.002509688654831915
+2026-05-09,38,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0029696623465414952
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.729509362579287e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,3.422615899463558e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,4.260086379188781e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,5.260356318342336e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,6.116200589936441e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,6.779793133029309e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,7.32567264536478e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,7.912801580990197e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,8.380660955234936e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,8.942948474727206e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,9.544392005596274e-4
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0010168179814819167
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0010821659462453826
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0011506351394774818
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0012317146402026041
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0013286266825188239
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0014187470404920066
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0015366704314846691
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.001720599571427852
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0019415539033045565
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0023076340763994044
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0027848726890617155
+2026-05-09,38,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.00333906801160294
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.2494690810644693e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.9154059776517245e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,3.8571333681188577e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,4.994314446230328e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,5.843601034994673e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,6.463171223710578e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,7.161927124369029e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,7.810706711224994e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,8.430223651821446e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,9.104689204628058e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,9.891251343790333e-4
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0010656244311842455
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0011445892212660798
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0012427654143006821
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0013452270159255222
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0014743273821843442
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0016136846416824717
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0017437700379543074
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.002003758598536454
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002322564462113384
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.002873358587676289
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0034468664114302573
+2026-05-09,38,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.003966441654341485
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,1.6745797542956075e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,2.4482645703036474e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,2.825049347383566e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,3.3256145627989764e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,3.5998106024819694e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,3.9065066845747403e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,4.088258353616235e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,4.3377408459073453e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,4.452004793254729e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,4.5697727336913436e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,4.727553907984014e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,4.95153079104534e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,5.174666501261955e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,5.319347353812039e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,5.608344007585332e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,5.870125684171962e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,6.200430756929262e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,6.542897376465668e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,7.122235045130036e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,8.26529685646662e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,9.566867570359872e-4
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0011598777863127152
+2026-05-09,39,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0014866202464320127
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.1766964295996655e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.6820955525618797e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,3.0314040779482615e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,3.6403997063068247e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,4.08054077504836e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,4.480846612744601e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,4.754145996687416e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,5.081892960502196e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,5.288880194104686e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,5.489023241300933e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,5.70562623004912e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,6.004688230407926e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,6.253808763911871e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,6.520429615831973e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,6.838295177538503e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,7.175449480560991e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,7.544788386517887e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,7.888273861977403e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,8.465678184706309e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,9.549625354814009e-4
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0010879574552012216
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0012870453017207561
+2026-05-09,39,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.001602840942422134
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.2384788789984925e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,1.7822667049658336e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,2.659990953008529e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.386085106116706e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,3.9922443963954406e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.394367541551106e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,4.730409125135154e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,5.037912640941091e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,5.346710991669827e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,5.612471238358104e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,6.020714335238877e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,6.328092944324195e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,6.682191752985327e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,7.234798237491443e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,7.81517282921273e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,8.331813922318414e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,9.11744670167945e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,9.873014293054867e-4
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0010704110693088003
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0011627233051839762
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0014573961089514617
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.001687855420912216
+2026-05-09,39,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.00188086709300139
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.5041035711513991e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.031673161851176e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,2.641536448434255e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,3.379178420227462e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,3.996074523242968e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,4.486120462002547e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,4.887100447265396e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,5.33055727369419e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,5.6704995994246e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,6.091898706882066e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,6.563510189708741e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,7.05001005421388e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,7.606013242770879e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,8.161063657727856e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,8.783147232684624e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,9.517518812735317e-4
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0010186094611423222
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0011068800690891304
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0012558870832223715
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0014154770181380523
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0016599567008815264
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0019967428544449715
+2026-05-09,39,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.002396577550206408
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.370520023783942e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.8063756740085515e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,2.5705166519202945e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,3.4274044391178647e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.0798755539895616e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,4.551062164579476e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,5.08539074079051e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,5.608735422106333e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,6.082052151515181e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,6.63069987375739e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,7.273191548662866e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,7.871569469952456e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,8.539011563644251e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,9.366362139467119e-4
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0010259957603202287
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0011339646406218872
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0012424371206366644
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0013443157705981404
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0015555152245168647
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0017875398971188019
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.00221859417632916
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.002647717758847301
+2026-05-09,39,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.003005703503700285
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,4.4523733283346524e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,5.561889739214162e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,6.175751682070044e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,6.947288676156848e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,7.391844782438631e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,7.879332414114256e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,8.179872403124046e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,8.566704653365198e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,8.761459895829701e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,8.975842705277646e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,9.199797586092065e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,9.560364343451596e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,9.901077215661248e-4
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0010129739868992068
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0010568126644703922
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0010945987538361875
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0011440251039714284
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001194170088269427
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0012805079534458936
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.001435175766051913
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0016053009094842802
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0018709127559325125
+2026-05-09,40,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0022626589662762555
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,1.2594197888285237e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,1.8075306246498012e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,2.1932376670315021e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,2.631316240470618e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,2.8521510605478503e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,3.1160424122786954e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,3.238359147401552e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,3.4117593174906363e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,3.5085608730293976e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,3.5680524538726625e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,3.688844041911605e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,3.8874969693592653e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,4.0408812819337663e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,4.274262604746056e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,4.437443638538903e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,4.981912576968776e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,5.232331593915195e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,5.792427790415364e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,6.419781278364829e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,7.144251275183262e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,8.205048279844944e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,9.646239408411431e-4
+2026-05-09,40,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0012688583159327091
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,7.725854542090947e-5
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,1.2001563774718633e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,0.00017983970903143746
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,2.1523238729591752e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,2.449984591544317e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,2.652857664575049e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,2.718851040265543e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,2.7897051657558664e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,2.9096218475998696e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,2.9967522775343564e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,3.1408040135592777e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,3.2660077021086495e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,3.378046638607548e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,3.626136078913825e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,3.900118964711439e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,4.1533294115558286e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,4.579133872197769e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,5.093332163878834e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,5.530872395075027e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,6.185904144813507e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,8.312222107486844e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,9.985364236082676e-4
+2026-05-09,40,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.001272143263603658
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.4529380832873932e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,1.952116699424437e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,2.478605680974824e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,3.0757167826993623e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,3.607200443480212e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,3.9809844981763637e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,4.2888702101173627e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,4.602119557712168e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,4.8747930794051323e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,5.174012046958772e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,5.442582262392512e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,5.788656305434146e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,6.098674003396109e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,6.438762260120045e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,6.888386465911158e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,7.373582667613197e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,7.801990411189769e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,8.427383847636673e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,9.491712740699253e-4
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0010774418083946637
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0012850859761254054
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.001554825636942072
+2026-05-09,40,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0018781892445502739
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.329940829237734e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.7295903298329124e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,2.2723458579068423e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,2.935968414472869e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,3.433970029880021e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,3.81197173083826e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,4.2821538914286216e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,4.6388157535712704e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,4.942822160040453e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,5.369917118204408e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,5.748798241526554e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,6.09938159889374e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,6.440083190185781e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,6.874831250417163e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,7.35435385781898e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,7.948565849744189e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,8.581411814867408e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,9.184116910001755e-4
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.001041441940255865
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0012118122638104945
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0015119693126212945
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0018069285232286928
+2026-05-09,40,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.00215372109004253
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,3.1261123744422305e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,4.0693452510076405e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,4.690216958415918e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,5.461828265334536e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,5.944768377489656e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,6.429358723372114e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,6.781996489012747e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,7.18411201886681e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,7.431731548332714e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,7.690077756671546e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,7.927444677814817e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,8.295072512290952e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,8.641245854913833e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,8.92838216788262e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,9.327261586159105e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,9.714654838077093e-4
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.001019119663946117
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0010664343059085491
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0011449877102983675
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0012778677989327759
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.001426589076899713
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0016598415231812746
+2026-05-09,41,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0019956765639448496
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.9548407940935555e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,3.8570281318919754e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,4.3601428439662526e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,4.918915100913523e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,5.329970820766322e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,5.673543367071609e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,5.926414092322142e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,6.228794049818814e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,6.491258350771097e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,6.726235181763029e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,7.060986449224636e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,7.336452439015075e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,7.645997219969786e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,7.920484738269605e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,8.199487931790123e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,8.53379953289837e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,8.943411022263987e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,9.440581893440055e-4
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0010193441484466857
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0011088042813056388
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0012679449306576926
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0014234574772138276
+2026-05-09,41,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.001631337763751795
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.9526146755363742e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.575308122658471e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,3.1461718969542647e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.9496485840677235e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.567319085447515e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.919168198550276e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,5.287088994810297e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,5.650387533958378e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,5.98186350566199e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,6.267826206495965e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,6.593512605260659e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,6.904658495283707e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,7.220897323735067e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,7.530511027823857e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,7.881723259416534e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,8.314856445911168e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,8.868894683177317e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,9.460854260590392e-4
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0010245821639615223
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0011315901179187156
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.001281215912989319
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.001425497285777347
+2026-05-09,41,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0015898974138681132
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.584085353822427e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.16954805664765e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,2.83936101209167e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,3.658923642233075e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,4.3157993181693e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,4.886093636867546e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,5.327940221717225e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,5.857943550696099e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,6.26779432141805e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,6.747278158777956e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,7.332549079282029e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,7.892598106127247e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,8.536402786790782e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,9.207529912436999e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,9.944969714228333e-4
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0010818642959514227
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0011635970538429647
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0012697586330121188
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0014347042888763414
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0016121323120559805
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0019008940088807288
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.00226889249512754
+2026-05-09,41,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0027269304666327878
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.3155236589906113e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.819998024253046e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,2.550246280679918e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,3.480404924193596e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.162517820330334e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,4.7166459918057864e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,5.305221768398068e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,5.883460645961816e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,6.429444062503254e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,7.049736967470767e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,7.760607764528641e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,8.470141380685853e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,9.226931657052224e-4
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001017126715061687
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0011138094191791093
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.00123645346854593
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0013596558015259008
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.001487533656827359
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.001727808172911007
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.001993252049437716
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0024556959080208017
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.00293374963861638
+2026-05-09,41,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0033801002698444892
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,4.961617128591153e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,5.994857098371038e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,6.556724427348072e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,7.297748748329882e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,7.720382099336107e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,8.155438595137147e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,8.405684671255721e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,8.739953766638697e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,8.905871115434573e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,9.10429893091808e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,9.308979421990927e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,9.619067909113056e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,9.908305781179325e-4
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0010103507922868996
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0010504391584106765
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.001085001648789623
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0011300907476129165
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0011776811409526054
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0012588312083484268
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0013970421444971673
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0015580350045590796
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0017957407826676003
+2026-05-09,42,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0021432562831643753
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,4.6048387074937145e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,5.652031646057019e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,6.105293064663589e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.621988660207135e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,7.250507098718821e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.849009868161332e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,8.385020719282376e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,8.831707366300154e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,9.320761371745024e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,9.80497973767612e-4
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0010237905925475476
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0010661601204840312
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0011170859827802475
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.001158514675353204
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0012009590431593712
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0012449494203332705
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.001293830270310928
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0013426101188546641
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001417687338207084
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0015509141299955215
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0017121100435306253
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0019468927778938134
+2026-05-09,42,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.002178511342716258
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,3.5785550651580816e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,4.271036213443694e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,5.107832429716582e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,6.093761247722188e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,6.747962130461841e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,7.330448252584948e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,7.893435570699068e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,8.419508738129826e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,8.918036278180029e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,9.374223316857955e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,9.831442756176073e-4
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0010311100904249596
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0010842070318470497
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0011412251965405636
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0011973864862765144
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0012571123764438192
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0013241680620505283
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0014051591672357092
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0015048673835490922
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0016405076708515555
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0019323424553805105
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0022402008260954797
+2026-05-09,42,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0026899557146265025
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.302524550134998e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,4.007515155622951e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,4.891744165805385e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,5.931614159159329e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,6.735237845175881e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,7.402311972855952e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,7.939869922506102e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,8.568616422197973e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,9.051718621609316e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,9.582163352525848e-4
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0010188782293805232
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0010837701210080612
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001157767712007049
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0012325704277365347
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0013105905930389694
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0014046073798191622
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.001493869452248821
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001610569779819703
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0017853143082056135
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0019732163660003063
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0022604521844139577
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0026299506379175498
+2026-05-09,42,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.00306456561032932
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.796824760475981e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.504652055513927e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.5145749192814996e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,5.697058490834175e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,6.564643365347591e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,7.26550403988293e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,7.973006566797251e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,8.665497042651416e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,9.318052743287821e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,9.991534084490576e-4
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0010837231728232492
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0011615691939145223
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0012447746984090512
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0013465497733615066
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0014509992373982123
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0015763189603231185
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0017055921425634991
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.001833088698779892
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.002074403748304014
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0023398493042183642
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.002801701131579829
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003234864148153379
+2026-05-09,42,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.003640486411172014
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,6.129911120718631e-4
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,7.454285011109492e-4
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,8.357182144213892e-4
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,9.533879795827507e-4
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0010274149247121536
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0010931519844036765
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.001141676037077057
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0011956358460824127
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001231095628311047
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0012698254657998243
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001303930234718351
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0013511922578938013
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0013949377740193171
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0014360496896985533
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0014873844303265387
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0015414286975197371
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0016042809649834072
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0016689418138739261
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0017727684010029187
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.001932487420110111
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002128535725130837
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0024120735863473993
+2026-05-09,44,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0028153464094106033
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,8.577728665497493e-5
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,1.2662262432536198e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,1.5571670066149597e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,1.8100403486608012e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,2.105531440646639e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,2.1925527037984206e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,2.3293975577638737e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,3.20218679819047e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,3.332872805300376e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,3.795598735322752e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,4.2868339213929805e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,4.440625648800483e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,5.169654530108974e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,5.448310833424403e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,5.74874153356207e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,6.475343504526456e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,6.945865897315523e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,7.796178082867975e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,8.757156992156123e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,9.896100963328511e-4
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.001215764501453596
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.00140440854199687
+2026-05-09,44,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0016347740699835405
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,3.577723490068088e-5
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.760684262770598e-5
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,1.0796554867101796e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,1.2421351739593447e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,1.3877652527371592e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,1.474893815155886e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,1.4795555269876391e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,1.4982874685473234e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,2.106862915998419e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,2.2065203971618336e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,2.2918164845687908e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,3.046893521314911e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,3.259014051711417e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,3.408848014837735e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,4.264843320784471e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,4.612071708197066e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,5.48550909869036e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,6.32735244260452e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,7.243105671145449e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,8.922389983797661e-4
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0011561285729716475
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.001555579848829797
+2026-05-09,44,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0018423887677951382
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,1.1874828196896452e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,1.623767552189006e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,2.0333502131086683e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,2.470789398087702e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,2.9424741726024554e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,3.237595854471435e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,3.493361535838953e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,3.755883035835672e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,3.994308056676706e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,4.2735821369044346e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,4.4863962829461834e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,4.7291460834157325e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,4.949862397070017e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,5.195812739395212e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,5.513894591692033e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,5.885921436795149e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,6.243293859194485e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,6.771542183494681e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,7.479413075351013e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,8.497783231369864e-4
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.00103934748426177
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.00123567368176541
+2026-05-09,44,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0015209863061699017
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.1608675548252054e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,1.4573693146095775e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,1.8437972265296913e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,2.376734508985569e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,2.7826266849072235e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,3.094147765521567e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,3.457637837320925e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,3.7422534663616124e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,3.958639287722312e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,4.2456719692268805e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,4.551175607922991e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,4.8134998828369674e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,5.071428647879969e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,5.377131625571353e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,5.739175927535331e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,6.148645961041871e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,6.633519858498763e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,7.105660245628648e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,7.880424643283382e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,9.159404704776607e-4
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0011210763224007937
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.001361916578835271
+2026-05-09,44,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.001668792698891966
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.001148610674793605
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0013415431902199279
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0014548717654511466
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0015915457445054315
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0016748565393113466
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0017592899049981082
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.001816824770549016
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0018830525616269165
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0019278791078916337
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.001970142600801349
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0020136497151779452
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0020720273352489373
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.002130088787858389
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0021764670593906643
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0022435040420008164
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.002307425577742614
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.002389127463065665
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002474847653478634
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0026064042421983812
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0028320648175044227
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0031011608070154436
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.003478894798936518
+2026-05-09,45,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0040152768430537725
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.915269861642518e-4
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.834983162939285e-4
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,0.0010007193292068675
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.001151298863317731
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0012534455086328834
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0013412941095948417
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.001409112603723403
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0014802144998341264
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0015243505837639012
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.001558473272808338
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.001596723007772408
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0016468265887729522
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0016915396316036153
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.001733087686028051
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0017930010862483182
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0018472280131595332
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0019143067347674428
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0019879413753194596
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0021015800414620244
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0022876051685819148
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.00254698868616817
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0028665292015835732
+2026-05-09,45,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0033066537625476844
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,6.637178640190414e-4
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,7.878909001117297e-4
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,8.967723336083974e-4
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,0.001034870558281362
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0011487865108739362
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0012328003178100585
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0012870923201091825
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0013376307048234438
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.001391239000768574
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0014370429271275984
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0014973515581084124
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.00155126936521494
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0016058536409476185
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.001681777602774504
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0017662696553186288
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0018478169131038067
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0019663442042272
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.002100098653205289
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.00225728156165705
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.002470313861283778
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0028839632908221322
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.003256994027691477
+2026-05-09,45,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.00376934311370765
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.851809720626359e-4
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.94450128292803e-4
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,8.181799947196532e-4
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,9.612171269249675e-4
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.0010677467581494523
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0011522820271234547
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.001222791278695666
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0012935318109252236
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0013538026028081652
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0014219794889389374
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.001495671367405865
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0015746851296472718
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0016500619911084988
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0017325237296710314
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0018312229940028962
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0019392972515410605
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.002045525097538586
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0021960904952362664
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.002405416755121976
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.00266918585979324
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.003088179936260101
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.003575942837295621
+2026-05-09,45,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.004191300169779694
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.957311216191045e-4
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,6.036471218373006e-4
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,7.329092141138513e-4
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,8.901871954887079e-4
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.0010002177328325439
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0010923220233135956
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0011853181012697288
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0012715682252336569
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0013465422139223992
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0014238993250377148
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0015140643628019073
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0016012087000210214
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.001693854944905677
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0017999569724714967
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0019166400153920495
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0020659511901188893
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0022260875283409043
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.002385353215650799
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.002643598317936724
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0029751645043681954
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0035378696303798515
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.004125267327105935
+2026-05-09,45,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004701743556885537
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0016274695080013698
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.001884542448672377
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.002107234477482942
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.002383808580909211
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.00256900003383318
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0027202152126876624
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0028565652329462054
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.002989193500144015
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.003083898145459517
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0031875476883778497
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0032629955625068075
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.003375368325938238
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0034742747049700882
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.003585787732756854
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0036814787563242985
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0037989095029777324
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.003920020666510778
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.004032222919798593
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.004212335953590576
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.004446662682739145
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.004707707719521125
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0051342613668085004
+2026-05-09,46,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.00567904835860802
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.225831112319768e-4
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.476691862232545e-4
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.685885396546643e-4
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.001105506710659968
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0012068762091656513
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0012815255822878862
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0013257445177947244
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0013695532416397832
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.001397299988480856
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0014178355178028814
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0014529464285496009
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0015328689837616702
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0016669809489290172
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0017279182126892904
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0018713980214116349
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0019714296009066493
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0020602666775769735
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0021604442130506
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.002283148520612917
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.002448527456670642
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002685388401907938
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0029279367046583754
+2026-05-09,46,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.003339942663530806
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.993451979516536e-4
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,7.26112584175241e-4
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,8.601609805931118e-4
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.589395208045288e-4
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0010319790603327166
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0010934607826020475
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0011210533829708249
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0011482772706094058
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0011876043939669974
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.001215396222420585
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0013360659804827976
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0014543927680576176
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0015559465124381094
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0017107832663067113
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0018175081453838983
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0019070420850949188
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0020082151266106784
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0021118663097522044
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.002240114665125359
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0023950774482684196
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0026667515193433966
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0029228985016293424
+2026-05-09,46,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0034906270881260052
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,5.290900433093024e-4
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,6.357830822188893e-4
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,7.428285746531888e-4
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,8.536144896294187e-4
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,9.675635472375619e-4
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0010462855909716224
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0011044088203116553
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0011686804854904496
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0012160264885853899
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0012742448760393447
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0013280271435268287
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0013911427253695638
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0014422640635503917
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0014979814916650878
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0015739140217534222
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.001664604809782099
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0017528787957871643
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0018761003319002372
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0020562950984359014
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002278917568013793
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0026745045835886274
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.003138267706841637
+2026-05-09,46,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0037367355388147126
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,4.139625756856707e-4
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,5.24412587694426e-4
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,6.44853087462214e-4
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,7.878736390912312e-4
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,8.834449884941413e-4
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,9.638310395375883e-4
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0010462216785555865
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0011085158060940804
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001166513488385007
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0012393810759874372
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0013182658311069976
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.001384360485189712
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0014555278854374277
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0015425374897689533
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0016290847397967176
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0017410342534310474
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0018644216907716584
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0019853755445966527
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0022012660097180843
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002502927054454856
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.003004649354137426
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0035388450705642165
+2026-05-09,46,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004096682591909222
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.0011025151111144311
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0012869585097520576
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0014054845933434582
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.001560514792744516
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0016555004719500752
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0017376676027912657
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0017979247401348874
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0018652184029096944
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0019081167878131436
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0019550265579939734
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0019977146956560903
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0020546761562142907
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.002107380608488488
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0021573746213431224
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.002218934696396792
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.002285125673207695
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0023598542603874397
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.002436533951295866
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0025588570345296334
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002748284023739684
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0029804706042955795
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0033107073378602697
+2026-05-09,47,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0037852730236225124
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,9.638409576842207e-4
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,0.0011153692431476387
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,0.0012261494596453972
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0013594210880300988
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.001440699875771939
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0015099235789801668
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0015647515667579345
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0016155240622535583
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.001660537251015942
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.001699165211694945
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0017412123751419642
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0017869108052474404
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0018318923973150948
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0018920911136526743
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0019473954499804017
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0020053091094131724
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0020575311445905214
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0021285485183532983
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.00221970113045387
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.002334021325396035
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002528508143314421
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002781603588767364
+2026-05-09,47,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0030092645695396956
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.877051839192913e-4
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,7.092381118373506e-4
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,8.204576160639669e-4
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.693753321776815e-4
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0010991374847175097
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0011944954805043915
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0012973518950896044
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0013824086957187614
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0014718127752134142
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0015684953228085332
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0016539795833194412
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0017324931506106853
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0018291117622121515
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0019378560928342598
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0020310431068126054
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.002118485339986186
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.002240342551897239
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.002376206030198545
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0025151943365910702
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0027123411605794274
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.003139913409373956
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0034892293272175486
+2026-05-09,47,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0039017374430642565
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,6.145702452112212e-4
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,7.297117872017349e-4
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,8.491837635616259e-4
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,9.918085255256875e-4
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.0011058720980590367
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.001195212024186008
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0012664007021389815
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0013443181940828311
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0014040010090205848
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.001475645017397858
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.001550677321306862
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0016303054471138887
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0017175882594956879
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0018065663898600244
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0019073776219669812
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0020237627892462327
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0021445513078054506
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0022848131602418195
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0024986726391011726
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0027355975735159
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.003127858338917465
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.003564337857945563
+2026-05-09,47,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0041183002990875005
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,5.544490449520131e-4
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,6.549530333288557e-4
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,7.915952785822482e-4
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,9.451972805077965e-4
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.001060189995719812
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0011492498669278285
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0012457529032204526
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.001330199699677818
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0014110194999514053
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0014964232307027475
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.001596800618900573
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0016886953488369028
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0017869489910140683
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0019098813657136985
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0020365514623766224
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.002187252277735316
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0023494546448206304
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0025011452498607755
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0027840742326640487
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0031248504316682846
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0036892016033560028
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.004246665136997204
+2026-05-09,47,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004757097206926087
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,9.091132998270511e-4
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0010667316254088358
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0011700156440376567
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.001298244003343842
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0013784003272445428
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0014515432724495109
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0015070034008099358
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0015670661655393242
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0016077524932276881
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.001648962849906481
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0016866883927731619
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0017380551252223723
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0017868207936741832
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0018320240811507075
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0018855176410366506
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.001942248155119712
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.002008236355194976
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.00207505305393412
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.002179162805457924
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0023452163789667185
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002542324522659645
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0028271024202533445
+2026-05-09,48,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.003227706835849682
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,7.221613484240712e-4
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,8.434486860167543e-4
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,9.318881326524894e-4
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0010450622143418336
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0011117979075288456
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0011728578160406678
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0012133996218868443
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0012598752596760154
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0012926467555080506
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.001322797567305948
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0013558775032588525
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0013982684613852714
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0014362816759694486
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.001472345030941678
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0015213045901851798
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0015668976665637801
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0016220434435595293
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0016689727484160604
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001730014195508417
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0018534771254315528
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.002062832378762675
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002293120408057998
+2026-05-09,48,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0025029226979066893
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.622722893216202e-4
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.694754218425378e-4
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,7.975081914184681e-4
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,9.067219948885393e-4
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,9.91313437361042e-4
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.001053663495779845
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0011024601351050144
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0011478394846255102
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0011952182053340873
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0012352898606900922
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.001287629747995531
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0013351285548916095
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0013849450074391676
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0014511811948060898
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0015241456000325481
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.001594200307682323
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0016916952265550295
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0018030786139678818
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0019164059077646821
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.002082540261723506
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0023632769066672553
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.00267543588925494
+2026-05-09,48,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002990596874904003
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,4.3317562485477204e-4
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,5.1778101228556e-4
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,6.104489538464421e-4
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,7.213666745373999e-4
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,8.143894574230519e-4
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.906181919166035e-4
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,9.519797351886433e-4
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0010123568146328122
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0010632006478262887
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.001119644188314714
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0011798478631723966
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0012438465318589562
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001309312892133329
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0013817429746518922
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.00146040851710598
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0015562070237150002
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0016478400972503582
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0017659785825372507
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0019386082230965697
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0021467618836005535
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.002468742466142639
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0028539022078787482
+2026-05-09,48,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0033090524076926546
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.62476853332108e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,4.371071687399762e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,5.468216833400644e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,6.751385497690905e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,7.731836488658886e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,8.452327188177628e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,9.210275880130302e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,9.930851633388855e-4
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0010549855324189247
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0011242263604214894
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0012022127657038337
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0012770412167249358
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0013539914141495284
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0014473001096156864
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0015460322380491391
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0016653479292856503
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0017907726877226956
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0019141907748691494
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0021342962777251458
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0024188789201832054
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.002900001226580758
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003358820086478472
+2026-05-09,48,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0038511583830729227
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,6.127669391436317e-4
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,7.734871478580544e-4
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,8.919624824498799e-4
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0010420347713450107
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0011405612561845519
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0012254581161573685
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.001300571315449522
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0013762620839780735
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001429241127599841
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0014830286906165654
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0015293172928503062
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0015930525676406345
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.001652672487863444
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0017159713865912665
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0017735619418847498
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0018443853146337796
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.001918370328216937
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001988512931293272
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0020978088848680183
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0022671271404007495
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0024590894122310607
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002763816817087515
+2026-05-09,49,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0031983446719773974
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,3.53799085244573e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,4.464646183056862e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,5.152349689117586e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.002569561448659e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,6.489800457662869e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,6.980031561958414e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,7.276404583472973e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,7.634804523670047e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,8.007529880568597e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,8.46366781470219e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,8.904290722617926e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,9.359509461114735e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,9.825682498174546e-4
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0010367495304254664
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0010861953330270834
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0011418613143146842
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0012039280667394132
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0012675787931356276
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.001352092760918611
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0014633458377098306
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.001629835513257279
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0018187417992508307
+2026-05-09,49,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0022085019031416794
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.692675867772485e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,3.426519758574758e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,4.1911795258330314e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,5.036547495808351e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,5.677927194485223e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,6.256699377283406e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,6.751926788227996e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,7.247089431964733e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,7.688269170729902e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,8.129987363232672e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,8.578280932549745e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,9.065618420594267e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,9.556914847803128e-4
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0010047037781232742
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.001059695086957174
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0011133776249748627
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.001176747094376713
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0012483987519256888
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0013380964449096686
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0014514501081657847
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0017456070045716709
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.002032205636922323
+2026-05-09,49,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002457977546056043
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.1204061428486964e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.8343415734845056e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.63557516950416e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,4.4953161952223915e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,5.223651989464443e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,5.769255672332782e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,6.212899994381756e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,6.694310696954756e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,7.095221713010504e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,7.525644951601354e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,7.97536550580192e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.00084850047053583455
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,8.985271076764772e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,9.498939293475612e-4
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0010146959651888233
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0010896173924109364
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0011604959511622094
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001258946480858753
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0014078165591166918
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0015855155872973464
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0019029519855897912
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.002271516758941787
+2026-05-09,49,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0027101167114613267
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.8277974456422169e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.4035935192251085e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,3.1862404219638776e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,4.158497873859747e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.878633478294282e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,5.437456781234824e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,6.038363547321748e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,6.546179360415411e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,7.007881938891441e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,7.561191371190281e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,8.145781325551067e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,8.69157029046896e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,9.318545653363052e-4
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001003513198777472
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0010813339925547583
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0011782458026737379
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0012836880727435116
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0013851509117683149
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.001576264338577845
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.001823051026597257
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0022553354531049024
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0027077331572142715
+2026-05-09,49,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0031743115327502397
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.00047168109872671485
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,5.974394475780028e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,6.630289283214405e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,7.448984226435719e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,7.917843353131118e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,8.437839785248069e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,8.763049458445093e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,9.17755875828576e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,9.404879024314821e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,9.624755544374959e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,9.885929240353469e-4
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.001026030592942858
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0010633335373955895
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0010889612582625431
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0011347575987588306
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0011759651989066647
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.001229314487916143
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0012844512201472505
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.001374448170691356
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.001544237062189337
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0017370997635979201
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002028354501866855
+2026-05-09,50,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0024704419792873846
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,4.336597877781183e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,5.135976576731464e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,5.93647772830642e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,7.013601928922563e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,7.823334972843597e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,8.47629931224876e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,9.112938698461615e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,9.651565603178848e-4
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0010160124757668553
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0010665045625699004
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0011181401015118392
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0011643406347786344
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0012091175223821796
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0012623688694504988
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0013182181731971163
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.001377271338135092
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.001444006505134996
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0015262464640769908
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0016291298010250017
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0017585464877876917
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0020236802907424726
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0022770027845139783
+2026-05-09,50,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0026907182887414022
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,3.7643550782111296e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,4.4495599459743097e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,5.438233969767024e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,6.535560570936829e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,7.364166440110817e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,7.960543818470689e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,8.549382886060427e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,9.080828994113643e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,9.655845645489775e-4
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0010203358814971641
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0010744448305143252
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0011248819622812025
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0011815151885549496
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0012421034042489
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0013055000359015962
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.001369679390178167
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0014460219629094607
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0015275247818860756
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0016348653453672499
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0017731416835739667
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0020394766382813762
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.002534591400055505
+2026-05-09,50,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.003271492302244353
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.154689320454808e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,3.946701933956901e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,4.94802739954471e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,6.127423144999661e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,7.059486899154016e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,7.818226697317366e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,8.442061291545507e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,9.092035281392523e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,9.687113227421338e-4
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0010312643095232803
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0011032018236292649
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0011808226169906265
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0012660570571914015
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0013535915574396664
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0014571512602229906
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0015611707706375609
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0016666977711863274
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0018044390911644607
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.002044084351694339
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002278460495793456
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0026649564024328314
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0031169558672886864
+2026-05-09,50,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0036329707088051857
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.939046759005e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.610954692945868e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.7011315998458946e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,5.94337916013418e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,6.881709736720025e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,7.646992577239292e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,8.418789475558321e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,9.28339574688589e-4
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001001286465023
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.001072532938882932
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.00116157010072178
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.001242731505416975
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0013425299524354225
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001457781818451887
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0015814569237701686
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.001726924045158884
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0018767464525846422
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.002044282201294562
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0023326237437358427
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.002637943739545735
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0032096150658166905
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003752580686153373
+2026-05-09,50,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004268436627997209
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,0.001056858976859767
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,0.0012356801845042628
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0013303563140011484
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.0014453786990109684
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0015126637055051712
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.001588374833393474
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0016315808171525443
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0016874295348839148
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001722277692144831
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0017557233391430538
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0017932486792532015
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.001845529645255026
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0018982123082984027
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.001932339303679308
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.002000797330772381
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0020577727045545118
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0021380693762072926
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0022252660233307094
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0023626685606211216
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0026054514953292728
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.002895783436376574
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.003300753287670086
+2026-05-09,51,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0038789501223250333
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,9.306776884979297e-4
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,0.0010971392614687412
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,0.0012195965318573068
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,0.0013529481793805715
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,0.0014330086464547356
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0014919332148755132
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0015669867365857354
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0016388285408912033
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0017147951238905995
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0017846300393980137
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0018466014349233547
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.001907466898681338
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0019632450576298572
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.002018408429557684
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.002086464994535983
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.002155099893282217
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0022342504831689702
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.002319597699205148
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.002446762583248068
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0026545589822747568
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0029331530404791027
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0032268235213137914
+2026-05-09,51,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.003508715934841297
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,7.1907680043031e-4
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,8.622479019121462e-4
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,0.0010167795633648177
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,0.0011809049468851501
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,0.0013018678165382586
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,0.0014008870556584667
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,0.0014803143498713638
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,0.0015651811337300703
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.00163783247472322
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0017012683147104132
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.0017691746637220587
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.0018423739497496507
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0019151384999844525
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0019876625675828248
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0020713897797521768
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.002168577610860628
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0022684552337475525
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.00238418039971743
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0025955096736920103
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0029415807862396867
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0035031591655637477
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.003937263646227686
+2026-05-09,51,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.004463644978451114
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,6.441412422821792e-4
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,7.615088965929352e-4
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,9.088740770028065e-4
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,0.0010815487552688998
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,0.0012107129878018844
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.0013153108254262563
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,0.0013984855813893898
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,0.0014854677181939955
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0015620676935811121
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0016441332450307699
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0017365835712928688
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0018377782024542539
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0019380374192156092
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.002040053175342241
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0021576536723951754
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0022956195752658727
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0024285928363494743
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.002599216452993436
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0028580663468341684
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0031575306122077805
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.003642157672524048
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.004192753984746611
+2026-05-09,51,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0048672815108987
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,5.573921165093529e-4
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,6.805965822197716e-4
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,8.394717980985893e-4
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,0.001015836554660999
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,0.0011477655653787647
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,0.0012548945609197203
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,0.0013602047714900709
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,0.0014615452139228762
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.001557614236611036
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0016558102626449732
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0017669187838082483
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0018796580431890632
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0020010555382413754
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0021420412618428555
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.002290733515351951
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.002470683224794913
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0026611005320826154
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.002865689320259545
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.003197350610475885
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0035908970093703604
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.004267005552993704
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0049606046995592824
+2026-05-09,51,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.005574104194444697
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,4.886519462401743e-4
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,6.117386386595024e-4
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,6.961734756345744e-4
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,8.059553075928135e-4
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,8.75201826869623e-4
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,9.372462645219468e-4
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,9.848115994357271e-4
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0010371271930542994
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001070437698821438
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0011067606606887845
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0011387063174983084
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0011844141863062284
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0012264994397175983
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0012664090416917334
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0013141643344036407
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0013655585435342205
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0014238277802604761
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0014819771490137826
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0015769870739839376
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0017261930490494433
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0019021179189318697
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.0021685341777533435
+2026-05-09,53,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0025523813626130427
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,4.953716102939031e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,5.556186891376778e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,6.058055548942141e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.815888648726651e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,7.295512037229777e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,7.741354339679838e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,8.088059899390474e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,8.357412276570745e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,8.605710575288887e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,8.906650442519054e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,9.33037924863811e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,9.814503629292496e-4
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0010299899952017938
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.001076633813214965
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0011295916074268266
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0011874489742374622
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0012457761659180318
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0013204895069661364
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0014058595052745173
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0015187557641397913
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0017157677329702951
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0019039944611392702
+2026-05-09,53,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.002090930057138941
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,3.202147646086372e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,3.783366304408263e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,4.4372748198266026e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,5.395821798234038e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,6.029537009367712e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,6.636946363144486e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,7.145032565146237e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,7.701596033629144e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,8.159107574120053e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,8.61784372468077e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,9.079453987716193e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,9.583743985990508e-4
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.001010501855174066
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0010631464527212104
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0011150168473135474
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0011789234263082358
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0012446852976770904
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.001318880094479776
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0014169933443683805
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0015450553529550637
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0017399205174214475
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0019220951142325522
+2026-05-09,53,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002182524762303271
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.127780081936583e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,3.9280407447086666e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,4.85097929053398e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,6.066944096807443e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,6.963516524455214e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,0.00077577455241514175
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,8.390547092075807e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,9.071782881012499e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,9.597832140943602e-4
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0010214737046371108
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0010970206193828681
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0011676424775462217
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0012545668714714375
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0013429468202734137
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0014347154982951946
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0015431213085140005
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0016513643196985712
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0017796119926459454
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0019855811996176455
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.00219521241094975
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0025522203756140217
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.0029737281361613436
+2026-05-09,53,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.003440306457065132
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,2.823917127639365e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.5285746079457533e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.570239068168154e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,5.742482556743433e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,6.695799105051675e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,7.482353940424055e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,8.240193916175431e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,9.024705887370138e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,9.793441733730558e-4
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0010581387372870115
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0011518812954437142
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0012419485716949766
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0013443402701577645
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.001463925002240954
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0015883696730806455
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0017395211231608235
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0018963645673199347
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0020499447066233936
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0023360126147192193
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0026551956973773147
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0032263905210943907
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0037511463392394294
+2026-05-09,53,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0041886196008361345
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,5.786295089572857e-4
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,7.206371849971017e-4
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,7.890981616794432e-4
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,8.81571398295452e-4
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,9.324147487719921e-4
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,9.870647416150632e-4
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0010162892032377707
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.001057960247896953
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.001078001864359651
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0011003840969277523
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.001128264794412673
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0011664235934697171
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.0012040112677931731
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0012273917304566461
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0012805483469234922
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0013262345464846613
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0013866665733685607
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.0014524519680414259
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0015618431372368844
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.001760774395360637
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0019995685299850114
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002346247450574469
+2026-05-09,54,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0028777163309776977
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,3.947163636697242e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,5.048956751623232e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,5.84573323337959e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,6.93220451061965e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,7.542524146038332e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,8.12296039055993e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,8.484651348938819e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,8.932395811332005e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,9.221010223257496e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,9.47865161280196e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,9.780375371931836e-4
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.001020642203682302
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0010564467324344516
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0010913822249733144
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.00114094218842313
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0011869035578487527
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.001241822468483934
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0013011076137085483
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0014269831252935446
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.0015554485200515067
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0018077344166538864
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.002064373724994997
+2026-05-09,54,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.0025410090703339226
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,2.991941687560949e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,3.887234558857574e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,5.158343613307639e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,6.141848680911405e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,6.952688295062695e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,7.50254624054662e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,7.908041766918858e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,8.286081337787006e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,8.691533962167782e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,9.034894031777545e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,9.540110881595543e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,9.946010940254427e-4
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0010380631817104643
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.001106962923241608
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0011813806445280634
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.001249567738849663
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0013542867900358832
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.001469386970677701
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0015940667775121012
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0018930792161297296
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.002194624803229406
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.002470940576239302
+2026-05-09,54,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.0028568716163428765
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,3.457600628955714e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,4.2743412191560383e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.27786244011343e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,6.349818207817586e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,7.3045989139902e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.020892312578609e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,8.559853762330862e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,9.180246651686914e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,9.661550579758644e-4
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0010212962461610931
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0010827860719688593
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0011465664181579838
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.001212643133540314
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.001284105373415229
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0013685230413629894
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0014605993477189213
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0015502439386935844
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001672680396742566
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0018672948861495346
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.0020832412502451766
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.00243239848096667
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.002910495088873883
+2026-05-09,54,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0034577898134407446
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.088398320672062e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,3.8439449599725925e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,4.929350235691948e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,6.183660540691762e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,7.081407923455988e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,7.763183608504355e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,8.521789063570288e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,9.23551580309941e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,9.88117532024762e-4
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.0010568595128648956
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0011393340044373213
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.0012172037386769992
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.0012980092130438028
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0013955408718701167
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0014988206690897147
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.001633820569048509
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0017709680762075983
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0018977989401488728
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0021508641941045607
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0024683692092705776
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0030430991056596647
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.003603882551266064
+2026-05-09,54,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.004167854514523281
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,4.531620128934996e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,5.737718571143092e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,6.4348280392359e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,7.364912648800631e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,7.90638021735656e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,8.430749283818246e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,8.781191152940752e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,9.215409263749585e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,9.428942975282517e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,9.682928308175687e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,9.93533775737522e-4
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0010321307099802222
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.001067404281131965
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0010951614776000256
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0011399109508601463
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0011831424534999488
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0012339919815592757
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001284789318497117
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.00137345057077241
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.0015260440242998875
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0016973316751713048
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.001966044174571309
+2026-05-09,55,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0023720242027836253
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,2.3158825041350706e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,2.994035936694572e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,3.524304943717474e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,4.184439033028772e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,4.5267941014204077e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,4.906561613656819e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,5.12100240801338e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,5.388917519265055e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,5.539669196602816e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,5.657915381054344e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,5.847301855833899e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,6.123357531790377e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,6.335453195243277e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,6.532591025939862e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,6.863537643952974e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,7.127738605272204e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,7.479856721163366e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,7.81641519114341e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,8.422212180971361e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,9.584094586101615e-4
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0011068761595802714
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0013181773887785302
+2026-05-09,55,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.001674008792022138
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,1.6720771988780573e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,2.31123751721466e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,3.1812806886365457e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,3.7717228948682026e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,4.256055146565977e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,4.5966191069350194e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,4.7742722607908107e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,4.931257338752775e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,5.139778986238772e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,5.289662545980566e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,5.551148512124188e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,5.764214494113972e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,5.983334117755775e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,6.394727431816029e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,6.819527463269184e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,7.197839314209806e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,7.822157045790232e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,8.526214638801109e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,9.162839969283906e-4
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0010036375349243153
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.001269409063270113
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0014810584498423484
+2026-05-09,55,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.001759310917477588
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,2.0089141250000152e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,2.6407264612807104e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,3.288346175909366e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,4.007224654985935e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,4.679606430514206e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,5.154614115043244e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,5.549678614892279e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,5.944170157859051e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,6.214790041095067e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,6.569881200679736e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,6.934612658915979e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,7.356088293556644e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,7.771715969003162e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,8.179016282751877e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,8.685656637388937e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,9.340673761781573e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,9.88633750426667e-4
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.001067127962337125
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0011930120378215768
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.001349853942155386
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0015934559416447354
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.001918626393768688
+2026-05-09,55,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0022953022476334033
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,1.706009540025081e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,2.242618718159859e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,3.0481225029048724e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,3.877103192114892e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,4.5456424642059256e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,5.028384096245233e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,5.564340275689846e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,6.036474606855517e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,6.448619175563338e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,6.921169230382706e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,7.446053608193819e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,7.941720990630881e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,8.471022800498534e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,9.093521441736768e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,9.774689291659634e-4
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0010630304297203131
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.001151481420050843
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0012289538610404421
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0013922048514128245
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0016056654646815862
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0019886115259756297
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0023655844728851716
+2026-05-09,55,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0027561698186402937
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.01,8.166326605998933e-4
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.025,9.622768425067045e-4
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.05,0.0010474311822040632
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.1,0.00115586017596162
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.15,0.0012203914633222134
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.2,0.0012814899793007536
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.25,0.0013239571026615574
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.3,0.0013734002125102437
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.35,0.0014030063695577217
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.4,0.0014339328859694187
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.45,0.0014648482817128242
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.5,0.0015073862111484972
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.55,0.001547820464493157
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.6,0.0015817705513505242
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.65,0.0016295131015743175
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.7,0.0016773488680303988
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.75,0.0017340054446192924
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.8,0.001791906234000518
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.85,0.0018850232276072878
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.9,0.002041900239879728
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.95,0.0022253427537515633
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.975,0.002492192862643852
+2026-05-09,US,-1,wk inc covid prop ed visits,2026-05-02,quantile,0.99,0.0028811991598419124
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.01,6.260270335543362e-4
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.025,7.359853205893141e-4
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.05,8.14237920652734e-4
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.1,9.152191959771942e-4
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.15,9.717544122836782e-4
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.2,0.0010252999911412658
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.25,0.0010587804835608062
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.3,0.0010988926897255594
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.35,0.0011194300298102825
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.4,0.0011426372113518403
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.45,0.0011763417224913007
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.5,0.0012137647772183765
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.55,0.0012455991850054934
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.6,0.0012759601225815359
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.65,0.0013192076053038593
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.7,0.0013583906981463436
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.75,0.0014059777957012318
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.8,0.0014551133143057443
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.85,0.0015338621870254318
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.9,0.001670263116380361
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.95,0.0018493283389784084
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.975,0.0020833969054708636
+2026-05-09,US,0,wk inc covid prop ed visits,2026-05-09,quantile,0.99,0.002448995133033231
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.01,5.083288672066086e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.025,6.031982021195986e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.05,6.544643289387533e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.1,7.204968681277682e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.15,7.993131717296762e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.2,8.651391364834631e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.25,9.238092842321058e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.3,9.866900821113218e-4
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.35,0.0010431887210840493
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.4,0.0010907420524388378
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.45,0.001134967102059673
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.5,0.001172325905436982
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.55,0.0012114334136544822
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.6,0.0012699507029784276
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.65,0.0013329929776772884
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.7,0.0013914051333348818
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.75,0.0014780642311133828
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.8,0.0015741956188630721
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.85,0.0016677188138934998
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.9,0.0018016902177385552
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.95,0.0020940320100496334
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.975,0.0022885317592603086
+2026-05-09,US,1,wk inc covid prop ed visits,2026-05-16,quantile,0.99,0.002528387640930531
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.01,4.192072895584614e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.025,5.039068398652465e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.05,5.966592247034247e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.1,7.048318514879442e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.15,7.947414693417085e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.2,8.634332672917994e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.25,9.179580401207527e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.3,9.724113870257845e-4
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.35,0.0010210566998545604
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.4,0.0010735931101406226
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.45,0.0011320014934089978
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.5,0.0011949151227041448
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.55,0.0012532913968982787
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.6,0.0013119988823063246
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.65,0.0013847009254813372
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.7,0.0014669909294640275
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.75,0.0015488856701228184
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.8,0.0016585640319312183
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.85,0.0018178426517976498
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.9,0.002003545369225406
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.95,0.0022944757278077054
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.975,0.00265503491519842
+2026-05-09,US,2,wk inc covid prop ed visits,2026-05-23,quantile,0.99,0.0030647145745806145
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.01,3.656321929535498e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.025,4.448825288650784e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.05,5.531538486256622e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.1,6.741232432322442e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.15,7.666139557073123e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.2,8.344442484524314e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.25,9.06901193627186e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.3,9.724131993223573e-4
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.35,0.0010308857064478339
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.4,0.001094597634884611
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.45,0.0011667038276401706
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.5,0.001235127798015343
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.55,0.001304668279683916
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.6,0.0013938565175260044
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.65,0.0014882017005768528
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.7,0.0015973176655972193
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.75,0.0017164783518884852
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.8,0.0018272879596921037
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.85,0.0020342479582388328
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.9,0.0022819896131992413
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.95,0.0027132668510685574
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.975,0.0031644041670821793
+2026-05-09,US,3,wk inc covid prop ed visits,2026-05-30,quantile,0.99,0.0035562751094977826


### PR DESCRIPTION
This PR is a manually generated ensemble addition (since GHA hasn't been cooperating). Generated with `hubhelpr::generate_hub_ensemble(".", "2026-05-09", "covid")`. <https://github.com/CDCgov/covid19-forecast-hub/pull/1556> was reverted since it was the generated using an outdated version of `hubhelpr`.